### PR TITLE
[JENKINS-39147] Add API to programmatically configure global settings for email-ext plugin

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -106,11 +106,11 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
     private String defaultPostsendScript = "";
 
     private List<GroovyScriptPath> defaultClasspath = new ArrayList<>();
-    
+
     private transient List<EmailTriggerDescriptor> defaultTriggers = new ArrayList<>();
-    
+
     private List<String> defaultTriggerIds = new ArrayList<>();
-    
+
     /**
      * This is the global emergency email address
      */
@@ -182,7 +182,7 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
     public String getDefaultSuffix() {
         return defaultSuffix;
     }
-    
+
     public void setDefaultSuffix(String defaultSuffix) {
         this.defaultSuffix = defaultSuffix;
     }
@@ -253,16 +253,43 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
         return smtpAuthUsername;
     }
 
+    @SuppressWarnings("unused")
+    public void setSmtpAuthUsername(String username) {
+        this.smtpAuthUsername = username;
+    }
+
     public String getSmtpAuthPassword() {
         return Secret.toString(smtpAuthPassword);
+    }
+
+    @SuppressWarnings("unused")
+    public void setSmtpAuthPassword(String password) {
+        this.smtpAuthPassword = Secret.fromString(password);
+    }
+
+    // Make API match Mailer plugin
+    @SuppressWarnings("unused")
+    public void setSmtpAuth(String userName, String password) {
+        setSmtpAuthUsername(userName);
+        setSmtpAuthPassword(password);
     }
 
     public boolean getUseSsl() {
         return useSsl;
     }
 
+    @SuppressWarnings("unused")
+    public void setUseSsl(boolean useSsl) {
+        this.useSsl = useSsl;
+    }
+
     public String getSmtpPort() {
         return smtpPort;
+    }
+
+    @SuppressWarnings("unused")
+    public void setSmtpPort(String port) {
+        this.smtpPort = nullify(port);
     }
 
     public String getCharset() {
@@ -273,16 +300,48 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
         return c;
     }
 
+    @SuppressWarnings("unused")
+    public void setCharset(String charset) {
+        this.charset = charset;
+    }
+
     public String getDefaultContentType() {
         return defaultContentType;
+    }
+
+    @SuppressWarnings("unused")
+    public void setDefaultContentType(String contentType) {
+        if (StringUtils.isBlank(contentType)) {
+            this.defaultContentType = "text/plain";
+        } else {
+            this.defaultContentType = contentType;
+        }
     }
 
     public String getDefaultSubject() {
         return defaultSubject;
     }
 
+    @SuppressWarnings("unused")
+    public void setDefaultSubject(String subject) {
+        if (subject == null) {
+            this.defaultSubject = ExtendedEmailPublisher.DEFAULT_SUBJECT_TEXT;
+        } else {
+            this.defaultSubject = subject;
+        }
+    }
+
     public String getDefaultBody() {
         return defaultBody;
+    }
+
+    @SuppressWarnings("unused")
+    public void setDefaultBody(String body) {
+        if (body == null) {
+            this.defaultBody = ExtendedEmailPublisher.DEFAULT_BODY_TEXT;
+        } else {
+            this.defaultBody = body;
+        }
     }
 
     public String getEmergencyReroute() {
@@ -290,39 +349,80 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
     }
 
     protected void setEmergencyReroute(String emergencyReroute) {
-        this.emergencyReroute = emergencyReroute;
+        if (emergencyReroute == null) {
+            this.emergencyReroute = ExtendedEmailPublisher.DEFAULT_EMERGENCY_REROUTE_TEXT;
+        } else {
+            this.emergencyReroute = emergencyReroute;
+        }
     }
 
     public long getMaxAttachmentSize() {
         return maxAttachmentSize;
     }
 
