### PR TITLE
[FIXED JENKINS-10990] Send email for NOT_BUILT and ABORTED builds.

### DIFF
--- a/src/main/java/hudson/plugins/emailext/EmailExtensionPlugin.java
+++ b/src/main/java/hudson/plugins/emailext/EmailExtensionPlugin.java
@@ -28,8 +28,10 @@ import hudson.plugins.emailext.plugins.ContentBuilder;
 import hudson.plugins.emailext.plugins.EmailContent;
 import hudson.plugins.emailext.plugins.EmailTriggerDescriptor;
 import hudson.plugins.emailext.plugins.content.*;
+import hudson.plugins.emailext.plugins.trigger.AbortedTrigger;
 import hudson.plugins.emailext.plugins.trigger.FailureTrigger;
 import hudson.plugins.emailext.plugins.trigger.FixedTrigger;
+import hudson.plugins.emailext.plugins.trigger.NotBuiltTrigger;
 import hudson.plugins.emailext.plugins.trigger.PreBuildTrigger;
 import hudson.plugins.emailext.plugins.trigger.StillFailingTrigger;
 import hudson.plugins.emailext.plugins.trigger.StillUnstableTrigger;
@@ -82,6 +84,8 @@ public class EmailExtensionPlugin extends Plugin {
         addEmailTriggerPlugin(StillUnstableTrigger.DESCRIPTOR);
         addEmailTriggerPlugin(SuccessTrigger.DESCRIPTOR);
         addEmailTriggerPlugin(FixedTrigger.DESCRIPTOR);
+        addEmailTriggerPlugin(AbortedTrigger.DESCRIPTOR);
+        addEmailTriggerPlugin(NotBuiltTrigger.DESCRIPTOR);
     }
 
     private void addEmailContentPlugin(EmailContent content) {

--- a/src/main/java/hudson/plugins/emailext/plugins/content/BuildStatusContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/BuildStatusContent.java
@@ -79,6 +79,10 @@ public class BuildStatusContent implements EmailContent {
             } else {
                 return "Successful";
             }
+        } else if (buildResult == Result.NOT_BUILT) {
+            return "Not Built";
+        } else if (buildResult == Result.ABORTED) {
+            return "Aborted";
         }
 
         return "Unknown";

--- a/src/main/java/hudson/plugins/emailext/plugins/trigger/AbortedTrigger.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/trigger/AbortedTrigger.java
@@ -1,0 +1,60 @@
+package hudson.plugins.emailext.plugins.trigger;
+
+import hudson.model.AbstractBuild;
+import hudson.model.Result;
+import hudson.plugins.emailext.plugins.EmailTrigger;
+import hudson.plugins.emailext.plugins.EmailTriggerDescriptor;
+
+public class AbortedTrigger extends EmailTrigger {
+
+    public static final String TRIGGER_NAME = "Aborted";
+
+    public AbortedTrigger() {
+    }
+
+    @Override
+    public boolean trigger(AbstractBuild<?, ?> build) {
+        Result buildResult = build.getResult();
+
+        if (buildResult == Result.ABORTED) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public EmailTriggerDescriptor getDescriptor() {
+        return DESCRIPTOR;
+    }
+
+    public static DescriptorImpl DESCRIPTOR = new DescriptorImpl();
+
+    public static final class DescriptorImpl extends EmailTriggerDescriptor {
+
+        @Override
+        public String getTriggerName() {
+            return TRIGGER_NAME;
+        }
+
+        @Override
+        public EmailTrigger newInstance() {
+            return new AbortedTrigger();
+        }
+
+        @Override
+        public String getHelpText() {
+            return Messages.AbortedTrigger_HelpText();
+        }
+    }
+
+    @Override
+    public boolean getDefaultSendToDevs() {
+        return true;
+    }
+
+    @Override
+    public boolean getDefaultSendToList() {
+        return true;
+    }
+}

--- a/src/main/java/hudson/plugins/emailext/plugins/trigger/NotBuiltTrigger.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/trigger/NotBuiltTrigger.java
@@ -1,0 +1,60 @@
+package hudson.plugins.emailext.plugins.trigger;
+
+import hudson.model.AbstractBuild;
+import hudson.model.Result;
+import hudson.plugins.emailext.plugins.EmailTrigger;
+import hudson.plugins.emailext.plugins.EmailTriggerDescriptor;
+
+public class NotBuiltTrigger extends EmailTrigger {
+
+    public static final String TRIGGER_NAME = "Not Built";
+
+    public NotBuiltTrigger() {
+    }
+
+    @Override
+    public boolean trigger(AbstractBuild<?, ?> build) {
+        Result buildResult = build.getResult();
+
+        if (buildResult == Result.NOT_BUILT) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public EmailTriggerDescriptor getDescriptor() {
+        return DESCRIPTOR;
+    }
+
+    public static DescriptorImpl DESCRIPTOR = new DescriptorImpl();
+
+    public static final class DescriptorImpl extends EmailTriggerDescriptor {
+
+        @Override
+        public String getTriggerName() {
+            return TRIGGER_NAME;
+        }
+
+        @Override
+        public EmailTrigger newInstance() {
+            return new NotBuiltTrigger();
+        }
+
+        @Override
+        public String getHelpText() {
+            return Messages.NotBuiltTrigger_HelpText();
+        }
+    }
+
+    @Override
+    public boolean getDefaultSendToDevs() {
+        return true;
+    }
+
+    @Override
+    public boolean getDefaultSendToList() {
+        return true;
+    }
+}

--- a/src/main/resources/hudson/plugins/emailext/plugins/trigger/Messages.properties
+++ b/src/main/resources/hudson/plugins/emailext/plugins/trigger/Messages.properties
@@ -17,3 +17,7 @@ UnstableTrigger.HelpText=\
  An email will be sent any time the build is unstable.\
  If the "Still Unstable" trigger is configured, and the previous build status was "Unstable",\
  then the "Still Unstable" trigger will send an email instead.
+NotBuiltTrigger.HelpText=\
+ An email will be sent if the build status is "Not Built".
+AbortedTrigger.HelpText=\
+ An email will be sent if the build status is "Aborted".


### PR DESCRIPTION
Added support for sending email on NOT_BUILT and ABORTED build status including unit tests.

There are a couple of new messages that need localizing.

Tested on a local jenkins 1.430 instance.
