### PR TITLE
Fixed trigger now ignores previous Aborted builds

### DIFF
--- a/src/main/java/hudson/plugins/emailext/plugins/trigger/FixedTrigger.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/trigger/FixedTrigger.java
@@ -15,13 +15,28 @@ public class FixedTrigger extends EmailTrigger {
         Result buildResult = build.getResult();
 
         if (buildResult == Result.SUCCESS) {
-            AbstractBuild<?, ?> prevBuild = build.getPreviousBuild();
+            AbstractBuild<?, ?> prevBuild = getPreviousBuild(build);
             if (prevBuild != null && (prevBuild.getResult() == Result.UNSTABLE || prevBuild.getResult() == Result.FAILURE)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /**
+     * Find most recent previous build matching certain criteria.
+     */
+    private AbstractBuild<?, ?> getPreviousBuild(AbstractBuild<?, ?> build) {
+
+        AbstractBuild<?, ?> prevBuild = build.getPreviousBuild();
+
+        // Skip ABORTED builds
+        if (prevBuild != null && (prevBuild.getResult() == Result.ABORTED)) {
+            return getPreviousBuild(prevBuild);
+        }
+
+        return prevBuild;
     }
 
     @Override


### PR DESCRIPTION
Given a build history like this:
#4 Success
#3 Aborted
#2 Failed
#1 Success

I would like the Fixed trigger to fire for build #4.  The most recent previous build that resulted in a "hard" status was Failed (#2).  #3 is a "soft" status because it was cancelled by a user.  So in my reasoning, #4 is a Fixed transition from #2.  It just so happens that there is an intervening Aborted build.
