### PR TITLE
Cleanup - pmd:ConsecutiveLiteralAppends - Consecutive Literal Appends

### DIFF
--- a/src/main/java/hudson/plugins/emailext/EmailExtTemplateAction.java
+++ b/src/main/java/hudson/plugins/emailext/EmailExtTemplateAction.java
@@ -51,8 +51,7 @@ public class EmailExtTemplateAction implements Action {
     
     private String renderError(Exception ex) {
         StringBuilder builder = new StringBuilder();
-        builder.append("<h3>An error occured trying to render the template:</h3><br/>")
-                .append("<span style=\"color:red; font-weight:bold\">")
+        builder.append("<h3>An error occured trying to render the template:</h3><br/><span style=\"color:red; font-weight:bold\">")
                 .append(ex.toString().replace("\n", "<br/>")).append("</span>");
         return builder.toString();
     }

--- a/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
@@ -57,7 +57,7 @@ public class FailedTestsContent extends DataBoundTokenMacro {
         if (failCount == 0) {
             buffer.append("All tests passed");
         } else {
-            buffer.append(failCount).append(" tests failed.").append('\n');
+            buffer.append(failCount).append(" tests failed.\n");
 
             boolean showOldFailures = !onlyRegressions;
             if(maxLength < Integer.MAX_VALUE) {
@@ -111,11 +111,11 @@ public class FailedTestsContent extends DataBoundTokenMacro {
         local.append('.').append(failedTest.getDisplayName()).append('\n');
 
         if (showMessage) {
-            local.append('\n').append("Error Message:\n").append(failedTest.getErrorDetails()).append('\n');
+            local.append("\nError Message:\n").append(failedTest.getErrorDetails()).append('\n');
         }
         
         if (showStack) {
-            local.append('\n').append("Stack Trace:\n").append(failedTest.getErrorStackTrace()).append('\n');
+            local.append("\nStack Trace:\n").append(failedTest.getErrorStackTrace()).append('\n');
         }
 
         if (showMessage || showStack) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule pmd:ConsecutiveLiteralAppends - Consecutive Literal Appends

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=pmd:ConsecutiveLiteralAppends

Please let me know if you have any questions.

M-Ezzat