### PR TITLE
squid:S1488, squid:CommentedOutCodeLine - Local Variables should not …

### DIFF
--- a/src/main/java/hudson/plugins/emailext/EmailRecipientUtils.java
+++ b/src/main/java/hudson/plugins/emailext/EmailRecipientUtils.java
@@ -188,7 +188,6 @@ public class EmailRecipientUtils {
     
     public static String getRecipientList(ExtendedEmailPublisherContext context, String recipients)
         throws MessagingException {
-        final String recipientsTransformed = StringUtils.isBlank(recipients) ? "" : ContentBuilder.transformText(recipients, context, context.getPublisher().getRuntimeMacros(context));
-        return recipientsTransformed;
+        return StringUtils.isBlank(recipients) ? "" : ContentBuilder.transformText(recipients, context, context.getPublisher().getRuntimeMacros(context));
     }
 }

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -416,7 +416,6 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
         }
         debugMode = req.hasParameter("ext_mailer_debug_mode");
 
-        //enableWatching = req.getParameter("ext_mailer_enable_watching") != null;
         // convert the value into megabytes (1024 * 1024 bytes)
         maxAttachmentSize = nullify(req.getParameter("ext_mailer_max_attachment_size")) != null
                 ? (Long.parseLong(req.getParameter("ext_mailer_max_attachment_size")) * 1024 * 1024) : -1;

--- a/src/main/java/hudson/plugins/emailext/plugins/EmailTrigger.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/EmailTrigger.java
@@ -137,8 +137,7 @@ public abstract class EmailTrigger implements Describable<EmailTrigger>, Extensi
     }
     
     protected EmailType createMailType(StaplerRequest req, JSONObject formData) {
-        EmailType m = (EmailType)req.bindJSON(EmailType.class, formData);
-        return m;
+        return (EmailType)req.bindJSON(EmailType.class, formData);
     }
 
     /**

--- a/src/main/java/hudson/plugins/emailext/plugins/content/JellyScriptContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/JellyScriptContent.java
@@ -46,8 +46,7 @@ public class JellyScriptContent extends AbstractEvalContent {
         } catch (JellyException e) {
             return "JellyException: " + e.getMessage();
         } catch (FileNotFoundException e) {
-            String missingTemplateError = generateMissingFile("Jelly", template);
-            return missingTemplateError;
+            return generateMissingFile("Jelly", template);
         } finally {
             IOUtils.closeQuietly(inputStream);
         }

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
@@ -788,8 +788,6 @@ public class ExtendedEmailPublisherTest {
 
         assertThat("Access was done to Jenkins instance with security enabled, so we should see an error", build.getLog(100),
                 not(hasItem("Pre-send script tried to access secured objects: Use of 'jenkins' is disallowed by security policy")));
-
-        //f.set(ExtendedEmailPublisher.DESCRIPTOR, false);
     }
 
     @Test
@@ -822,7 +820,6 @@ public class ExtendedEmailPublisherTest {
 
         assertThat("Access was done to Jenkins instance with security enabled, so we should see an error", build.getLog(100),
                 hasItem("Pre-send script tried to access secured objects: Use of 'Jenkins' and 'Hudson' are disallowed by security policy"));
-        //f.set(ExtendedEmailPublisher.DESCRIPTOR, false);
     }
 
     @Test


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1488, squid:CommentedOutCodeLine - Local Variables should not be declared and then immediately returned or thrown, Sections of code should not be "commented out"

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1488
https://dev.eclipse.org/sonar/coding_rules#q=squid:CommentedOutCodeLine

Please let me know if you have any questions.

M-Ezzat