### PR TITLE
[JENKINS-18609] Triggers two mails: UNSTABLE and IMPROVEMENT

### DIFF
--- a/src/main/java/hudson/plugins/emailext/plugins/trigger/ImprovementTrigger.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/trigger/ImprovementTrigger.java
@@ -51,7 +51,12 @@ public class ImprovementTrigger extends EmailTrigger {
     }
 
     public static final class DescriptorImpl extends EmailTriggerDescriptor {
-
+        
+        public DescriptorImpl() {
+            addTriggerNameToReplace(UnstableTrigger.TRIGGER_NAME);
+            addTriggerNameToReplace(StillUnstableTrigger.TRIGGER_NAME);
+        }
+        
         @Override
         public String getDisplayName() {
             return TRIGGER_NAME;


### PR DESCRIPTION
The improvement trigger is only triggered when there are LESS failing tests. It implies being UNSTABLE or STILL UNSTABLE. Otherwise it would be SUCCESS or FIXED.
This modification makes the IMPROVEMENT trigger overriding the UNSTABLE or STILL UNSTABLE triggers.
