### PR TITLE
Add option for adding 'Precedence: bulk' header according to http://tools.ietf.org/search/rfc3834. 

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -357,6 +357,10 @@ public class ExtendedEmailPublisher extends Notifier {
             msg.setHeader("List-ID", listId);
         }
 
+        if (ExtendedEmailPublisher.DESCRIPTOR.getPrecedenceBulk()) {
+            msg.setHeader("Precedence", "bulk");
+        }
+
         return msg;
     }
 

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -96,6 +96,8 @@ public class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<Publis
      */
     private String listId;
 
+    private boolean precedenceBulk;
+
     @Override
     public String getDisplayName() {
         return Messages.ExtendedEmailPublisherDescriptor_DisplayName();
@@ -201,7 +203,7 @@ public class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<Publis
         return defaultBody;
     }
     
-    public String getDefaultRecipients() {    	
+    public String getDefaultRecipients() {
     	return recipientList;
     }
 
@@ -211,6 +213,10 @@ public class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<Publis
 
     public String getListId() {
         return listId;
+    }
+
+    public boolean getPrecedenceBulk() {
+        return precedenceBulk;
     }
 
     public boolean isApplicable(Class<? extends AbstractProject> jobType) {
@@ -308,8 +314,10 @@ public class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<Publis
         defaultBody = nullify(req.getParameter("ext_mailer_default_body"));
         recipientList = nullify(req.getParameter("ext_mailer_default_recipients")) != null ?
         	req.getParameter("ext_mailer_default_recipients") : "";
-        
+
         overrideGlobalSettings = req.getParameter("ext_mailer_override_global_settings") != null;
+
+        precedenceBulk = req.getParameter("extmailer.addPrecedenceBulk") != null;
 
         // specify List-ID information
         if (req.getParameter("extmailer.useListID") != null) {

--- a/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/global.jelly
@@ -68,6 +68,8 @@
                  type="text" value="${descriptor.listId}"/>
         </f:entry>
       </f:optionalBlock>
+      <f:optionalBlock name="extmailer.addPrecedenceBulk" title="${%Add 'Precedence: bulk' Email Header}" checked="${descriptor.precedenceBulk}"
+          help="/plugin/email-ext/help/globalConfig/precedenceBulk.html"/>
       <f:entry title="${%Default Recipients}"
       		   help="/plugin/email-ext/help/globalConfig/defaultRecipients.html">
         <input class="setting-input" name="ext_mailer_default_recipients"

--- a/src/main/webapp/help/globalConfig/precedenceBulk.html
+++ b/src/main/webapp/help/globalConfig/precedenceBulk.html
@@ -1,0 +1,8 @@
+<div>
+	<p>
+	Set a 'Precedence: bulk' header on all emails.  This will stop most auto-responders from sending
+	replies back to the sender (out-of-office, on-vacation, etc.)
+	</p>
+	For a full description of the specification see <a href="http://tools.ietf.org/search/rfc3834" target="_new">RFC-3834<a/>.
+	</p>
+</div>


### PR DESCRIPTION
Even with the List-Id header we still get out-of-office messages. This patch will just add another option to add a 'Precedence: bulk' header according to http://tools.ietf.org/search/rfc3834.
