### PR TITLE
JENKINS-21730 - Add bcc support to email-ext plugin

### DIFF
--- a/src/main/webapp/help/globalConfig/defaultRecipients.html
+++ b/src/main/webapp/help/globalConfig/defaultRecipients.html
@@ -4,6 +4,7 @@
 	project configuration. You may use the $DEFAULT_RECIPIENTS
 	token in projects to include this default list, as well as
 	add new addresses at the project level. 
-	To CC someone instead of putting them in the To list, add 
-	cc: before the email address (e.g., cc:someone@somewhere.com).
+	To CC or BCC someone instead of putting them in the To list, add
+	cc: or bcc: before the email address
+    (e.g., cc:someone@example.com, bcc:bob@example.com).
 </div>

--- a/src/main/webapp/help/globalConfig/defaultRecipients_zh_TW.html
+++ b/src/main/webapp/help/globalConfig/defaultRecipients_zh_TW.html
@@ -2,6 +2,6 @@
     自訂電子郵件通知的預設收件人清單。
     如果沒有被專案設定覆蓋掉，就會使用這一組清單。
     您可以在專案中使用 <code>$DEFAULT_RECIPIENTS</code> Token，在專案層級設定其他收件人的同時也加入這份預設清單。
-    要是想把某些人放在副本清單，而不是放在收件人清單裡，請在信箱前面加上 <code>cc:</code>
-    (例如: <code>cc:someone@somewhere.com</code>)。
+    要是想把某些人放在副本清單，而不是放在收件人清單裡，請在信箱前面加上 <code>cc:/bcc:</code>
+    (例如: <code>cc:someone@example.com, bcc:bob@example.com</code>)。
 </div>

--- a/src/test/java/hudson/plugins/emailext/EmailRecipientUtilsTest.java
+++ b/src/test/java/hudson/plugins/emailext/EmailRecipientUtilsTest.java
@@ -173,6 +173,45 @@ public class EmailRecipientUtilsTest {
     }
 
     @Test
+    public void testBCC()
+            throws Exception {
+        envVars.put("EMAIL_LIST", "ashlux@gmail.com, bcc:slide.o.mix@gmail.com, another@gmail.com");
+
+        Set<InternetAddress> internetAddresses = emailRecipientUtils.convertRecipientString("$EMAIL_LIST", envVars);
+
+        assertEquals(2, internetAddresses.size());
+        assertTrue(internetAddresses.contains(new InternetAddress("ashlux@gmail.com")));
+        assertTrue(internetAddresses.contains(new InternetAddress("another@gmail.com")));
+
+        internetAddresses = emailRecipientUtils.convertRecipientString("$EMAIL_LIST", envVars, EmailRecipientUtils.BCC);
+
+        assertEquals(1, internetAddresses.size());
+        assertTrue(internetAddresses.contains(new InternetAddress("slide.o.mix@gmail.com")));
+    }
+
+    @Test
+    public void testBCCandCC()
+            throws Exception {
+        envVars.put("EMAIL_LIST", "ashlux@gmail.com, bcc:slide.o.mix@gmail.com, another@gmail.com, cc:example@gmail.com");
+
+        Set<InternetAddress> internetAddresses = emailRecipientUtils.convertRecipientString("$EMAIL_LIST", envVars);
+
+        assertEquals(2, internetAddresses.size());
+        assertTrue(internetAddresses.contains(new InternetAddress("ashlux@gmail.com")));
+        assertTrue(internetAddresses.contains(new InternetAddress("another@gmail.com")));
+
+        internetAddresses = emailRecipientUtils.convertRecipientString("$EMAIL_LIST", envVars, EmailRecipientUtils.BCC);
+
+        assertEquals(1, internetAddresses.size());
+        assertTrue(internetAddresses.contains(new InternetAddress("slide.o.mix@gmail.com")));
+
+        internetAddresses = emailRecipientUtils.convertRecipientString("$EMAIL_LIST", envVars, EmailRecipientUtils.CC);
+
+        assertEquals(1, internetAddresses.size());
+        assertTrue(internetAddresses.contains(new InternetAddress("example@gmail.com")));
+    }
+
+    @Test
     public void testUTF8()
             throws Exception {
         envVars.put("EMAIL_LIST", "ashlux@gmail.com, cc:slide.o.mix@gmail.com, 愛嬋 <another@gmail.com>");


### PR DESCRIPTION
I noticed the email-ext plugin only supports cc: and not bcc: as well.  Had a business need to bcc some people on a release announcement email that I wanted automated via Jenkins.  This allows me to do that.

Change includes Unit Tests and the updated hpi worked on a local copy of Jenkins running version 1.549.
