### PR TITLE
Stop skipping tests during release:prepare

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,12 +292,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <arguments>-DskipTests=true</arguments>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Reverts b601cc995f734238d1aac0b8076531039d95cf9a: the parent POM already skips tests during `release:perform`, so this is turning off the valuable safety feature of ensuring that `release:prepare` will not run with outstanding test failures.

@reviewbybees