### PR TITLE
squid:S1068 - Unused private fields should be removed

### DIFF
--- a/src/main/java/hudson/plugins/emailext/plugins/recipients/RequesterRecipientProvider.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/recipients/RequesterRecipientProvider.java
@@ -27,8 +27,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 
 public class RequesterRecipientProvider extends RecipientProvider {
-    private static final Logger LOGGER = Logger.getLogger(RequesterRecipientProvider.class.getName());
-
     @DataBoundConstructor
     public RequesterRecipientProvider() {
         

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/FailingTestSuspectsRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/FailingTestSuspectsRecipientProviderTest.java
@@ -48,8 +48,6 @@ import jenkins.model.Jenkins;
 })
 public class FailingTestSuspectsRecipientProviderTest {
 
-    private static final String AT_DOMAIN = "@DOMAIN";
-
     @Before
     public void before() throws Exception {
         final Jenkins jenkins = PowerMockito.mock(Jenkins.class);

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/FirstFailingBuildSuspectsRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/FirstFailingBuildSuspectsRecipientProviderTest.java
@@ -48,8 +48,6 @@ import jenkins.model.Jenkins;
 })
 public class FirstFailingBuildSuspectsRecipientProviderTest {
 
-    private static final String AT_DOMAIN = "@DOMAIN";
-
     @Before
     public void before() throws Exception {
         final Jenkins jenkins = PowerMockito.mock(Jenkins.class);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1068 - Unused private fields should be removed

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1068

Please let me know if you have any questions.

M-Ezzat