### PR TITLE
squid:S2325 - private methods that don't access instance data should …

### DIFF
--- a/src/main/java/hudson/plugins/emailext/EmailExtTemplateAction.java
+++ b/src/main/java/hudson/plugins/emailext/EmailExtTemplateAction.java
@@ -49,7 +49,7 @@ public class EmailExtTemplateAction implements Action {
         return "templateTest";
     }   
     
-    private String renderError(Exception ex) {
+    private static String renderError(Exception ex) {
         StringBuilder builder = new StringBuilder();
         builder.append("<h3>An error occured trying to render the template:</h3><br/>");
         builder.append("<span style=\"color:red; font-weight:bold\">");
@@ -78,7 +78,7 @@ public class EmailExtTemplateAction implements Action {
         return FormValidation.ok();
     }
     
-    private FormValidation checkForManagedFile(final String value) {
+    private static FormValidation checkForManagedFile(final String value) {
         Plugin plugin = Jenkins.getActiveInstance().getPlugin("config-file-provider");
         if(plugin != null) {
             Config config = null;

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -465,7 +465,7 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
         return super.configure(req, formData);
     }
 
-    private String nullify(String v) {
+    private static String nullify(String v) {
         if (v != null && v.length() == 0) {
             v = null;
         }

--- a/src/main/java/hudson/plugins/emailext/plugins/CssInliner.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/CssInliner.java
@@ -57,7 +57,7 @@ public class CssInliner {
      * @param doc the html document
      * @return a string representing the stylesheet.
      */
-    private String fetchStyles(Document doc) {
+    private static String fetchStyles(Document doc) {
         Elements els = doc.select(STYLE_TAG);
         StringBuilder styles = new StringBuilder();
         for (Element e : els) {
@@ -102,7 +102,7 @@ public class CssInliner {
      *
      * @param doc the html document
      */
-    private void inlineImages(Document doc) {
+    private static void inlineImages(Document doc) {
         Elements allImages = doc.getElementsByTag(IMG_TAG);
         for (Element img : allImages) {
             if (img.attr(DATA_INLINE_ATTR).equals("true")) {
@@ -131,7 +131,7 @@ public class CssInliner {
      *
      * @param doc the html document
      */
-    private void applyStyles(Document doc) {
+    private static void applyStyles(Document doc) {
         Elements allStyledElements = doc.getElementsByAttribute(CSS_STYLE);
 
         for (Element e : allStyledElements) {

--- a/src/main/java/hudson/plugins/emailext/plugins/content/EmailExtScript.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/EmailExtScript.java
@@ -18,7 +18,7 @@ import java.util.Map;
 
 public abstract class EmailExtScript extends Script {
 
-    private void populateArgs(Object args, Map<String, String> map, ListMultimap<String, String> multiMap) {
+    private static void populateArgs(Object args, Map<String, String> map, ListMultimap<String, String> multiMap) {
         if(args instanceof Object[]) {
             Object[] argArray = (Object[])args;
             if(argArray.length > 0) {

--- a/src/main/java/hudson/plugins/emailext/plugins/content/JellyScriptContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/JellyScriptContent.java
@@ -82,7 +82,7 @@ public class JellyScriptContent extends AbstractEvalContent {
         return output.toString(getCharset(build));
     }
 
-    private JellyContext createContext(Object it, AbstractBuild<?, ?> build, TaskListener listener) {
+    private static JellyContext createContext(Object it, AbstractBuild<?, ?> build, TaskListener listener) {
         JellyContext context = new JellyContext();
         ExtendedEmailPublisherDescriptor descriptor = Jenkins.getActiveInstance().getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
         context.setVariable("it", it);

--- a/src/main/java/hudson/plugins/emailext/plugins/content/ScriptContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/ScriptContent.java
@@ -175,7 +175,7 @@ public class ScriptContent extends AbstractEvalContent {
      * @throws FileNotFoundException
      * @throws IOException
      */
-    private GroovyShell createEngine(ExtendedEmailPublisherDescriptor descriptor, Map<String, Object> variables)
+    private static GroovyShell createEngine(ExtendedEmailPublisherDescriptor descriptor, Map<String, Object> variables)
             throws FileNotFoundException, IOException {
 
         ClassLoader cl = Jenkins.getActiveInstance().getPluginManager().uberClassLoader;

--- a/src/main/java/hudson/plugins/emailext/plugins/content/StaticAnalysisUtilities.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/StaticAnalysisUtilities.java
@@ -25,7 +25,7 @@ public class StaticAnalysisUtilities {
      * @return The static analysis actions for the specified build. The returned
      * list might be empty if there are no such actions.
      */
-    public List<Action> getActions(AbstractBuild<?, ?> build) {
+    public static List<Action> getActions(AbstractBuild<?, ?> build) {
         ArrayList<Action> actions = new ArrayList<Action>();
         for (Action action : build.getActions()) {
             if (AbstractResultAction.class.isInstance(action) || MavenResultAction.class.isInstance(action)) {

--- a/src/main/java/hudson/plugins/emailext/plugins/recipients/UpstreamComitterRecipientProvider.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/recipients/UpstreamComitterRecipientProvider.java
@@ -105,7 +105,7 @@ public class UpstreamComitterRecipientProvider extends RecipientProvider {
      * @param env The build environment
      * @param listener The listener for logging
      */
-    private void addUserFromChangeSet(ChangeLogSet.Entry change, Set<InternetAddress> to, Set<InternetAddress> cc, Set<InternetAddress> bcc, EnvVars env, TaskListener listener) {
+    private static void addUserFromChangeSet(ChangeLogSet.Entry change, Set<InternetAddress> to, Set<InternetAddress> cc, Set<InternetAddress> bcc, EnvVars env, TaskListener listener) {
         User user = change.getAuthor();
         String email = user.getProperty(Mailer.UserProperty.class).getAddress();
         if (email != null) {

--- a/src/main/java/hudson/plugins/emailext/plugins/trigger/AbstractScriptTrigger.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/trigger/AbstractScriptTrigger.java
@@ -67,7 +67,7 @@ public abstract class AbstractScriptTrigger extends EmailTrigger {
         return result;
     }
     
-    private GroovyShell createEngine(AbstractBuild<?, ?> build, TaskListener listener) {
+    private static GroovyShell createEngine(AbstractBuild<?, ?> build, TaskListener listener) {
         ClassLoader cl = Jenkins.getActiveInstance().getPluginManager().uberClassLoader;
         ScriptSandbox sandbox = null;
         CompilerConfiguration cc = new CompilerConfiguration();

--- a/src/main/java/hudson/plugins/emailext/plugins/trigger/FixedUnhealthyTrigger.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/trigger/FixedUnhealthyTrigger.java
@@ -47,7 +47,7 @@ public class FixedUnhealthyTrigger extends EmailTrigger {
     /**
      * Find most recent previous build matching certain criteria.
      */
-    private Run<?, ?> getPreviousRun(Run<?, ?> build, TaskListener listener) {
+    private static Run<?, ?> getPreviousRun(Run<?, ?> build, TaskListener listener) {
 
         Run<?, ?> prevBuild = ExtendedEmailPublisher.getPreviousRun(build, listener);
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar squid:S2325 - "private" methods that don't access instance data should be "static"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325

Please let me know if you have any questions.

M-Ezzat