### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -170,6 +170,9 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
      */
     public MatrixTriggerMode matrixTriggerMode;
 
+    public ExtendedEmailPublisher() {
+    }
+
     @Deprecated
     public ExtendedEmailPublisher(String project_recipient_list, String project_content_type, String project_default_subject,
             String project_default_content, String project_attachments, String project_presend_script,
@@ -207,10 +210,7 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
     public void setPostsendScript(String project_postsend_script) {
         this.postsendScript = project_postsend_script;
     }
-
-    public ExtendedEmailPublisher() {
-    }
-
+    
     /**
      * Get the list of configured email theTriggers for this project.
      *

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -159,6 +159,17 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
      */
     private boolean enableWatching;
 
+    public ExtendedEmailPublisherDescriptor() {
+        super(ExtendedEmailPublisher.class);
+        load();
+        if (defaultBody == null && defaultSubject == null && emergencyReroute == null) {
+            defaultBody = ExtendedEmailPublisher.DEFAULT_BODY_TEXT;
+            defaultSubject = ExtendedEmailPublisher.DEFAULT_SUBJECT_TEXT;
+            emergencyReroute = ExtendedEmailPublisher.DEFAULT_EMERGENCY_REROUTE_TEXT;
+            enableSecurity = false;
+        }
+    }
+
     @Override
     public String getDisplayName() {
         return Messages.ExtendedEmailPublisherDescriptor_DisplayName();
@@ -358,17 +369,6 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
             save();
         }
         return defaultTriggerIds;
-    }
-
-    public ExtendedEmailPublisherDescriptor() {
-        super(ExtendedEmailPublisher.class);
-        load();
-        if (defaultBody == null && defaultSubject == null && emergencyReroute == null) {
-            defaultBody = ExtendedEmailPublisher.DEFAULT_BODY_TEXT;
-            defaultSubject = ExtendedEmailPublisher.DEFAULT_SUBJECT_TEXT;
-            emergencyReroute = ExtendedEmailPublisher.DEFAULT_EMERGENCY_REROUTE_TEXT;
-            enableSecurity = false;
-        }
     }
 
     @Override

--- a/src/main/java/hudson/plugins/emailext/plugins/EmailTrigger.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/EmailTrigger.java
@@ -29,6 +29,55 @@ public abstract class EmailTrigger implements Describable<EmailTrigger>, Extensi
 
     private EmailType email;
 
+    @Deprecated
+    protected EmailTrigger(boolean sendToList, boolean sendToDevs, boolean sendToRequestor, boolean sendToCulprits, String recipientList, String replyTo, String subject, String body, String attachmentsPattern, int attachBuildLog, String contentType) {
+        List<RecipientProvider> providers = new ArrayList<RecipientProvider>();
+        if(sendToList) {
+            providers.add(new ListRecipientProvider());
+        }
+
+        if(sendToDevs) {
+            providers.add(new DevelopersRecipientProvider());
+        }
+
+        if(sendToRequestor) {
+            providers.add(new RequesterRecipientProvider());
+        }
+
+        if(sendToCulprits) {
+            providers.add(new CulpritsRecipientProvider());
+        }
+
+        email = new EmailType();
+        email.addRecipientProviders(providers);
+        email.setRecipientList(recipientList);
+        email.setReplyTo(replyTo);
+        email.setSubject(subject);
+        email.setBody(body);
+        email.setAttachmentsPattern(attachmentsPattern);
+        email.setAttachBuildLog(attachBuildLog > 0);
+        email.setCompressBuildLog(attachBuildLog > 1);
+        email.setContentType(contentType);
+    }
+
+    protected EmailTrigger(List<RecipientProvider> recipientProviders, String recipientList, String replyTo,
+                           String subject, String body, String attachmentsPattern, int attachBuildLog, String contentType) {
+        email = new EmailType();
+        email.addRecipientProviders(recipientProviders);
+        email.setRecipientList(recipientList);
+        email.setReplyTo(replyTo);
+        email.setSubject(subject);
+        email.setBody(body);
+        email.setAttachmentsPattern(attachmentsPattern);
+        email.setAttachBuildLog(attachBuildLog > 0);
+        email.setCompressBuildLog(attachBuildLog > 1);
+        email.setContentType(contentType);
+    }
+
+    protected EmailTrigger(JSONObject formData) {
+
+    }
+
     public static DescriptorExtensionList<EmailTrigger, EmailTriggerDescriptor> all() {
         return Jenkins.getActiveInstance().<EmailTrigger, EmailTriggerDescriptor>getDescriptorList(EmailTrigger.class);
     }
