### PR TITLE
Fix multibyte text corruption in email sender name

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -528,25 +528,6 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
 
         MimeMessage msg;
 
-        // If not overriding global settings, use the Mailer class to create a session and set the from address
-        // Else we'll do it ourselves
-        Session session;
-        if (!overrideGlobalSettings) {
-            debug(context.getListener().getLogger(), "NOT overriding default server settings, using Mailer to create session");
-            session = Mailer.descriptor().createSession();
-            msg = new MimeMessage(session);
-            msg.setFrom(new InternetAddress(JenkinsLocationConfiguration.get().getAdminAddress()));
-        } else {
-            debug(context.getListener().getLogger(), "Overriding default server settings, creating our own session");
-            session = descriptor.createSession();
-            msg = new MimeMessage(session);
-            msg.setFrom(new InternetAddress(descriptor.getAdminAddress()));
-        }
-
-        if (descriptor.isDebugMode()) {
-            session.setDebugOut(context.getListener().getLogger());
-        }
-
         String charset = Mailer.descriptor().getCharset();
         if (overrideGlobalSettings) {
             String overrideCharset = descriptor.getCharset();
@@ -554,6 +535,25 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
                 debug(context.getListener().getLogger(), "Overriding charset %s", overrideCharset);
                 charset = overrideCharset;
             }
+        }
+
+        // If not overriding global settings, use the Mailer class to create a session and set the from address
+        // Else we'll do it ourselves
+        Session session;
+        if (!overrideGlobalSettings) {
+            debug(context.getListener().getLogger(), "NOT overriding default server settings, using Mailer to create session");
+            session = Mailer.descriptor().createSession();
+            msg = new MimeMessage(session);
+            msg.setFrom(Mailer.StringToAddress(JenkinsLocationConfiguration.get().getAdminAddress(), charset));
+        } else {
+            debug(context.getListener().getLogger(), "Overriding default server settings, creating our own session");
+            session = descriptor.createSession();
+            msg = new MimeMessage(session);
+            msg.setFrom(Mailer.StringToAddress(descriptor.getAdminAddress(), charset));
+        }
+
+        if (descriptor.isDebugMode()) {
+            session.setDebugOut(context.getListener().getLogger());
         }
 
         // Set the contents of the email


### PR DESCRIPTION
If the `System Admin e-mail address` contains multibyte characters,

![jenkins-configuration](https://cloud.githubusercontent.com/assets/3761357/6349305/7117929e-bc6c-11e4-9a35-b7fcfef5dd73.png)

the sender text received is corrupts.

![recieved-email-header](https://cloud.githubusercontent.com/assets/3761357/6349404/5ff095c8-bc6d-11e4-8fbd-b7057b17dd44.png)

I confirmed this problem on

- Jenkins 1.585
- email-ext-plugin 2.39

and

- Jenkins 1.580.1 (development environment)
- email-ext-plugin 04b383 (master branch)