### PR TITLE
Additional tests for the ZipDataSource and associated configuration points

### DIFF
--- a/src/main/java/hudson/plugins/emailext/plugins/ZipDataSource.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/ZipDataSource.java
@@ -23,22 +23,24 @@ public class ZipDataSource implements DataSource {
     private byte[] contents;
 
     public ZipDataSource(File f) throws IOException {
-        name = f.getName() + FILE_EXTENSION;
+        this(f.getName(), new FileInputStream(f));
+    }
 
-        InputStream fin = new FileInputStream(f);
+    ZipDataSource(String name, InputStream in) throws IOException {
+        this.name = name + FILE_EXTENSION;
+
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ZipOutputStream zos = new ZipOutputStream(baos);
-        zos.putNextEntry(new ZipEntry(f.getName()));
+        zos.putNextEntry(new ZipEntry(name));
 
         int size;
         byte[] buffer = new byte[BUFFER_SIZE];
-        while ((size = fin.read(buffer, 0, buffer.length)) > 0) {
+        while ((size = in.read(buffer, 0, buffer.length)) > 0) {
             zos.write(buffer, 0, size);
         }
         zos.closeEntry();
         zos.close();
-        fin.close();
-
+        in.close();
         contents = baos.toByteArray();
     }
 

--- a/src/test/java/hudson/plugins/emailext/EmailTypeTest.java
+++ b/src/test/java/hudson/plugins/emailext/EmailTypeTest.java
@@ -40,6 +40,17 @@ public class EmailTypeTest extends TestCase {
 		assertTrue(t.getHasRecipients());
 	}
 
+	public void testCompressBuildAttachment(){
+		EmailType t = new EmailType();
+		t.setCompressBuildLog(true);
 
+		assertTrue(t.getCompressBuildLog());
+	}
+
+	public void testDefaultCompressBuildAttachment(){
+		EmailType t = new EmailType();
+
+		assertFalse(t.getCompressBuildLog());
+	}
 
 }

--- a/src/test/java/hudson/plugins/emailext/plugins/ZipDataSourceTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/ZipDataSourceTest.java
@@ -1,0 +1,66 @@
+package hudson.plugins.emailext.plugins;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.ZipInputStream;
+
+import org.junit.Assert;
+
+import junit.framework.TestCase;
+
+public class ZipDataSourceTest extends TestCase {
+	private final static int BUFFER_SIZE = 1024;
+
+    public void testGetName() throws IOException{
+        String name = "myFile";
+
+        ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
+        ZipDataSource dataSource = new ZipDataSource(name, in);
+
+        assertEquals(name + ".zip", dataSource.getName());
+    }
+
+    public void testGetContentType() throws IOException {
+        String name = "myFile";
+
+        ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
+        ZipDataSource dataSource = new ZipDataSource(name, in);
+
+        assertEquals("application/zip", dataSource.getContentType());
+    }
+
+    public void testGetInputStream() throws IOException {
+        byte[] sample = "Hello World lllllllllllots of repeated charactersssssssssssss Hello World again".getBytes();
+        ZipDataSource dataSource = new ZipDataSource("name", new ByteArrayInputStream(sample));
+        InputStream in = dataSource.getInputStream();
+
+        ZipInputStream zin = new ZipInputStream(in);
+        // Need this to move the ZipInputStream to the start of the "file"
+        zin.getNextEntry();
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        int size;
+        byte[] buffer = new byte[BUFFER_SIZE];
+        while ((size = zin.read(buffer, 0, buffer.length)) > 0) {
+            baos.write(buffer, 0, size);
+        }
+        Assert.assertArrayEquals(sample, baos.toByteArray());
+
+    }
+
+    public void testGetOutputStream() throws IOException {
+        String name = "myFile";
+
+        ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
+        ZipDataSource dataSource = new ZipDataSource(name, in);
+
+        try {
+            dataSource.getOutputStream();
+        } catch (IOException e) {
+            return;
+        }
+        Assert.fail("It is not possible to get an OutputStream from the ZipDataSource, an exception should have been thrown");
+    }
+}


### PR DESCRIPTION
I've modified the ZipDataSource to be more easily testable, modified the EmailTypeTest to test the extra config points for the compressBuildLog boolean and added the ZipDataSourceTest to ensure that files can be correctly zipped and unzipped as expected.
