### PR TITLE
Add the email content after the attachments

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -455,8 +455,6 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
 
         Multipart multipart = new MimeMultipart();
         
-        multipart.addBodyPart(getContent(type, build, msg, listener, charset));
-
         AttachmentUtils attachments = new AttachmentUtils(attachmentsPattern);
         attachments.attach(multipart, this, build, listener);
 
@@ -470,6 +468,8 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
             debug(listener.getLogger(), "Request made to attach build log");
             AttachmentUtils.attachBuildLog(multipart, build, listener);
         }
+
+        multipart.addBodyPart(getContent(type, build, msg, listener, charset));
 
         msg.setContent(multipart);
         


### PR DESCRIPTION
After upgrading to version 2.25 (from 2.24.1) emails sent by email-ext that included attachments were somewhat broken (using Exchange server/Outlook client).

The problem is that the email will show up with an extra attachment that contains the expected body of the email. This appears to be due to an Exchange bug, which is discussed here: http://support.microsoft.com/kb/969854

A quick look at the source history showed me the ordering of adding the body content / attachments has changed since 2.24.1, this patch simply adds the body content last again.

![BadAttachment](https://f.cloud.github.com/assets/1126869/75378/eac1038a-60c2-11e2-9231-9cd3184858a3.png)
