### PR TITLE
Fix NPE with Jenkins 1.535

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -239,7 +239,7 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
         debug(listener.getLogger(), "Checking if email needs to be generated");
         Map<String, EmailTrigger> triggered = new HashMap<String, EmailTrigger>();
 
-        for (EmailTrigger trigger : configuredTriggers) {
+        for (EmailTrigger trigger : getConfiguredTriggers()) {
             if (trigger.isPreBuild() == forPreBuild && trigger.trigger(build, listener)) {
                 String tName = trigger.getDescriptor().getDisplayName();
                 triggered.put(tName, trigger);


### PR DESCRIPTION
After upgrading to Jenkins 1.535, I got the following NPE and fixed it with the suggested patch:

```
java.lang.NullPointerException
    at hudson.plugins.emailext.ExtendedEmailPublisher._perform(ExtendedEmailPublisher.java:242)
    at hudson.plugins.emailext.ExtendedEmailPublisher.prebuild(ExtendedEmailPublisher.java:222)
    at hudson.model.AbstractBuild$AbstractBuildExecution.preBuild(AbstractBuild.java:815)
    at hudson.model.AbstractBuild$AbstractBuildExecution.preBuild(AbstractBuild.java:810)
    at hudson.model.Build$BuildExecution.doRun(Build.java:142)
    at hudson.plugins.project_inheritance.projects.InheritanceBuild$InheritanceBuildExecution.doRun(InheritanceBuild.java:111)
    at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:562)
    at hudson.model.Run.execute(Run.java:1665)
    at hudson.plugins.project_inheritance.projects.InheritanceBuild.run(InheritanceBuild.java:96)
    at hudson.model.ResourceController.execute(ResourceController.java:88)
    at hudson.model.Executor.run(Executor.java:246)
```
