### PR TITLE
pmd:UseProperClassLoader, squid:S1118 - Use Proper Class Loader,  Uti…

### DIFF
--- a/src/main/java/hudson/plugins/emailext/EmailExtTemplateAction.java
+++ b/src/main/java/hudson/plugins/emailext/EmailExtTemplateAction.java
@@ -9,12 +9,15 @@ import hudson.plugins.emailext.plugins.content.JellyScriptContent;
 import hudson.plugins.emailext.plugins.content.ScriptContent;
 import hudson.util.FormValidation;
 import hudson.util.StreamTaskListener;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+
 import jenkins.model.Jenkins;
+
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
@@ -61,7 +64,8 @@ public class EmailExtTemplateAction implements Action {
                 return checkForManagedFile(value);
             } else {
                 // first check in the default resources area...
-                InputStream inputStream = getClass().getClassLoader().getResourceAsStream("hudson/plugins/emailext/templates/" + value);                
+                InputStream inputStream = Thread.currentThread().getContextClassLoader()
+                		.getResourceAsStream("hudson/plugins/emailext/templates/" + value);                
                 if(inputStream == null) {                
                     final File scriptsFolder = new File(Jenkins.getActiveInstance().getRootDir(), "email-templates");
                     final File scriptFile = new File(scriptsFolder, value);

--- a/src/main/java/hudson/plugins/emailext/plugins/ContentBuilder.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/ContentBuilder.java
@@ -25,7 +25,7 @@ import org.jenkinsci.plugins.tokenmacro.TokenMacro;
  * @author kyle.sweeney@valtech.com
  *
  */
-public class ContentBuilder {
+public final class ContentBuilder {
     
     @CopyOnWrite
     private static volatile List<TokenMacro> privateMacros;
@@ -39,6 +39,10 @@ public class ContentBuilder {
     private static final String PROJECT_DEFAULT_BODY = "\\$PROJECT_DEFAULT_CONTENT|\\$\\{PROJECT_DEFAULT_CONTENT\\}";
     private static final String PROJECT_DEFAULT_SUBJECT = "\\$PROJECT_DEFAULT_SUBJECT|\\$\\{PROJECT_DEFAULT_SUBJECT\\}";
     private static final String PROJECT_DEFAULT_REPLYTO = "\\$PROJECT_DEFAULT_REPLYTO|\\$\\{PROJECT_DEFAULT_REPLYTO\\}";
+
+    private ContentBuilder() {
+    	throw new InstantiationError( "Must not instantiate this class" );
+    }
 
     private static String noNull(String string) {
         return string == null ? "" : string;

--- a/src/main/java/hudson/plugins/emailext/plugins/content/AbstractEvalContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/AbstractEvalContent.java
@@ -27,6 +27,7 @@ import hudson.Plugin;
 import hudson.model.AbstractBuild;
 import hudson.model.TaskListener;
 import hudson.plugins.emailext.ExtendedEmailPublisher;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -36,6 +37,7 @@ import java.io.InputStream;
 
 import hudson.plugins.emailext.ExtendedEmailPublisherDescriptor;
 import jenkins.model.Jenkins;
+
 import org.apache.commons.io.FilenameUtils;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
@@ -99,7 +101,7 @@ public abstract class AbstractEvalContent extends DataBoundTokenMacro {
             fileName += extension;
         }        
         
-        inputStream = getClass().getClassLoader().getResourceAsStream(
+        inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(
                 "hudson/plugins/emailext/templates/" + fileName);
 
         if (inputStream == null) {

--- a/src/test/java/hudson/plugins/emailext/plugins/OnlyRegressionsTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/OnlyRegressionsTest.java
@@ -32,7 +32,7 @@ public class OnlyRegressionsTest {
         project.getBuildersList().add(new TestBuilder() {
             @Override
             public boolean perform(AbstractBuild<?, ?> abstractBuild, Launcher launcher, BuildListener buildListener) throws InterruptedException, IOException {
-                final URL failedTestReport = OnlyRegressionsTest.class.getClassLoader().getResource("hudson/plugins/emailext/testreports/failed_test.xml");
+                final URL failedTestReport = Thread.currentThread().getContextClassLoader().getResource("hudson/plugins/emailext/testreports/failed_test.xml");
                 FilePath workspace = abstractBuild.getWorkspace();
 
                 FilePath testDir = workspace.child("target").child("testreports");

--- a/src/test/java/hudson/plugins/emailext/plugins/content/ScriptContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/ScriptContentTest.java
@@ -11,6 +11,7 @@ import hudson.plugins.emailext.ExtendedEmailPublisherDescriptor;
 import hudson.util.DescribableList;
 import hudson.util.StreamTaskListener;
 import jenkins.model.JenkinsLocationConfiguration;
+
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Rule;
@@ -146,7 +147,7 @@ public class ScriptContentTest {
 
         // read expected file in resource to easy compare
         String expectedFile = "hudson/plugins/emailext/templates/" + "content-token.result";
-        InputStream in = getClass().getClassLoader().getResourceAsStream(expectedFile);
+        InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(expectedFile);
         String expected = new Scanner(in).useDelimiter("\\Z").next();
         
         // windows has a \r in each line, so make sure the comparison works correctly
@@ -182,7 +183,7 @@ public class ScriptContentTest {
 
         // read expected file in resource to easy compare
         String expectedFile = "hudson/plugins/emailext/templates/" + "groovy-sample.result";
-        InputStream in = getClass().getClassLoader().getResourceAsStream(expectedFile);
+        InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(expectedFile);
         String expected = new Scanner(in).useDelimiter("\\Z").next();
         
         // windows has a \r in each line, so make sure the comparison works correctly


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule pmd:UseProperClassLoader - squid:S1118
Use Proper Class Loader and Utility classes should not have public constructors
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=pmd:UseProperClassLoader
https://dev.eclipse.org/sonar/coding_rules#squid:S1118
Please let me know if you have any questions.
M-Ezzat