@@ -42,55 +91,6 @@ public abstract class EmailTrigger implements Describable<EmailTrigger>, Extensi
         }
 
         return list;
-    }
-
-    @Deprecated
-    protected EmailTrigger(boolean sendToList, boolean sendToDevs, boolean sendToRequestor, boolean sendToCulprits, String recipientList, String replyTo, String subject, String body, String attachmentsPattern, int attachBuildLog, String contentType) {
-        List<RecipientProvider> providers = new ArrayList<RecipientProvider>();
-        if(sendToList) {
-            providers.add(new ListRecipientProvider());
-        }
-        
-        if(sendToDevs) {
-            providers.add(new DevelopersRecipientProvider());
-        }
-        
-        if(sendToRequestor) {
-            providers.add(new RequesterRecipientProvider());
-        }
-        
-        if(sendToCulprits) {
-            providers.add(new CulpritsRecipientProvider());
-        }
-        
-        email = new EmailType();
-        email.addRecipientProviders(providers);
-        email.setRecipientList(recipientList);
-        email.setReplyTo(replyTo);
-        email.setSubject(subject);
-        email.setBody(body);
-        email.setAttachmentsPattern(attachmentsPattern);
-        email.setAttachBuildLog(attachBuildLog > 0);
-        email.setCompressBuildLog(attachBuildLog > 1);
-        email.setContentType(contentType);
-    }
-    
-    protected EmailTrigger(List<RecipientProvider> recipientProviders, String recipientList, String replyTo, 
-            String subject, String body, String attachmentsPattern, int attachBuildLog, String contentType) {
-        email = new EmailType();
-        email.addRecipientProviders(recipientProviders);
-        email.setRecipientList(recipientList);
-        email.setReplyTo(replyTo);
-        email.setSubject(subject);
-        email.setBody(body);
-        email.setAttachmentsPattern(attachmentsPattern);
-        email.setAttachBuildLog(attachBuildLog > 0);
-        email.setCompressBuildLog(attachBuildLog > 1);
-        email.setContentType(contentType);
-    }
-    
-    protected EmailTrigger(JSONObject formData) {
-        
     }
 
     /**

--- a/src/main/java/hudson/plugins/emailext/plugins/trigger/FailureTrigger.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/trigger/FailureTrigger.java
@@ -17,23 +17,23 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class FailureTrigger extends EmailTrigger {
 
     public static final String TRIGGER_NAME = "Failure - Any";
-    
+
+    @DataBoundConstructor
+    public FailureTrigger(List<RecipientProvider> recipientProviders, String recipientList, String replyTo, String subject, String body,
+                          String attachmentsPattern, int attachBuildLog, String contentType) {
+        super(recipientProviders, recipientList, replyTo, subject, body, attachmentsPattern, attachBuildLog, contentType);
+    }
+
+    @Deprecated
+    public FailureTrigger(boolean sendToList, boolean sendToDevs, boolean sendToRequester, boolean sendToCulprits, String recipientList,
+                          String replyTo, String subject, String body, String attachmentsPattern, int attachBuildLog, String contentType) {
+        super(sendToList, sendToDevs, sendToRequester, sendToCulprits,recipientList, replyTo, subject, body, attachmentsPattern, attachBuildLog, contentType);
+    }
+
     @Deprecated
     public static FailureTrigger createDefault() {
         DescriptorImpl descriptor = (DescriptorImpl) Jenkins.getActiveInstance().getDescriptor(FailureTrigger.class);
         return (FailureTrigger) descriptor.createDefault();
-    }
-    
-    @DataBoundConstructor
-    public FailureTrigger(List<RecipientProvider> recipientProviders, String recipientList, String replyTo, String subject, String body, 
-            String attachmentsPattern, int attachBuildLog, String contentType) {
-        super(recipientProviders, recipientList, replyTo, subject, body, attachmentsPattern, attachBuildLog, contentType);
-    }
-    
-    @Deprecated
-    public FailureTrigger(boolean sendToList, boolean sendToDevs, boolean sendToRequester, boolean sendToCulprits, String recipientList, 
-            String replyTo, String subject, String body, String attachmentsPattern, int attachBuildLog, String contentType) {
-        super(sendToList, sendToDevs, sendToRequester, sendToCulprits,recipientList, replyTo, subject, body, attachmentsPattern, attachBuildLog, contentType);
     }
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat