### PR TITLE
squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -541,14 +541,14 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
     private void expandClasspath(ExtendedEmailPublisherContext context, CompilerConfiguration cc) {
         List<String> classpathList = new ArrayList<String>();
 
-        if ((classpath != null) && classpath.size() > 0) {
+        if ((classpath != null) && !classpath.isEmpty()) {
             for (GroovyScriptPath path : classpath) {
                 classpathList.add(ContentBuilder.transformText(path.getPath(), context, getRuntimeMacros(context)));
             }
         }
 
         List<GroovyScriptPath> globalClasspath = getDescriptor().getDefaultClasspath();
-        if ((globalClasspath != null) && (globalClasspath.size() > 0)) {
+        if (globalClasspath != null && !globalClasspath.isEmpty()) {
             for (GroovyScriptPath path : globalClasspath) {
                 classpathList.add(ContentBuilder.transformText(path.getPath(), context, getRuntimeMacros(context)));
             }
@@ -647,10 +647,10 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
         bcc.removeAll(excludedRecipients);
 
         msg.setRecipients(Message.RecipientType.TO, to.toArray(new InternetAddress[to.size()]));
-        if (cc.size() > 0) {
+        if (!cc.isEmpty()) {
             msg.setRecipients(Message.RecipientType.CC, cc.toArray(new InternetAddress[cc.size()]));
         }
-        if (bcc.size() > 0) {
+        if (!bcc.isEmpty()) {
             msg.setRecipients(Message.RecipientType.BCC, bcc.toArray(new InternetAddress[bcc.size()]));
         }
 
@@ -664,7 +664,7 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
             EmailRecipientUtils.addAddressesFromRecipientList(replyToAddresses, null, null, EmailRecipientUtils.getRecipientList(context, context.getTrigger().getEmail().getReplyTo()), env, context.getListener());
         }
 
-        if (replyToAddresses.size() > 0) {
+        if (!replyToAddresses.isEmpty()) {
             msg.setReplyTo(replyToAddresses.toArray(new InternetAddress[replyToAddresses.size()]));
         }
 

--- a/src/main/java/hudson/plugins/emailext/plugins/content/BuildLogRegexContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/BuildLogRegexContent.java
@@ -229,7 +229,7 @@ public class BuildLogRegexContent extends DataBoundTokenMacro {
         if (showTruncatedLines == true) {
             // Count the rest of the lines.
             // Include any lines in linesBefore.
-            while (linesBeforeList.size() > 0) {
+            while (!linesBeforeList.isEmpty()) {
                 linesBeforeList.remove();
                 ++numLinesTruncated;
             }

--- a/src/main/java/hudson/plugins/emailext/watching/EmailExtWatchAction.java
+++ b/src/main/java/hudson/plugins/emailext/watching/EmailExtWatchAction.java
@@ -92,7 +92,7 @@ public class EmailExtWatchAction implements Action {
     
     public boolean isWatching() {
         List<EmailTrigger> triggers = getTriggers();
-        return triggers != null && triggers.size() > 0;
+        return triggers != null && !triggers.isEmpty();
     }
     
     public List<EmailTrigger> getTriggers() {

--- a/src/test/java/hudson/plugins/emailext/EmailTypeTest.java
+++ b/src/test/java/hudson/plugins/emailext/EmailTypeTest.java
@@ -85,7 +85,7 @@ public class EmailTypeTest {
         assertNotNull(pub);
         
         // make sure the trigger was marshalled
-        assertFalse(0 == pub.configuredTriggers.size());
+        assertFalse(pub.configuredTriggers.isEmpty());
         
         // should have developers, requestor and culprits
         assertEquals(3, pub.configuredTriggers.get(0).getEmail().getRecipientProviders().size());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155
- Collection.isEmpty() should be used to test for emptiness
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155
Please let me know if you have any questions.
M-Ezzat