### PR TITLE
pmd:BooleanGetMethodName - Boolean Get Method Name

### DIFF
--- a/src/main/java/hudson/plugins/emailext/EmailExtStep.java
+++ b/src/main/java/hudson/plugins/emailext/EmailExtStep.java
@@ -93,7 +93,7 @@ public class EmailExtStep extends AbstractStepImpl {
         this.mimeType = Util.fixNull(mimeType);
     }
 
-    public boolean getAttachLog() {
+    public boolean isAttachLog() {
         return attachLog;
     }
 
@@ -102,7 +102,7 @@ public class EmailExtStep extends AbstractStepImpl {
         this.attachLog = attachLog;
     }
 
-    public boolean getCompressLog() {
+    public boolean isCompressLog() {
         return compressLog;
     }
 

--- a/src/main/java/hudson/plugins/emailext/EmailType.java
+++ b/src/main/java/hudson/plugins/emailext/EmailType.java
@@ -111,7 +111,7 @@ public class EmailType {
         this.body = body;
     }
 
-    public boolean getHasRecipients() {
+    public boolean isHasRecipients() {
         return (recipientProviders != null && !recipientProviders.isEmpty())
                 || (recipientList != null && recipientList.trim().length() != 0);
     }
@@ -160,11 +160,11 @@ public class EmailType {
         this.attachmentsPattern = attachmentsPattern;
     }
 
-    public boolean getAttachBuildLog() {
+    public boolean isAttachBuildLog() {
         return attachBuildLog;
     }
 
-    public boolean getCompressBuildLog() {
+    public boolean isCompressBuildLog() {
         return compressBuildLog;
     }
 

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -578,7 +578,7 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
     private MimeMessage createMail(ExtendedEmailPublisherContext context) throws MessagingException, IOException, InterruptedException {
         ExtendedEmailPublisherDescriptor descriptor = getDescriptor();
 
-        if (!descriptor.getOverrideGlobalSettings()) {
+        if (!descriptor.isOverrideGlobalSettings()) {
             descriptor.upgradeFromMailer();
         }
 
@@ -618,9 +618,9 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
             typeAttachments.attach(multipart, context);
         }
 
-        if (attachBuildLog || context.getTrigger().getEmail().getAttachBuildLog()) {
+        if (attachBuildLog || context.getTrigger().getEmail().isAttachBuildLog()) {
             debug(context.getListener().getLogger(), "Request made to attach build log");
-            AttachmentUtils.attachBuildLog(context, multipart, compressBuildLog || context.getTrigger().getEmail().getCompressBuildLog());
+            AttachmentUtils.attachBuildLog(context, multipart, compressBuildLog || context.getTrigger().getEmail().isCompressBuildLog());
         }
 
         msg.setContent(multipart);

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -245,7 +245,7 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
         return Secret.toString(smtpAuthPassword);
     }
 
-    public boolean getUseSsl() {
+    public boolean isUseSsl() {
         return useSsl;
     }
 
@@ -297,7 +297,7 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
         return excludedCommitters;
     }
 
-    public boolean getOverrideGlobalSettings() {
+    public boolean isOverrideGlobalSettings() {
         return overrideGlobalSettings;
     }
     

--- a/src/main/java/hudson/plugins/emailext/plugins/content/JenkinsURLContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/JenkinsURLContent.java
@@ -29,7 +29,7 @@ public class JenkinsURLContent extends DataBoundTokenMacro {
         
         ExtendedEmailPublisher publisher = context.getProject().getPublishersList().get(ExtendedEmailPublisher.class);
         
-        if (publisher.getDescriptor().getOverrideGlobalSettings()) {
+        if (publisher.getDescriptor().isOverrideGlobalSettings()) {
             jenkinsUrl = publisher.getDescriptor().getHudsonUrl();
         }
 

--- a/src/test/java/hudson/plugins/emailext/EmailTypeTest.java
+++ b/src/test/java/hudson/plugins/emailext/EmailTypeTest.java
@@ -24,7 +24,7 @@ public class EmailTypeTest {
     public void testHasNoRecipients() {
         EmailType t = new EmailType();
 
-        assertFalse(t.getHasRecipients());
+        assertFalse(t.isHasRecipients());
     }
 
     @Test
@@ -33,7 +33,7 @@ public class EmailTypeTest {
         
         t.addRecipientProvider(new DevelopersRecipientProvider());
         
-        assertTrue(t.getHasRecipients());
+        assertTrue(t.isHasRecipients());
     }
 
     @Test
@@ -42,7 +42,7 @@ public class EmailTypeTest {
         
         t.addRecipientProvider(new ListRecipientProvider());
         
-        assertTrue(t.getHasRecipients());
+        assertTrue(t.isHasRecipients());
     }
 
     @Test
@@ -52,7 +52,7 @@ public class EmailTypeTest {
         t.addRecipientProvider(new ListRecipientProvider());
         t.addRecipientProvider(new DevelopersRecipientProvider());
 
-        assertTrue(t.getHasRecipients());
+        assertTrue(t.isHasRecipients());
     }
 
     @Test
@@ -60,14 +60,14 @@ public class EmailTypeTest {
         EmailType t = new EmailType();
         t.setCompressBuildLog(true);
 
-        assertTrue(t.getCompressBuildLog());
+        assertTrue(t.isCompressBuildLog());
     }
 
     @Test
     public void testDefaultCompressBuildAttachment() {
         EmailType t = new EmailType();
 
-        assertFalse(t.getCompressBuildLog());
+        assertFalse(t.isCompressBuildLog());
     }
     
     @Test


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule pmd:BooleanGetMethodName - Boolean Get Method Name
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=pmd:BooleanGetMethodName
Please let me know if you have any questions.
M-Ezzat