### PR TITLE
[JENKINS-13191] bug fix

### DIFF
--- a/src/main/resources/hudson/plugins/emailext/templates/groovy-html.template
+++ b/src/main/resources/hudson/plugins/emailext/templates/groovy-html.template
@@ -17,7 +17,7 @@ TD.console { font-family:Courier New; }
 <BODY>
 
 <TABLE>
-  <TR><TD align="right"><IMG SRC="${rooturl}static/e59dfe28/images/32x32/<%= build.result == 'SUCCESS' ? "blue.gif" : build.result == 'FAILURE' ? 'red.gif' : 'yellow.gif' %>" />
+  <TR><TD align="right"><IMG SRC="${rooturl}static/e59dfe28/images/32x32/<%= build.result.toString() == 'SUCCESS' ? "blue.gif" : build.result.toString() == 'FAILURE' ? 'red.gif' : 'yellow.gif' %>" />
   </TD><TD valign="center"><B style="font-size: 200%;">BUILD ${build.result}</B></TD></TR>
   <TR><TD>Build URL</TD><TD><A href="${rooturl}${build.url}">${rooturl}${build.url}</A></TD></TR>
   <TR><TD>Project:</TD><TD>${project.name}</TD></TR>


### PR DESCRIPTION
url for the bug https://issues.jenkins-ci.org/browse/JENKINS-13191
build.result == SUCCESS is always false due to build.result is not string
convert to string directly in template to solve this

could be update in java codes as well
