### PR TITLE
Token Replacement fix

### DIFF
--- a/src/main/java/hudson/plugins/emailext/plugins/content/ChangesSinceLastBuildContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/ChangesSinceLastBuildContent.java
@@ -113,7 +113,7 @@ public class ChangesSinceLastBuildContent extends DataBoundTokenMacro {
                 case 'm': {
                     String m = entry.getMsg();
                     buf.append(m);
-                    if (!m.endsWith("\n")) {
+                    if (m == null || !m.endsWith("\n")) {
                         buf.append('\n');
                     }
                     return true;


### PR DESCRIPTION
Without this null check, a null msg will cause an NPE which travels up and aborts the entire TokenMacro.expandAll call.   As a use case, the Jenkins Accurev SCM plugin will produce this (literal null) if a commit msg is not provided by the user:  

"changeSet" : {
    "items" : [
      {
        "affectedPaths" : [
          "foo/bar/Baz.java"
        ],
        "author" : {
          "absoluteUrl" : "http://someurlhere/whatever",
          "fullName" : "Mr FooBar"
        },
        "commitId" : null,
        "msg" : null,
        "timestamp" : -1
      }
    ],
    "kind" : null
  }
