### PR TITLE
squid:S2065, squid:S1488 - Fields in non-serializable classes should …

### DIFF
--- a/src/main/java/hudson/plugins/emailext/EmailRecipientUtils.java
+++ b/src/main/java/hudson/plugins/emailext/EmailRecipientUtils.java
@@ -188,7 +188,6 @@ public class EmailRecipientUtils {
     
     public static String getRecipientList(ExtendedEmailPublisherContext context, String recipients)
         throws MessagingException {
-        final String recipientsTransformed = StringUtils.isBlank(recipients) ? "" : ContentBuilder.transformText(recipients, context, context.getPublisher().getRuntimeMacros(context));
-        return recipientsTransformed;
+        return StringUtils.isBlank(recipients) ? "" : ContentBuilder.transformText(recipients, context, context.getPublisher().getRuntimeMacros(context));
     }
 }

--- a/src/main/java/hudson/plugins/emailext/EmailType.java
+++ b/src/main/java/hudson/plugins/emailext/EmailType.java
@@ -64,24 +64,24 @@ public class EmailType {
      * Specifies whether or not we should send this email to the developer/s who
      * made changes.
      */
-    private transient boolean sendToDevelopers;
+    private boolean sendToDevelopers;
 
     /**
      * Specifies whether or not we should send this email to the requester who
      * triggered build.
      */
-    private transient boolean sendToRequester;
+    private boolean sendToRequester;
 
     /**
      * Specifies whether or not we should send this email to all developers
      * since the last success.
      */
-    private transient boolean includeCulprits;
+    private boolean includeCulprits;
 
     /**
      * Specifies whether or not we should send this email to the recipient list
      */
-    private transient boolean sendToRecipientList;
+    private boolean sendToRecipientList;
 
     public EmailType() {
         subject = "";

--- a/src/main/java/hudson/plugins/emailext/plugins/EmailTrigger.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/EmailTrigger.java
@@ -137,8 +137,7 @@ public abstract class EmailTrigger implements Describable<EmailTrigger>, Extensi
     }
     
     protected EmailType createMailType(StaplerRequest req, JSONObject formData) {
-        EmailType m = (EmailType)req.bindJSON(EmailType.class, formData);
-        return m;
+        return (EmailType)req.bindJSON(EmailType.class, formData);
     }
 
     /**

--- a/src/main/java/hudson/plugins/emailext/plugins/content/JellyScriptContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/JellyScriptContent.java
@@ -46,8 +46,7 @@ public class JellyScriptContent extends AbstractEvalContent {
         } catch (JellyException e) {
             return "JellyException: " + e.getMessage();
         } catch (FileNotFoundException e) {
-            String missingTemplateError = generateMissingFile("Jelly", template);
-            return missingTemplateError;
+            return generateMissingFile("Jelly", template);
         } finally {
             IOUtils.closeQuietly(inputStream);
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2065, squid:S1125 - Fields in non-serializable classes should not be "transient", Local Variables should not be declared and then immediately returned or thrown

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2065
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1488

Please let me know if you have any questions.

M-Ezzat