### PR TITLE
Added inline style version of html_gmail.jelly...

### DIFF
--- a/src/main/resources/hudson/plugins/emailext/templates/html_gmail.jelly
+++ b/src/main/resources/hudson/plugins/emailext/templates/html_gmail.jelly
@@ -1,0 +1,360 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
+ <body style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+  <j:set var="spc" value="&amp;nbsp;&amp;nbsp;" />
+  <!-- GENERAL INFO -->
+  <table style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+   <tr>
+    <td align="right" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+     <j:choose>
+      <j:when test="${build.result=='SUCCESS'}">
+       <img src="${rooturl}static/e59dfe28/images/32x32/blue.gif">
+       </img>
+      </j:when>
+      <j:when test="${build.result=='FAILURE'}">
+       <img src="${rooturl}static/e59dfe28/images/32x32/red.gif">
+       </img>
+      </j:when>
+      <j:otherwise>
+       <img src="${rooturl}static/e59dfe28/images/32x32/yellow.gif">
+       </img>
+      </j:otherwise>
+     </j:choose>
+    </td>
+    <td valign="center" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+     <b style="font-size: 200%;">
+      BUILD ${build.result}
+     </b>
+    </td>
+   </tr>
+   <tr>
+    <td style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+     Build URL
+    </td>
+    <td style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+     <a href="${rooturl}${build.url}">
+      ${rooturl}${build.url}
+     </a>
+    </td>
+   </tr>
+   <tr>
+    <td style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+     Project:
+    </td>
+    <td style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+     ${project.name}
+    </td>
+   </tr>
+   <tr>
+    <td style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+     Date of build:
+    </td>
+    <td style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+     ${it.timestampString}
+    </td>
+   </tr>
+   <tr>
+    <td style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+     Build duration:
+    </td>
+    <td style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+     ${build.durationString}
+    </td>
+   </tr>
+  </table>
+  <br />
+  <!-- CHANGE SET -->
+  <j:set var="changeSet" value="${build.changeSet}" />
+  <j:if test="${changeSet!=null}">
+   <j:set var="hadChanges" value="false" />
+   <table width="100%" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+    <tr>
+     <td class="bg1" colspan="2" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black; color: white; background-color: #0000C0; font-size: 120%">
+      <b>
+       CHANGES
+      </b>
+     </td>
+    </tr>
+    <j:forEach var="cs" items="${changeSet.logs}" varStatus="loop">
+     <j:set var="hadChanges" value="true" />
+     <j:set var="aUser" value="${cs.hudsonUser}" />
+     <tr>
+      <td colspan="2" class="bg2" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black; color: white; background-color: #4040FF; font-size: 110%">
+       ${spc}Revision
+       <b>
+        ${cs.revision}
+       </b>
+       by
+       <b>
+        <j:choose>
+         <j:when test="${aUser!=null}">
+          ${aUser.displayName}:
+         </j:when>
+         <j:otherwise>
+          ${cs.user}:
+         </j:otherwise>
+        </j:choose>
+       </b>
+       <b>
+        (${cs.msgAnnotated})
+       </b>
+      </td>
+     </tr>
+     <j:forEach var="p" items="${cs.paths}">
+      <tr>
+       <td width="10%" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+        ${spc}${p.editType.name}
+       </td>
+       <td style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+        ${p.value}
+       </td>
+      </tr>
+     </j:forEach>
+    </j:forEach>
+    <j:if test="${!hadChanges}">
+     <tr>
+      <td colspan="2" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+       No Changes
+      </td>
+     </tr>
+    </j:if>
+   </table>
+   <br />
+  </j:if>
+  <!-- ARTIFACTS -->
+  <j:set var="artifacts" value="${build.artifacts}" />
+  <j:if test="${artifacts!=null and artifacts.size()&gt;0}">
+   <table width="100%" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+    <tr>
+     <td class="bg1" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black; color: white; background-color: #0000C0; font-size: 120%">
+      <b>
+       BUILD ATRIFACTS
+      </b>
+     </td>
+    </tr>
+    <tr>
+     <td style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+      <j:forEach var="f" items="${artifacts}">
+       <li>
+        <a href="${rooturl}${build.url}artifact/${f}">
+         ${f}
+        </a>
+       </li>
+      </j:forEach>
+     </td>
+    </tr>
+   </table>
+   <br />
+  </j:if>
+  <!-- MAVEN ARTIFACTS -->
+  <j:set var="mbuilds" value="${build.moduleBuilds}" />
+  <j:if test="${mbuilds!=null}">
+   <table width="100%" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+    <tr>
+     <td class="bg1" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black; color: white; background-color: #0000C0; font-size: 120%">
+      <b>
+       BUILD ATRIFACTS
+      </b>
+     </td>
+    </tr>
+    <j:forEach var="m" items="${mbuilds}">
+     <tr>
+      <td class="bg2" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black; color: white; background-color: #4040FF; font-size: 110%">
+       <b>
+        ${m.key.displayName}
+       </b>
+      </td>
+     </tr>
+     <j:forEach var="mvnbld" items="${m.value}">
+      <j:set var="artifacts" value="${mvnbld.artifacts}" />
+      <j:if test="${artifacts!=null and artifacts.size()&gt;0}">
+       <tr>
+        <td style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+         <j:forEach var="f" items="${artifacts}">
+          <li>
+           <a href="${rooturl}${mvnbld.url}artifact/${f}">
+            ${f}
+           </a>
+          </li>
+         </j:forEach>
+        </td>
+       </tr>
+      </j:if>
+     </j:forEach>
+    </j:forEach>
+   </table>
+   <br />
+  </j:if>
+  <!-- JUnit TEMPLATE -->
+  <j:set var="junitResultList" value="${it.JUnitTestResult}" />
+  <j:if test="${junitResultList.isEmpty()!=true}">
+   <table width="100%" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+    <tr>
+     <td class="bg1" colspan="2" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black; color: white; background-color: #0000C0; font-size: 120%">
+      <b>
+       JUnit Tests
+      </b>
+     </td>
+    </tr>
+    <j:forEach var="junitResult" items="${it.JUnitTestResult}">
+     <j:forEach var="packageResult" items="${junitResult.getChildren()}">
+      <tr>
+       <td class="bg2" colspan="2" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black; color: white; background-color: #4040FF; font-size: 110%">
+        Name: ${packageResult.getName()} Failed: ${packageResult.getFailCount()} test(s), Passed: ${packageResult.getPassCount()} test(s), Skipped: ${packageResult.getSkipCount()} test(s), Total: ${packageResult.getPassCount()+packageResult.getFailCount()+packageResult.getSkipCount()} test(s)
+       </td>
+      </tr>
+      <j:forEach var="failed_test" items="${packageResult.getFailedTests()}">
+       <tr bgcolor="white">
+        <td class="test_failed" colspan="2" style="color: red; font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+         <b>
+          <li>
+           Failed: ${failed_test.getFullName()}
+          </li>
+         </b>
+        </td>
+       </tr>
+      </j:forEach>
+     </j:forEach>
+    </j:forEach>
+   </table>
+   <br />
+  </j:if>
+  <!-- COBERTURA TEMPLATE -->
+  <j:set var="coberturaAction" value="${it.coberturaAction}" />
+  <j:if test="${coberturaAction!=null}">
+   <j:set var="coberturaResult" value="${coberturaAction.result}" />
+   <j:if test="${coberturaResult!=null}">
+    <table width="100%" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+     <td class="bg1" colspan="2" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black; color: white; background-color: #0000C0; font-size: 120%">
+      <b>
+       Cobertura Report
+      </b>
+     </td>
+    </table>
+    <table width="100%" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+     <td class="bg2" colspan="2" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black; color: white; background-color: #4040FF; font-size: 110%">
+      <b>
+       Project Coverage Summary
+      </b>
+     </td>
+    </table>
+    <table border="1px" class="pane" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+     <tr>
+      <td style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+       Name
+      </td>
+      <j:forEach var="metric" items="${coberturaResult.metrics}">
+       <td style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+        ${metric.name}
+       </td>
+      </j:forEach>
+     </tr>
+     <tr>
+      <td style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+       ${coberturaResult.name}
+      </td>
+      <j:forEach var="metric" items="${coberturaResult.metrics}">
+       <td data="${coberturaResult.getCoverage(metric).percentageFloat}" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+        ${coberturaResult.getCoverage(metric).percentage}%
+                            (${coberturaResult.getCoverage(metric)})
+       </td>
+      </j:forEach>
+     </tr>
+    </table>
+    <j:if test="${coberturaResult.sourceCodeLevel}">
+     <h2 style="color: black">
+      Source
+     </h2>
+     <j:choose>
+      <j:when test="${coberturaResult.sourceFileAvailable}">
+       <div style="overflow-x:scroll;">
+        <table class="source" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+         <thead>
+          <tr>
+           <th colspan="3" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+            ${coberturaResult.relativeSourcePath}
+           </th>
+          </tr>
+         </thead>
+         ${coberturaResult.sourceFileContent}
+        </table>
+       </div>
+      </j:when>
+      <j:otherwise>
+       <p style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+        <i>
+         Source code is unavailable
+        </i>
+       </p>
+      </j:otherwise>
+     </j:choose>
+    </j:if>
+    <j:forEach var="element" items="${coberturaResult.childElements}">
+     <j:set var="childMetrics" value="${coberturaResult.getChildMetrics(element)}" />
+     <table width="100%" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+      <td class="bg2" colspan="2" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black; color: white; background-color: #4040FF; font-size: 110%">
+       Coverage Breakdown by ${element.displayName}
+      </td>
+     </table>
+     <table border="1px" class="pane sortable" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+      <tr>
+       <td style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+        Name
+       </td>
+       <j:forEach var="metric" items="${childMetrics}">
+        <td style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+         ${metric.name}
+        </td>
+       </j:forEach>
+      </tr>
+      <j:forEach var="c" items="${coberturaResult.children}">
+       <j:set var="child" value="${coberturaResult.getChild(c)}" />
+       <tr>
+        <td style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+         ${child.xmlTransform(child.name)}
+        </td>
+        <j:forEach var="metric" items="${childMetrics}">
+         <j:set var="childResult" value="${child.getCoverage(metric)}" />
+         <j:choose>
+          <j:when test="${childResult!=null}">
+           <td data="${childResult.percentageFloat}" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+            ${childResult.percentage}%
+                                            (${childResult})
+           </td>
+          </j:when>
+          <j:otherwise>
+           <td data="101" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+            N/A
+           </td>
+          </j:otherwise>
+         </j:choose>
+        </j:forEach>
+       </tr>
+      </j:forEach>
+     </table>
+    </j:forEach>
+   </j:if>
+   <br />
+  </j:if>
+  <!-- CONSOLE OUTPUT -->
+  <j:getStatic var="resultFailure" field="FAILURE" className="hudson.model.Result" />
+  <j:if test="${build.result==resultFailure}">
+   <table width="100%" cellpadding="0" cellspacing="0" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black">
+    <tr>
+     <td class="bg1" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black; color: white; background-color: #0000C0; font-size: 120%">
+      <b>
+       CONSOLE OUTPUT
+      </b>
+     </td>
+    </tr>
+    <j:forEach var="line" items="${build.getLog(100)}">
+     <tr>
+      <td class="console" style="font-family: Verdana, Helvetica, sans serif; font-size: 11px; color: black; font-family: Courier New">
+       ${line}
+      </td>
+     </tr>
+    </j:forEach>
+   </table>
+   <br />
+  </j:if>
+ </body>
+</j:jelly>


### PR DESCRIPTION
Gmail doesn't work well with the html.jelly since it expects inline HTML's...this file was generated by hacking up Pynliner (see README.TXT file check-in at https://github.com/rogerhu/email-ext-plugin/commit/8474407ef6e6b7850bc73a89cb1b42d90a186af3)