+    public void setMaxAttachmentSize(long bytes) {
+        if (bytes < 0) {
+            bytes = -1; // set to default "empty" value
+        }
+        this.maxAttachmentSize = bytes;
+    }
+
     public long getMaxAttachmentSizeMb() {
         return maxAttachmentSize / (1024 * 1024);
+    }
+
+    @SuppressWarnings("unused")
+    public void setMaxAttachmentSizeMb(long mb) {
+        setMaxAttachmentSize(mb * (1024 * 1024));
     }
 
     public String getDefaultRecipients() {
         return recipientList;
     }
 
+    @SuppressWarnings("unused")
+    public void setDefaultRecipients(String recipients) {
+        this.recipientList = ((recipients == null) ? "" : recipients);
+    }
+
     public String getExcludedCommitters() {
         return excludedCommitters;
+    }
+
+    @SuppressWarnings("unused")
+    public void setExcludedCommitters(String excluded) {
+        this.excludedCommitters = ((excluded == null) ? "" : excluded);
     }
 
     public boolean getOverrideGlobalSettings() {
         return overrideGlobalSettings;
     }
-    
+
     public String getListId() {
         return listId;
+    }
+
+    @SuppressWarnings("unused")
+    public void setListId(String id) {
+        this.listId = nullify(id);
     }
 
     public boolean getPrecedenceBulk() {
         return precedenceBulk;
     }
 
+    @SuppressWarnings("unused")
+    public void setPrecedenceBulk(boolean bulk) {
+        this.precedenceBulk = bulk;
+    }
+
     public String getDefaultReplyTo() {
         return defaultReplyTo;
+    }
+
+    @SuppressWarnings("unused")
+    public void setDefaultReplyTo(String to) {
+        this.defaultReplyTo = ((to == null) ? "" : to);
     }
 
     public boolean isSecurityEnabled() {
@@ -333,8 +433,18 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
         return requireAdminForTemplateTesting;
     }
 
+    @SuppressWarnings("unused")
+    public void setAdminRequiredForTemplateTesting(boolean requireAdmin) {
+        this.requireAdminForTemplateTesting = requireAdmin;
+    }
+
     public boolean isWatchingEnabled() {
         return enableWatching;
+    }
+
+    @SuppressWarnings("unused")
+    public void setWatchingEnabled(boolean enabled) {
+        this.enableWatching = enabled;
     }
 
     public boolean isApplicable(Class<? extends AbstractProject> jobType) {
@@ -345,14 +455,24 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
         return defaultPresendScript;
     }
 
+    @SuppressWarnings("unused")
+    public void setDefaultPresendScript(String script) {
+        this.defaultPresendScript = ((script == null) ? "" : script);
+    }
+
     public String getDefaultPostsendScript() {
         return defaultPostsendScript;
+    }
+
+    @SuppressWarnings("unused")
+    public void setDefaultPostsendScript(String script) {
+        this.defaultPostsendScript = ((script == null) ? "" : script);
     }
 
     public List<GroovyScriptPath> getDefaultClasspath() {
         return defaultClasspath;
     }
-    
+
     public List<String> getDefaultTriggerIds() {
         if (defaultTriggerIds.isEmpty()) {
             if (!defaultTriggers.isEmpty()) {
@@ -446,7 +566,7 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
         } else if(StringUtils.isNotEmpty(formData.optString("defaultTriggers"))) {
             ids.add(formData.getString("defaultTriggers"));
         }
-        
+
         if(!ids.isEmpty()) {
             defaultTriggerIds.clear();
             for(String id : ids) {
@@ -456,7 +576,7 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
                }
             }
         }
-        
+
         if(!overrideGlobalSettings) {
             upgradeFromMailer();
         }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-39147

This adds setter methods to match the getters for the plugin configuration: 
- smtp auth username
- smtp auth password
- use ssl
- charset
- default content type
- default subject
- default body
- max attachment size (in bytes or Mb)
- default recipients
- excluded committers
- list id
- precedence bulk
- default reply-to
- watching
- admin
- default present script
- default post send script

There were already setters for smtp server/host, emergency reroute, default suffix, debug mode.