### PR TITLE
Fix JENKINS-33205 (disappearing post-send script project setting)

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -206,8 +206,8 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
     }
 
     @DataBoundSetter
-    public void setPostsendScript(String project_postsend_script) {
-        this.postsendScript = project_postsend_script;
+    public void setPostsendScript(String postsendScript) {
+        this.postsendScript = postsendScript;
     }
     
     /**

--- a/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/config.groovy
+++ b/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/config.groovy
@@ -60,7 +60,7 @@ f.advanced(title: _("Advanced Settings")) {
     f.textarea(id: "project_presend_script", name: "project_presend_script", value: configured ? instance.presendScript : "\$DEFAULT_PRESEND_SCRIPT", class: "setting-input") 
   }
   f.entry(title: _("Post-send Script"), help: "/plugin/email-ext/help/projectConfig/postsendScript.html") {
-    f.textarea(id: "project_postsend_script", name: "project_postsend_script", value: configured ? instance.postsendScript : "\$DEFAULT_POSTSEND_SCRIPT", class: "setting-input")
+    f.textarea(id: "postsendScript", name: "postsendScript", value: configured ? instance.postsendScript : "\$DEFAULT_POSTSEND_SCRIPT", class: "setting-input")
   }
   f.entry(title: _("Additional groovy classpath"), help: "/plugin/help/projectConfig/defaultClasspath.html") {
     f.repeatable(field: "classpath") {

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
@@ -998,7 +998,7 @@ public class ExtendedEmailPublisherTest {
                 form.put("project_default_content", "Give me a $1000 check and I'll mail you back $5000!!!");
                 form.put("project_attachments", "");
                 form.put("project_presend_script", "");
-                form.put("project_postsend_script", "");
+                form.put("postsendScript", "println 1");
                 form.put("project_replyto", "");
 
                 ExtendedEmailPublisherDescriptor descriptor = new ExtendedEmailPublisherDescriptor();
@@ -1010,6 +1010,7 @@ public class ExtendedEmailPublisherTest {
                 assertEquals("Give me a $1000 check and I'll mail you back $5000!!!", publisher.defaultContent);
                 assertEquals("", publisher.attachmentsPattern);
                 assertEquals("", publisher.replyTo);
+                assertEquals("println 1", publisher.postsendScript);
 
                 return null;
             }


### PR DESCRIPTION
The post-send script setting disappears when saving job configuration.

This fixes up 51ab6c3 and adds a test.

References:
- https://issues.jenkins-ci.org/browse/JENKINS-33205
- Pull request #109