### PR TITLE
Add post-send script feature

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -54,6 +54,7 @@ import org.codehaus.groovy.control.customizers.ImportCustomizer;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import org.kohsuke.groovy.sandbox.SandboxTransformer;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * {@link Publisher} that sends notification e-mail.
@@ -152,18 +153,18 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
 
     @Deprecated
     public ExtendedEmailPublisher(String project_recipient_list, String project_content_type, String project_default_subject,
-            String project_default_content, String project_attachments, String project_presend_script, String project_postsend_script,
+            String project_default_content, String project_attachments, String project_presend_script,
             int project_attach_buildlog, String project_replyto, boolean project_save_output,
             List<EmailTrigger> project_triggers, MatrixTriggerMode matrixTriggerMode) {
 
         this(project_recipient_list, project_content_type, project_default_subject, project_default_content,
-                project_attachments, project_presend_script, project_postsend_script, project_attach_buildlog, project_replyto,
+                project_attachments, project_presend_script, project_attach_buildlog, project_replyto,
                 project_save_output, project_triggers, matrixTriggerMode, false, Collections.EMPTY_LIST);
     }
 
     @DataBoundConstructor
     public ExtendedEmailPublisher(String project_recipient_list, String project_content_type, String project_default_subject,
-            String project_default_content, String project_attachments, String project_presend_script, String project_postsend_script,
+            String project_default_content, String project_attachments, String project_presend_script,
             int project_attach_buildlog, String project_replyto, boolean project_save_output,
             List<EmailTrigger> project_triggers, MatrixTriggerMode matrixTriggerMode, boolean project_disabled,
             List<GroovyScriptPath> classpath) {
@@ -173,7 +174,6 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
         this.defaultContent = project_default_content;
         this.attachmentsPattern = project_attachments;
         this.presendScript = project_presend_script;
-        this.postsendScript = project_postsend_script;
         this.attachBuildLog = project_attach_buildlog > 0;
         this.compressBuildLog = project_attach_buildlog > 1;
         this.replyTo = project_replyto;
@@ -182,6 +182,11 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
         this.matrixTriggerMode = matrixTriggerMode;
         this.disabled = project_disabled;
         this.classpath = classpath;
+    }
+
+    @DataBoundSetter
+    public void setPostsendScript(String project_postsend_script) {
+        this.postsendScript = project_postsend_script;
     }
 
     public ExtendedEmailPublisher() {

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -99,6 +99,11 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
      */
     private String defaultPresendScript = "";
 
+    /**
+     * This is the global default post-send script.
+     */
+    private String defaultPostsendScript = "";
+
     private List<GroovyScriptPath> defaultClasspath = new ArrayList<GroovyScriptPath>();
     
     private transient List<EmailTriggerDescriptor> defaultTriggers = new ArrayList<EmailTriggerDescriptor>();
@@ -328,6 +333,10 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
         return defaultPresendScript;
     }
 
+    public String getDefaultPostsendScript() {
+        return defaultPostsendScript;
+    }
+
     public List<GroovyScriptPath> getDefaultClasspath() {
         return defaultClasspath;
     }
@@ -397,6 +406,8 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
                 ? req.getParameter("ext_mailer_default_replyto") : "";
         defaultPresendScript = nullify(req.getParameter("ext_mailer_default_presend_script")) != null
                 ? req.getParameter("ext_mailer_default_presend_script") : "";
