### PR TITLE
squid:S1596 -  Collections.emptyList(), emptyMap() and emptySet() sho…

### DIFF
--- a/src/main/java/hudson/plugins/emailext/EmailExtTemplateActionFactory.java
+++ b/src/main/java/hudson/plugins/emailext/EmailExtTemplateActionFactory.java
@@ -36,6 +36,6 @@ public class EmailExtTemplateActionFactory extends TransientProjectActionFactory
         if(hasEmailExt) {
             return Collections.singletonList(new EmailExtTemplateAction(target));
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }        
 }

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -178,7 +178,7 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
 
         this(project_recipient_list, project_content_type, project_default_subject, project_default_content,
                 project_attachments, project_presend_script, project_attach_buildlog, project_replyto,
-                project_save_output, project_triggers, matrixTriggerMode, false, Collections.EMPTY_LIST);
+                project_save_output, project_triggers, matrixTriggerMode, false, Collections.<GroovyScriptPath>emptyList());
     }
 
     @DataBoundConstructor

--- a/src/main/java/hudson/plugins/emailext/plugins/content/ScriptContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/ScriptContent.java
@@ -122,7 +122,7 @@ public class ScriptContent extends AbstractEvalContent {
         binding.put("project", build.getParent());
         
         // we add the binding to the SimpleTemplateEngine instead of the shell
-        GroovyShell shell = createEngine(descriptor, Collections.EMPTY_MAP);
+        GroovyShell shell = createEngine(descriptor, Collections.<String, Object>emptyMap());
         SimpleTemplateEngine engine = new SimpleTemplateEngine(shell);
         try {
             String text = IOUtils.toString(templateStream);

--- a/src/main/java/hudson/plugins/emailext/watching/EmailExtWatchAction.java
+++ b/src/main/java/hudson/plugins/emailext/watching/EmailExtWatchAction.java
@@ -48,7 +48,7 @@ public class EmailExtWatchAction implements Action {
         }
         
         private void clearTriggers() {
-            triggers = Collections.EMPTY_LIST;
+            triggers = Collections.<EmailTrigger>emptyList();
         }
 
         @Extension

--- a/src/main/java/hudson/plugins/emailext/watching/EmailExtWatchJobProperty.java
+++ b/src/main/java/hudson/plugins/emailext/watching/EmailExtWatchJobProperty.java
@@ -25,7 +25,7 @@ public class EmailExtWatchJobProperty extends JobProperty<Job<?, ?>> {
 
     @Override
     public Collection<Action> getJobActions(Job<?, ?> job) {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     public List<String> getWatchers() {

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/MockUtilities.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/MockUtilities.java
@@ -91,7 +91,7 @@ import hudson.tasks.test.AbstractTestResultAction;
 
                         @Override
                         public Collection<String> getAffectedPaths() {
-                            return Collections.EMPTY_SET;
+                            return Collections.emptySet();
                         }
 
                         @Override
@@ -101,7 +101,7 @@ import hudson.tasks.test.AbstractTestResultAction;
 
                         @Override
                         public Collection<? extends ChangeLogSet.AffectedFile> getAffectedFiles() {
-                            return Collections.EMPTY_SET;
+                            return Collections.emptySet();
                         }
                     };
                 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1596 -
Collections.emptyList(), emptyMap() and emptySet() should be used instead
of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1596
Please let me know if you have any questions.
M-Ezzat