### PR TITLE
[FIXED JENKINS-38519] EMail-Ext Extended Pipeline Support - Failed Tests

### DIFF
--- a/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
@@ -1,7 +1,9 @@
 package hudson.plugins.emailext.plugins.content;
 
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.junit.CaseResult;
 import hudson.tasks.test.AbstractTestResultAction;
@@ -44,9 +46,15 @@ public class FailedTestsContent extends DataBoundTokenMacro {
     @Override
     public String evaluate(AbstractBuild<?, ?> build, TaskListener listener, String macroName)
             throws MacroEvaluationException, IOException, InterruptedException {
+        return evaluate(build, build.getWorkspace(), listener, macroName);
+    }
+
+    @Override
+    public String evaluate(Run<?, ?> run, FilePath workspace, TaskListener listener, String macroName)
+            throws MacroEvaluationException, IOException, InterruptedException {
 
         StringBuilder buffer = new StringBuilder();
-        AbstractTestResultAction<?> testResult = build.getAction(AbstractTestResultAction.class);
+        AbstractTestResultAction<?> testResult = run.getAction(AbstractTestResultAction.class);
 
         if (null == testResult) {
             return "No tests ran.";
@@ -90,8 +98,8 @@ public class FailedTestsContent extends DataBoundTokenMacro {
     private int getTestAge(TestResult result) {
         if(result.isPassed())
             return 0;
-        else if (result.getOwner() != null) {
-            return result.getOwner().getNumber()-result.getFailedSince()+1;
+        else if (result.getRun() != null) {
+            return result.getRun().getNumber()-result.getFailedSince()+1;
         } else {
             return 0;
         }

--- a/src/main/java/hudson/plugins/emailext/plugins/content/TestCountsContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/TestCountsContent.java
@@ -1,7 +1,9 @@
 package hudson.plugins.emailext.plugins.content;
 
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.test.AbstractTestResultAction;
 import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;
@@ -31,8 +33,14 @@ public class TestCountsContent extends DataBoundTokenMacro {
     @Override
     public String evaluate(AbstractBuild<?, ?> build, TaskListener listener, String macroName)
             throws MacroEvaluationException, IOException, InterruptedException {
+        return evaluate(build, build.getWorkspace(), listener, macroName);
+    }
 
-        AbstractTestResultAction<?> action = build.getAction(AbstractTestResultAction.class);
+    @Override
+    public String evaluate(Run<?, ?> run, FilePath workspace, TaskListener listener, String macroName)
+            throws MacroEvaluationException, IOException, InterruptedException {
+
+        AbstractTestResultAction<?> action = run.getAction(AbstractTestResultAction.class);
         if (action == null) {
             return "";
         }

--- a/src/main/java/hudson/plugins/emailext/plugins/content/TriggerNameContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/TriggerNameContent.java
@@ -1,7 +1,9 @@
 package hudson.plugins.emailext.plugins.content;
 
 import com.google.common.collect.ListMultimap;
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
@@ -24,6 +26,10 @@ public class TriggerNameContent extends TokenMacro {
 
     @Override
     public String evaluate(AbstractBuild<?, ?> ab, TaskListener tl, String string, Map<String, String> map, ListMultimap<String, String> lm) throws MacroEvaluationException, IOException, InterruptedException {
+        return name;
+    }
+
+    public String evaluate(Run<?, ?> run, FilePath workspace, TaskListener listener, String macroName, Map<String, String> arguments, ListMultimap<String, String> argumentMultimap) throws MacroEvaluationException, IOException, InterruptedException {
         return name;
     }
 }

--- a/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
@@ -50,6 +50,17 @@ public class FailedTestsContentTest
         assertEquals( "No tests ran.", content );
     }
 
+    /**
+     * Verifies that token expansion works for pipeline builds (JENKINS-38519).
+     */
+    @Test
+    public void testGetContent_withWorkspaceAndNoTestsRanShouldGiveAMeaningfulMessage()
+            throws Exception {
+        String content = failedTestContent.evaluate( build, build.getWorkspace(), listener, FailedTestsContent.MACRO_NAME );
+
+        assertEquals( "No tests ran.", content );
+    }
+
     @Test
     public void testGetContent_whenAllTestsPassedShouldGiveMeaningfulMessage()
             throws Exception {

--- a/src/test/java/hudson/plugins/emailext/plugins/content/TestCountsContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/TestCountsContentTest.java
@@ -41,6 +41,16 @@ public class TestCountsContentTest {
         assertEquals("", target.evaluate(build, listener, TestCountsContent.MACRO_NAME));
     }
 
+    /**
+     * Verifies that token expansion works for pipeline builds (JENKINS-38519).
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetContent_withWorkspaceAndNoTestResults() throws Exception {
+        target.var = "total";
+        assertEquals("", target.evaluate(build, build.getWorkspace(), listener, TestCountsContent.MACRO_NAME));
+    }
+
     @Test
     @SuppressWarnings("unchecked")
     public void testGetContent() throws Exception {


### PR DESCRIPTION
Added pipeline support for FAILED_TESTS, TEST_COUNTS, and TRIGGER_NAME.