### PR TITLE
Proposed fix to JENKINS-11413

### DIFF
--- a/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
@@ -1,5 +1,8 @@
 package hudson.plugins.emailext.plugins.content;
 
+import java.util.Collections;
+import java.util.Map;
+
 import hudson.model.AbstractBuild;
 import hudson.tasks.test.AbstractTestResultAction;
 import org.junit.Before;
@@ -43,4 +46,20 @@ public class FailedTestsContentTest
 
         assertEquals( "All tests passed", content );
     }
+
+    @Test
+    public void testGetContent_whenSomeTestsFailedShouldGiveMeaningfulMessage()
+    {
+        AbstractTestResultAction<?> testResults = mock( AbstractTestResultAction.class );
+        when( testResults.getFailCount() ).thenReturn( 123 );
+
+        when( build.getTestResultAction() ).thenReturn( testResults );
+
+        Map<String, Integer> args = Collections.singletonMap(
+                FailedTestsContent.MAX_TESTS_ARG_NAME, 0 );
+        String content = failedTestContent.getContent( build, null, null, args );
+
+        assertEquals( "123 tests failed.\n", content );
+    }
+
 }


### PR DESCRIPTION
This commit adds a maxTests argument to the ${FAILED_TESTS} token. Only up to so many failing tests are displayed.

The setting is undefined by default for backwards compatibility with existing configurations.