+        defaultPostsendScript = nullify(req.getParameter("ext_mailer_default_postsend_script")) != null
+                ? req.getParameter("ext_mailer_default_postsend_script") : "";
         if (req.hasParameter("ext_mailer_default_classpath")) {
             defaultClasspath.clear();
             for (String s : req.getParameterValues("ext_mailer_default_classpath")) {

--- a/src/main/java/hudson/plugins/emailext/plugins/ContentBuilder.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/ContentBuilder.java
@@ -35,6 +35,7 @@ public class ContentBuilder {
     private static final String DEFAULT_RECIPIENTS = "\\$DEFAULT_RECIPIENTS|\\$\\{DEFAULT_RECIPIENTS\\}";
     private static final String DEFAULT_REPLYTO = "\\$DEFAULT_REPLYTO|\\$\\{DEFAULT_REPLYTO\\}";
     private static final String DEFAULT_PRESEND_SCRIPT = "\\$DEFAULT_PRESEND_SCRIPT|\\$\\{DEFAULT_PRESEND_SCRIPT\\}";
+    private static final String DEFAULT_POSTSEND_SCRIPT = "\\$DEFAULT_POSTSEND_SCRIPT|\\$\\{DEFAULT_POSTSEND_SCRIPT\\}";
     private static final String PROJECT_DEFAULT_BODY = "\\$PROJECT_DEFAULT_CONTENT|\\$\\{PROJECT_DEFAULT_CONTENT\\}";
     private static final String PROJECT_DEFAULT_SUBJECT = "\\$PROJECT_DEFAULT_SUBJECT|\\$\\{PROJECT_DEFAULT_SUBJECT\\}";
     private static final String PROJECT_DEFAULT_REPLYTO = "\\$PROJECT_DEFAULT_REPLYTO|\\$\\{PROJECT_DEFAULT_REPLYTO\\}";
@@ -54,6 +55,7 @@ public class ContentBuilder {
         String defaultRecipients = Matcher.quoteReplacement(noNull(context.getPublisher().getDescriptor().getDefaultRecipients()));
         String defaultExtReplyTo = Matcher.quoteReplacement(noNull(context.getPublisher().getDescriptor().getDefaultReplyTo()));
         String defaultPresendScript = Matcher.quoteReplacement(noNull(context.getPublisher().getDescriptor().getDefaultPresendScript()));
+        String defaultPostsendScript = Matcher.quoteReplacement(noNull(context.getPublisher().getDescriptor().getDefaultPostsendScript()));
         String newText = origText.replaceAll(
                 PROJECT_DEFAULT_BODY, defaultContent).replaceAll(
                 PROJECT_DEFAULT_SUBJECT, defaultSubject).replaceAll(
@@ -62,7 +64,8 @@ public class ContentBuilder {
                 DEFAULT_SUBJECT, defaultExtSubject).replaceAll(
                 DEFAULT_RECIPIENTS, defaultRecipients).replaceAll(
                 DEFAULT_REPLYTO, defaultExtReplyTo).replaceAll(
-                DEFAULT_PRESEND_SCRIPT, defaultPresendScript);
+                DEFAULT_PRESEND_SCRIPT, defaultPresendScript).replaceAll(
+                DEFAULT_POSTSEND_SCRIPT, defaultPostsendScript);
         
         try {
             List<TokenMacro> macros = new ArrayList<TokenMacro>(getPrivateMacros());

--- a/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/config.groovy
+++ b/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/config.groovy
@@ -59,6 +59,9 @@ f.advanced(title: _("Advanced Settings")) {
   f.entry(title: _("Pre-send Script"), help: "/plugin/email-ext/help/projectConfig/presendScript.html") {
     f.textarea(id: "project_presend_script", name: "project_presend_script", value: configured ? instance.presendScript : "\$DEFAULT_PRESEND_SCRIPT", class: "setting-input") 
   }
+  f.entry(title: _("Post-send Script"), help: "/plugin/email-ext/help/projectConfig/postsendScript.html") {
+    f.textarea(id: "project_postsend_script", name: "project_postsend_script", value: configured ? instance.postsendScript : "\$DEFAULT_POSTSEND_SCRIPT", class: "setting-input")
+  }
   f.entry(title: _("Additional groovy classpath"), help: "/plugin/help/projectConfig/defaultClasspath.html") {
     f.repeatable(field: "classpath") {
       f.textbox(field: "path") 

--- a/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/global.groovy
+++ b/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/global.groovy
@@ -72,6 +72,9 @@ f.section(title: _("Extended E-mail Notification")) {
   f.entry(help: "/plugin/email-ext/help/globalConfig/defaultPresendScript.html", title: _("Default Pre-send Script")) {
     f.textarea(class: "setting-input", value: descriptor.defaultPresendScript, name: "ext_mailer_default_presend_script")
   }
+  f.entry(help: "/plugin/email-ext/help/globalConfig/defaultPostsendScript.html", title: _("Default Post-send Script")) {
+    f.textarea(class: "setting-input", value: descriptor.defaultPostsendScript, name: "ext_mailer_default_postsend_script")
+  }
   f.entry(title: _("Additional groovy classpath"), help: "/plugin/email-ext/help/globalConfig/defaultClasspath.html") {
     f.repeatable(field: "defaultClasspath") {
       f.textbox(field: "path", name: "ext_mailer_default_classpath") 

--- a/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/help-tokens.groovy
+++ b/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/help-tokens.groovy
@@ -18,6 +18,9 @@ dl() {
   dt("\${DEFAULT_PRESEND_SCRIPT}")
   dd(_("defaultPresend"))
 
+  dt("\${DEFAULT_POSTSEND_SCRIPT}")
+  dd(_("defaultPostsend"))
+
   dt("\${PROJECT_DEFAULT_SUBJECT}")
   dd(_("projectDefaultSubject"))
 

--- a/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/help-tokens.properties
+++ b/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/help-tokens.properties
@@ -6,6 +6,8 @@ defaultSubject=This is the default email subject that is configured in Jenkins's
 defaultContent=This is the default email content that is configured in Jenkins's system configuration page.
 defaultPresend=This is the default pre-send script content that is configured in Jenkins's system configuration. \
   This is the only token supported in the pre-send script entry field.
+defaultPostsend=This is the default post-send script content that is configured in Jenkins's system configuration. \
+  This is the only token supported in the post-send script entry field.
 projectDefaultSubject=This is the default email subject for this project. The result of using this token in \
   the advanced configuration is what is in the Default Subject field above. WARNING: Do not use this token in \
   the Default Subject or Content fields.  Doing this has an undefined result.

--- a/src/main/resources/hudson/plugins/emailext/templates/Jive-Formatter-README.md
+++ b/src/main/resources/hudson/plugins/emailext/templates/Jive-Formatter-README.md
@@ -1,13 +1,13 @@
 Jive Formatter
 ==================
 
-jive-formatter.groovy contains methods for easy and convenient formatting of emails being sent from Jenkins to Jive. It should be called from the Pre-send Script area.
+jive-formatter.groovy contains methods for easy and convenient formatting of emails being sent from Jenkins to Jive. It should be called from the Pre-send or Post-send Script area.
 
 Also, it doesn't seem like Jive supports text with multiple formats, so only call one formatting method per block of text.
 
 Either formatLine or formatText can and should be called on every line of text that will be sent to the Jive system prior to calling formatting methods like color or size. Please test on your own instances of Jive and add functionality as you find it!
 
-The following lines should be added to the Pre-send Script area prior to attempting to invoke any functions.
+The following lines should be added to the Pre-send or Post-send Script area prior to attempting to invoke any functions.
 
         File sourceFile = new File("/your/preferred/path/jive-formatter.groovy");
         Class groovyClass = new GroovyClassLoader(getClass().getClassLoader()).parseClass(sourceFile);

--- a/src/main/resources/hudson/plugins/emailext/templates/jive-formatter.groovy
+++ b/src/main/resources/hudson/plugins/emailext/templates/jive-formatter.groovy
@@ -2,12 +2,12 @@ import java.lang.reflect.Array;
 import java.util.regex.*
 /**
  * This is a Groovy class to allow easy formatting for Jive social networking systems. 
- * It was designed to work in the email-ext plugin for Jenkins. It should be called from the Pre-send Script area. 
+ * It was designed to work in the email-ext plugin for Jenkins. It should be called from the Pre-send or Post-send Script area. 
  * Also, it doesn't seem like Jive supports text with multiple formats, so only call one formatting method per block of text.
  * Either formatLine or formatText can and should be called on every line of text that will be sent to the Jive system 
  * prior to calling formatting methods like color or size.
  * <p>
- * The following lines should be added to the Pre-send Script area prior to attempting to invoke any functions.
+ * The following lines should be added to the Pre-send or Post-send Script area prior to attempting to invoke any functions.
  * <p>
  * File sourceFile = new File("/your/preferred/path/jive-formatter.groovy");
  * Class groovyClass = new GroovyClassLoader(getClass().getClassLoader()).parseClass(sourceFile);

--- a/src/main/webapp/help/globalConfig/defaultClasspath.html
+++ b/src/main/webapp/help/globalConfig/defaultClasspath.html
@@ -1,6 +1,6 @@
 <div>
 	These pathes allow to extend the Groovy classpath when the
-	presend script is run. The syntax of the path is either a
+	presend and postsend script are run. The syntax of the path is either a
 	full url or a simple file path (may be relative).
 	These pathes are common to all projects when configured at
 	the global scope. 

--- a/src/main/webapp/help/globalConfig/defaultPostsendScript.html
+++ b/src/main/webapp/help/globalConfig/defaultPostsendScript.html
@@ -1,0 +1,13 @@
+<div>
+    This script will be run after sending the email to allow
+    modifying the email after sending. The MimeMessage variable
+    is "msg," the SMTPTransport "transport," the session
+    properties "props," the build is also available as "build"
+    and a logger is available as "logger." The trigger that
+    caused the email is available as "trigger" and all triggered
+    builds are available as a map "triggered."
+    <br/><br/>
+    You can set the default post-send script here and then use
+    ${DEFAULT_POSTSEND_SCRIPT} in the project settings to use
+    the script written here.
+</div>

--- a/src/main/webapp/help/globalConfig/defaultPostsendScript.html
+++ b/src/main/webapp/help/globalConfig/defaultPostsendScript.html
@@ -1,6 +1,6 @@
 <div>
     This script will be run after sending the email to allow
-    modifying the email after sending. The MimeMessage variable
+    acting upon the send result. The MimeMessage variable
     is "msg," the SMTPTransport "transport," the session
     properties "props," the build is also available as "build"
     and a logger is available as "logger." The trigger that

--- a/src/main/webapp/help/globalConfig/security.html
+++ b/src/main/webapp/help/globalConfig/security.html
@@ -1,6 +1,6 @@
 <div>
 	<p>
-	When enabled, it removes the ability for pre-send scripts to directly access the Jenkins instance. A security exception will be thrown
+	When enabled, it removes the ability for pre-send and post-send scripts to directly access the Jenkins instance. A security exception will be thrown
     if the user tries to access the Jenkins instance of the manager object.
 	</p>
 </div>

--- a/src/main/webapp/help/projectConfig/defaultClasspath.html
+++ b/src/main/webapp/help/projectConfig/defaultClasspath.html
@@ -1,6 +1,6 @@
 <div>
 	These pathes allow to extend the Groovy classpath when the
-	presend script is run. The syntax of the path is either a
+	presend and postsend script are run. The syntax of the path is either a
 	full url or a simple file path (may be relative).
 	These pathes are specific to this project and will be added
 	to those of	the global scope. 

--- a/src/main/webapp/help/projectConfig/postsendScript.html
+++ b/src/main/webapp/help/projectConfig/postsendScript.html
@@ -1,0 +1,7 @@
+<div>
+    This script will be run after sending the email to allow
+    acting upon the send result. The MimeMessage variable
+    is "msg," the SMTPTransport "transport," the session
+    properties "props," the build is also available as "build"
+    and a logger is available as "logger."
+</div>

--- a/src/test/java/hudson/plugins/emailext/plugins/ContentBuilderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/ContentBuilderTest.java
@@ -123,6 +123,17 @@ public class ContentBuilderTest {
     }
 
     @Test
+    public void testTransformText_shouldExpand_$DEFAULT_POSTSEND_SCRIPT()
+            throws IOException, InterruptedException {
+        assertEquals(publisher.getDescriptor().getDefaultPostsendScript(),
+                ContentBuilder.transformText("$DEFAULT_POSTSEND_SCRIPT", publisher,
+                build, listener));
+        assertEquals(publisher.getDescriptor().getDefaultPostsendScript(),
+                ContentBuilder.transformText("${DEFAULT_POSTSEND_SCRIPT}", publisher,
+                build, listener));
+    }
+
+    @Test
     public void testTransformText_noNPEWithNullDefaultSubjectBody() throws NoSuchFieldException, IllegalAccessException {
         Field f = ExtendedEmailPublisherDescriptor.class.getDeclaredField("defaultBody");
         f.setAccessible(true);

--- a/src/test/java/hudson/plugins/emailext/plugins/content/TriggerNameContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/TriggerNameContentTest.java
@@ -38,6 +38,7 @@ public class TriggerNameContentTest {
             publisher.attachmentsPattern = "";
             publisher.recipientList = "%DEFAULT_RECIPIENTS";
             publisher.presendScript = "";
+            publisher.postsendScript = "";
 
             project = createFreeStyleProject();
             project.getPublishersList().add(publisher);

--- a/src/test/postsend/hudson/plugins/emailext/ExtendedEmailPublisherTestHelper.groovy
+++ b/src/test/postsend/hudson/plugins/emailext/ExtendedEmailPublisherTestHelper.groovy
@@ -1,0 +1,7 @@
+package hudson.plugins.emailext
+
+class ExtendedEmailPublisherTestHelper {
+  static def messageid() {
+    "<12345@xxx.com>"
+  }
+}

--- a/src/test/resources/recipient-provider-upgrade.xml
+++ b/src/test/resources/recipient-provider-upgrade.xml
@@ -38,6 +38,7 @@
       <defaultContent>$DEFAULT_CONTENT</defaultContent>
       <attachmentsPattern></attachmentsPattern>
       <presendScript>$DEFAULT_PRESEND_SCRIPT</presendScript>
+      <postsendScript>$DEFAULT_POSTSEND_SCRIPT</postsendScript>
       <attachBuildLog>false</attachBuildLog>
       <compressBuildLog>false</compressBuildLog>
       <replyTo>$DEFAULT_REPLYTO</replyTo>

--- a/src/test/resources/recipient-provider-upgrade2.xml
+++ b/src/test/resources/recipient-provider-upgrade2.xml
@@ -38,6 +38,7 @@
       <defaultContent>$DEFAULT_CONTENT</defaultContent>
       <attachmentsPattern></attachmentsPattern>
       <presendScript>$DEFAULT_PRESEND_SCRIPT</presendScript>
+      <postsendScript>$DEFAULT_POSTSEND_SCRIPT</postsendScript>
       <attachBuildLog>false</attachBuildLog>
       <compressBuildLog>false</compressBuildLog>
       <replyTo>$DEFAULT_REPLYTO</replyTo>


### PR DESCRIPTION
For some tasks pre-send scripts are not sufficient, like rewriting the Message-ID based on the SMTP response for later In-Reply-To headers. This is needed when using Amazon Simple Email Service (AWS SES) for sending emails.

Other possible use cases are scripts that act upon failed sending attempts.

Here is a example post-send script that does the message id rewriting for AWS SES:

```groovy
import com.sun.mail.smtp.SMTPTransport;
import java.util.regex.Matcher;
import java.util.regex.Pattern;
import hudson.plugins.emailext.ExtendedEmailPublisherDescriptor;

String smtpHost = props.getProperty("mail.smtp.host", "");
String awsRegex = "^email-smtp\\.([a-z0-9-]+)\\.amazonaws\\.com\$";
Pattern p = Pattern.compile(awsRegex);
Matcher m = p.matcher(smtpHost);
if (m.matches()) {
    String region = m.group(1);
    if (transport instanceof SMTPTransport) {
        String response = ((SMTPTransport)transport).getLastServerResponse();
        String[] parts = response.trim().split(" +");
        if (parts.length == 3 && parts[0].equals("250") && parts[1].equals("Ok")) {
            String MessageID = "<" + parts[2] + "@" + region + ".amazonses.com>";
            msg.setHeader("Message-ID", MessageID);
        }
    }
}
```

References:
- https://issues.jenkins-ci.org/browse/JENKINS-30854
- Pull request #108
- http://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-response-codes.html