### PR TITLE
Add uberClassLoader to JellyContext

### DIFF
--- a/src/main/java/hudson/plugins/emailext/plugins/content/JellyScriptContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/JellyScriptContent.java
@@ -165,6 +165,7 @@ public class JellyScriptContent extends DataBoundTokenMacro {
     private JellyContext createContext(Object it, AbstractBuild<?, ?> build, TaskListener listener) {
         JellyContext context = new JellyContext();
         ExtendedEmailPublisherDescriptor descriptor = Jenkins.getInstance().getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
+        context.setClassLoader(Jenkins.getInstance().getPluginManager().uberClassLoader);
         context.setVariable("it", it);
         context.setVariable("build", build);
         context.setVariable("project", build.getParent());


### PR DESCRIPTION
Allows for a jelly email create classes from plugins, like [BuildFailureAnalyzer's ScanOnDemandTask](https://github.com/jenkinsci/build-failure-analyzer-plugin/blob/master/src/main/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandTask.java).

This is already done on the groovy-script side, so I've added it here.