### PR TITLE
isMatrixProject should not assume that its parameter is an AbstractProject.

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -446,7 +446,7 @@ public class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<Publis
         }
     }
 
-    public boolean isMatrixProject(AbstractProject<?, ?> project) {
+    public boolean isMatrixProject(Object project) {
         return project instanceof MatrixProject;
     }
 


### PR DESCRIPTION
Otherwise when trying to include `ExtendedEmailPublisher` configuration in a special UI, such as in a template attribute using the CloudBees Templates plugin, you get a nasty exception like

```
groovy.lang.MissingMethodException: No signature of method: hudson.plugins.emailext.ExtendedEmailPublisherDescriptor.isMatrixProject() is applicable for argument types: (com.cloudbees.hudson.plugins.modeling.controls.DescriptorListControl) values: [com.cloudbees.hudson.plugins.modeling.controls.DescriptorListControl@4a54fa67] 
Possible solutions: isMatrixProject(hudson.model.AbstractProject) 
        at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:55) 
        at org.codehaus.groovy.runtime.callsite.PojoMetaClassSite.call(PojoMetaClassSite.java:46) 
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:42) 
        at hudson.plugins.emailext.ExtendedEmailPublisherDescriptor$isMatrixProject.call(Unknown Source) 
        at config.run(config.groovy:109)
```

Since in this context the configuration snippet cannot determine if it is supposed to be applied to a `MatrixProject` or not (in general configuration cannot inspect its environment reliably), it is best to assume it is not and just skip that block.
