### PR TITLE
Create MIT-LICENSE.txt

### DIFF
--- a/MIT-LICENSE.txt
+++ b/MIT-LICENSE.txt
@@ -1,0 +1,20 @@
+Copyright 2014 Alex Earl
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Heya,

Thanks for your work on this plugin. We really appreciate your efforts at Swrve, but we've been unable to track down which license your plugin false under. I would have preferred to simply open an issue about this, but your repo doesn't seem to accept issues :cry:, hence this pull request. I've added the MIT license in this PR, as it seems to be used quite frequently by Jenkins plugins, although you can of course choose whichever license you like.
