### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expression…

### DIFF
--- a/src/main/java/hudson/plugins/emailext/AttachmentUtils.java
+++ b/src/main/java/hudson/plugins/emailext/AttachmentUtils.java
@@ -137,7 +137,7 @@ public class AttachmentUtils implements Serializable {
 
             for (FilePath file : files) {
                 if (maxAttachmentSize > 0
-                        && (totalAttachmentSize + file.length()) >= maxAttachmentSize) {
+                        && totalAttachmentSize + file.length() >= maxAttachmentSize) {
                     context.getListener().getLogger().println("Skipping `" + file.getName()
                             + "' (" + file.length()
                             + " bytes) - too large for maximum attachments size");

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -392,8 +392,8 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
                             break;
                         } catch (SendFailedException e) {
                             if (e.getNextException() != null
-                                    && ((e.getNextException() instanceof SocketException)
-                                    || (e.getNextException() instanceof ConnectException))) {
+                                    && (e.getNextException() instanceof SocketException
+                                    || e.getNextException() instanceof ConnectException)) {
                                 context.getListener().getLogger().println("Socket error sending email, retrying once more in 10 seconds...");
                                 transport.close();
                                 Thread.sleep(10000);
@@ -427,7 +427,7 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
                                 break;
                             }
                         } catch (MessagingException e) {
-                            if (e.getNextException() != null && (e.getNextException() instanceof ConnectException)) {
+                            if (e.getNextException() != null && e.getNextException() instanceof ConnectException) {
                                 context.getListener().getLogger().println("Connection error sending email, retrying once more in 10 seconds...");
                                 transport.close();
                                 Thread.sleep(10000);
@@ -525,7 +525,7 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
 
             try {
                 shell.evaluate(script);
-                cancel = ((Boolean) shell.getVariable("cancel"));
+                cancel = (Boolean) shell.getVariable("cancel");
                 debug(context.getListener().getLogger(), "%s script set cancel to %b", StringUtils.capitalize(scriptName), cancel);
             } catch (SecurityException e) {
                 context.getListener().getLogger().println(StringUtils.capitalize(scriptName) + " script tried to access secured objects: " + e.getMessage());
@@ -550,7 +550,7 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
     private void expandClasspath(ExtendedEmailPublisherContext context, CompilerConfiguration cc) {
         List<String> classpathList = new ArrayList<String>();
 
-        if ((classpath != null) && !classpath.isEmpty()) {
+        if (classpath != null && !classpath.isEmpty()) {
             for (GroovyScriptPath path : classpath) {
                 classpathList.add(ContentBuilder.transformText(path.getPath(), context, getRuntimeMacros(context)));
             }

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -417,7 +417,7 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
 
         // convert the value into megabytes (1024 * 1024 bytes)
         maxAttachmentSize = nullify(req.getParameter("ext_mailer_max_attachment_size")) != null
-                ? (Long.parseLong(req.getParameter("ext_mailer_max_attachment_size")) * 1024 * 1024) : -1;
+                ? Long.parseLong(req.getParameter("ext_mailer_max_attachment_size")) * 1024 * 1024 : -1;
         recipientList = nullify(req.getParameter("ext_mailer_default_recipients")) != null
                 ? req.getParameter("ext_mailer_default_recipients") : "";
 

--- a/src/main/java/hudson/plugins/emailext/plugins/trigger/AbortedTrigger.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/trigger/AbortedTrigger.java
@@ -30,7 +30,7 @@ public class AbortedTrigger extends EmailTrigger {
     
     @Override
     public boolean trigger(AbstractBuild<?, ?> build, TaskListener listener) {
-        return (build.getResult() == Result.ABORTED);
+        return build.getResult() == Result.ABORTED;
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/emailext/plugins/trigger/BuildingTrigger.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/trigger/BuildingTrigger.java
@@ -35,7 +35,7 @@ public class BuildingTrigger extends EmailTrigger {
 
         if (buildResult == Result.UNSTABLE) {
             Run<?, ?> prevRun = ExtendedEmailPublisher.getPreviousRun(build, listener);
-            if (prevRun != null && (prevRun.getResult() == Result.FAILURE)) {
+            if (prevRun != null && prevRun.getResult() == Result.FAILURE) {
                 return true;
             }
         }

--- a/src/main/java/hudson/plugins/emailext/plugins/trigger/FixedUnhealthyTrigger.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/trigger/FixedUnhealthyTrigger.java
@@ -52,7 +52,7 @@ public class FixedUnhealthyTrigger extends EmailTrigger {
         Run<?, ?> prevBuild = ExtendedEmailPublisher.getPreviousRun(build, listener);
 
         // Skip ABORTED builds
-        if (prevBuild != null && (prevBuild.getResult() == Result.ABORTED)) {
+        if (prevBuild != null && prevBuild.getResult() == Result.ABORTED) {
             return getPreviousRun(prevBuild, listener);
         }
 

--- a/src/main/java/hudson/plugins/emailext/plugins/trigger/NthFailureTrigger.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/trigger/NthFailureTrigger.java
@@ -49,7 +49,7 @@ public abstract class NthFailureTrigger extends EmailTrigger {
             run = ExtendedEmailPublisher.getPreviousRun(run, listener);
         }
 
-        return (run == null || run.getResult() == Result.SUCCESS || run.getResult() == Result.UNSTABLE);
+        return run == null || run.getResult() == Result.SUCCESS || run.getResult() == Result.UNSTABLE;
     }
 
     public abstract static class DescriptorImpl extends EmailTriggerDescriptor {

--- a/src/main/java/hudson/plugins/emailext/plugins/trigger/StatusChangedTrigger.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/trigger/StatusChangedTrigger.java
@@ -40,7 +40,7 @@ public class StatusChangedTrigger extends EmailTrigger {
                 return true;
             }
 
-            return (build.getResult() != prevRun.getResult());
+            return build.getResult() != prevRun.getResult();
         }
 
         return false;

--- a/src/main/java/hudson/plugins/emailext/plugins/trigger/StillFailingTrigger.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/trigger/StillFailingTrigger.java
@@ -34,7 +34,7 @@ public class StillFailingTrigger extends EmailTrigger {
 
         if (buildResult == Result.FAILURE) {
             Run<?, ?> prevRun = ExtendedEmailPublisher.getPreviousRun(build, listener);
-            if (prevRun != null && (prevRun.getResult() == Result.FAILURE)) {
+            if (prevRun != null && prevRun.getResult() == Result.FAILURE) {
                 return true;
             }
         }

--- a/src/main/java/hudson/plugins/emailext/plugins/trigger/StillUnstableTrigger.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/trigger/StillUnstableTrigger.java
@@ -36,7 +36,7 @@ public class StillUnstableTrigger extends EmailTrigger {
 
         if (buildResult == Result.UNSTABLE) {
             Run<?,?> prevRun = ExtendedEmailPublisher.getPreviousRun(build, listener);
-            if (prevRun != null && (prevRun.getResult() == Result.UNSTABLE)) {
+            if (prevRun != null && prevRun.getResult() == Result.UNSTABLE) {
                 return true;
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck

Please let me know if you have any questions.

M-Ezzat