### PR TITLE
Fix for JENKINS-17503 by adding an excluded committer list to email-ext global config

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -56,6 +56,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.StringTokenizer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -518,7 +519,7 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
             
             for (User user : users) {
                 String userAddress = EmailRecipientUtils.getUserConfiguredEmail(user);
-                if(userAddress != null){
+                if (userAddress != null && !isExcludedCommitter(user.getFullName())) {
                     addAddressesFromRecipientList(recipientAddresses, ccAddresses, userAddress, env, listener);
                 } else {
                     listener.getLogger().println("Failed to send e-mail to " + user.getFullName() + " because no e-mail address is known, and no default e-mail domain is configured");
@@ -598,6 +599,16 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
         }
 
         return msg;
+    }
+
+    private boolean isExcludedCommitter(String userName) {
+        StringTokenizer tokens = new StringTokenizer(DESCRIPTOR.getExcludedCommitters(), ",");
+        while (tokens.hasMoreTokens()) {
+            if (tokens.nextToken().trim().equalsIgnoreCase(userName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void addUserTriggeringTheBuild(AbstractBuild<?, ?> build, Set<InternetAddress> recipientAddresses, Set<InternetAddress> ccAddresses,

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -110,6 +110,12 @@ public class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<Publis
      */
     private String defaultReplyTo = "";
 
+    /*
+     * This is a global excluded committers list for not sending commit emails.
+     */
+    private String excludedCommitters = "";
+
+
     private boolean overrideGlobalSettings;
     
     /**
@@ -242,6 +248,10 @@ public class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<Publis
     
     public String getDefaultRecipients() {
         return recipientList;
+    }
+
+    public String getExcludedCommitters() {
+        return excludedCommitters;
     }
 
     public boolean getOverrideGlobalSettings() {
@@ -392,6 +402,8 @@ public class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<Publis
 
         precedenceBulk = req.getParameter("extmailer.addPrecedenceBulk") != null;
         enableSecurity = req.getParameter("ext_mailer_security_enabled") != null;
+
+        excludedCommitters = req.getParameter("ext_mailer_excluded_committers");
 
         // specify List-ID information
         if (req.getParameter("extmailer.useListID") != null) {

--- a/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/global.groovy
+++ b/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/global.groovy
@@ -62,6 +62,9 @@ f.section(title: _("Extended E-mail Notification")) {
   f.entry(help: "/plugin/email-ext/help/globalConfig/emergencyReroute.html", title: _("Emergency reroute")) {
     input(type: "text", class: "setting-input", value: descriptor.emergencyReroute, name: "ext_mailer_emergency_reroute") 
   }
+  f.entry(help: "/plugin/email-ext/help/globalConfig/excludedCommitters.html", title: _("Excluded Committers")) {
+    input(type: "text", class: "setting-input", value: descriptor.excludedCommitters, name: "ext_mailer_excluded_committers")
+  }
   f.entry(help: "/plugin/email-ext/help/globalConfig/defaultSubject.html", title: _("Default Subject")) {
     input(type: "text", class: "setting-input", value: descriptor.defaultSubject, name: "ext_mailer_default_subject") 
   }

--- a/src/main/webapp/help/globalConfig/excludedCommitters.html
+++ b/src/main/webapp/help/globalConfig/excludedCommitters.html
@@ -1,0 +1,6 @@
+<div>
+	Prevent system email account managers from being spammed
+    by commits by entering their account names here separated
+    by commas. They should just be the account names without
+    the "@domain.com" extension.
+</div>


### PR DESCRIPTION
This pull request adds an excluded committer list to the email-ext plugin's global configuration user interface so the account names can be added that will be prevented from receiving emails by this plugin. I see a preference for a more global solution - but since this code has been running in our group for almost a year and it's already written - even if it's not used it could help the conversation.
