### PR TITLE
Fix JENKINS-13317 - prevent null String derefences from the default Subject, Body, Recipient lists.

### DIFF
--- a/src/main/java/hudson/plugins/emailext/plugins/ContentBuilder.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/ContentBuilder.java
@@ -63,14 +63,28 @@ public class ContentBuilder {
         return EMAIL_CONTENT_TYPE_MAP.values();
     }
 
+    private String noNull(String string) {
+        return string == null ? "" : string;
+    }
+
     public String transformText(String origText, ExtendedEmailPublisher publisher, EmailType type, AbstractBuild<?, ?> build) {
-	String recipientList = publisher.recipientList == null ? "" : publisher.recipientList;
-        String newText = origText.replaceAll(PROJECT_DEFAULT_BODY, Matcher.quoteReplacement(publisher.defaultContent)).replaceAll(PROJECT_DEFAULT_SUBJECT, Matcher.quoteReplacement(publisher.defaultSubject)).replaceAll(DEFAULT_BODY, Matcher.quoteReplacement(ExtendedEmailPublisher.DESCRIPTOR.getDefaultBody())).replaceAll(DEFAULT_SUBJECT, Matcher.quoteReplacement(ExtendedEmailPublisher.DESCRIPTOR.getDefaultSubject())).replaceAll(DEFAULT_RECIPIENTS, Matcher.quoteReplacement(ExtendedEmailPublisher.DESCRIPTOR.getDefaultRecipients()));
+        String defaultContent = Matcher.quoteReplacement(noNull(publisher.defaultContent));
+        String defaultSubject = Matcher.quoteReplacement(noNull(publisher.defaultSubject));
+        String defaultBody = Matcher.quoteReplacement(noNull(ExtendedEmailPublisher.DESCRIPTOR.getDefaultBody()));
+        String defaultExtSubject = Matcher.quoteReplacement(noNull(ExtendedEmailPublisher.DESCRIPTOR.getDefaultSubject()));
+        String defaultRecipients = Matcher.quoteReplacement(noNull(ExtendedEmailPublisher.DESCRIPTOR.getDefaultRecipients()));
+        String newText = origText.replaceAll(
+                PROJECT_DEFAULT_BODY, defaultContent).replaceAll(
+                PROJECT_DEFAULT_SUBJECT, defaultSubject).replaceAll(
+                DEFAULT_BODY, defaultBody).replaceAll(
+                DEFAULT_SUBJECT, defaultExtSubject).replaceAll(
+                DEFAULT_RECIPIENTS, defaultRecipients);
         newText = replaceTokensWithContent(newText, publisher, type, build);
         return newText;
     }
 
-    private static <P extends AbstractProject<P, B>, B extends AbstractBuild<P, B>> String replaceTokensWithContent(String origText, ExtendedEmailPublisher publisher, EmailType type, AbstractBuild<P, B> build) {
+    private static <P extends AbstractProject<P, B>, B extends AbstractBuild<P, B>> String replaceTokensWithContent(
+            String origText, ExtendedEmailPublisher publisher, EmailType type, AbstractBuild<P, B> build) {
         StringBuffer sb = new StringBuffer();
         Tokenizer tokenizer = new Tokenizer(origText);
 

--- a/src/test/java/hudson/plugins/emailext/plugins/ContentBuilderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/ContentBuilderTest.java
@@ -202,4 +202,15 @@ public class ContentBuilderTest
                   new ContentBuilder().transformText( "${DEFAULT_RECIPIENTS}", publisher, null,
                                                       mock( AbstractBuild.class ) ) );
 }
+    public void testTransformText_noNPEWithNullDefaultSubjectBody() throws NoSuchFieldException, IllegalAccessException
+    {
+        Field f = ExtendedEmailPublisherDescriptor.class.getDeclaredField( "defaultBody" );
+        f.setAccessible( true );
+        f.set( ExtendedEmailPublisher.DESCRIPTOR, null );
+        f = ExtendedEmailPublisherDescriptor.class.getDeclaredField( "defaultSubject" );
+        f.setAccessible( true );
+        f.set( ExtendedEmailPublisher.DESCRIPTOR, null );
+        assertEquals( "", new ContentBuilder().transformText( "$DEFAULT_SUBJECT", publisher, null, mock (AbstractBuild.class )));
+        assertEquals( "", new ContentBuilder().transformText( "$DEFAULT_CONTENT", publisher, null, mock (AbstractBuild.class )));
+    }
 }


### PR DESCRIPTION
Fixed JENKINS-13317 - a call to Matcher.quoteReplacement was failing due to a null String parameter which is Matcher does not handle gracefully, causing an null pointer exception. Added a test to simulate passing in null values. The defaultBody and defaultSubject variables can potentially be null because they are set with a nullify method - which if the entries are empty, they are set to null. So we have to check for defaultBody and defaultSubject. The other three variables don't look like they can be null (JSONObject.getString only returns a non-null String or raises an exception) but it seemed safer just to check them all.

I added a unit test for this as well, and removed the unused de-reference of the publisher.recipientList local variable at the top of ContentBuilder.transformText.
