### PR TITLE
add smtp timeout to avoid hang

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -194,6 +194,11 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
         if (smtpAuthUsername != null) {
             props.put("mail.smtp.auth", "true");
         }
+
+        // avoid hang by setting some timeout.
+        props.put("mail.smtp.timeout","60000");
+        props.put("mail.smtp.connectiontimeout","60000");
+
         return Session.getInstance(props, getAuthenticator());
     }
 


### PR DESCRIPTION
It is possible to get a hanging behavior using the ext-email plugin when connecting to old smtp servers. The following timeout properties are set in the same way as the Mailer plugin in Mailer.java, createSession method to avoid this problem. If the smtp server is in a bad state this timeout will cause an error to be thrown rather than an infinite wait for a socket read.
