### PR TITLE
Cleanup - squid:S2147 - Catches should be combined

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -755,9 +755,7 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
                         String.format("%s-%s%d%s", context.getTrigger().getDescriptor().getDisplayName(), context.getRun().getId(), random.nextInt(), extension));
                 savedOutput.write(text, charset);
             }
-        } catch (IOException e) {
-            context.getListener().getLogger().println("Error trying to save email output to file. " + e.getMessage());
-        } catch (InterruptedException e) {
+        } catch (IOException | InterruptedException e) {
             context.getListener().getLogger().println("Error trying to save email output to file. " + e.getMessage());
         }
 

--- a/src/main/java/hudson/plugins/emailext/plugins/recipients/UpstreamComitterRecipientProvider.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/recipients/UpstreamComitterRecipientProvider.java
@@ -75,11 +75,7 @@ public class UpstreamComitterRecipientProvider extends RecipientProvider {
                 // check for getChangeSets which WorkflowRun has
                 Method m = build.getClass().getMethod("getChangeSets");
                 changeSets = (List<ChangeLogSet<? extends ChangeLogSet.Entry>>)m.invoke(build);
-            } catch (NoSuchMethodException e) {
-                listener.getLogger().print("Could not add upstream committers, build type does not provide change set");
-            } catch (InvocationTargetException e) {
-                listener.getLogger().print("Could not add upstream committers, build type does not provide change set");
-            } catch (IllegalAccessException e) {
+            } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
                 listener.getLogger().print("Could not add upstream committers, build type does not provide change set");
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2147 - Catches should be combined

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2147

Please let me know if you have any questions.

M-Ezzat