### PR TITLE
Add global checkbox to allow sending emails to unregistered users

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -168,6 +168,11 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
      * Enables the "Watch This Job" feature
      */
     private boolean enableWatching;
+    
+    /**
+     * Enables the "Allow Unregistered Emails" feature
+     */
+    private boolean enableAllowUnregistered;
 
     public ExtendedEmailPublisherDescriptor() {
         super(ExtendedEmailPublisher.class);
@@ -481,9 +486,18 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
         return enableWatching;
     }
 
+    public boolean isAllowUnregisteredEnabled() {
+        return enableAllowUnregistered;
+    }
+    
     @SuppressWarnings("unused")
     public void setWatchingEnabled(boolean enabled) {
         this.enableWatching = enabled;
+    }
+    
+    @SuppressWarnings("unused")
+    public void setAllowUnregisteredEnabled(boolean enabled) {
+        this.enableAllowUnregistered = enabled;
     }
 
     public boolean isApplicable(Class<? extends AbstractProject> jobType) {
@@ -617,6 +631,8 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
         requireAdminForTemplateTesting = req.hasParameter("ext_mailer_require_admin_for_template_testing");
 
         enableWatching = req.hasParameter("ext_mailer_watching_enabled");
+        
+        enableAllowUnregistered = req.hasParameter("ext_mailer_allow_unregistered_enabled");
 
         // specify List-ID information
         if (req.hasParameter("ext_mailer_use_list_id")) {

--- a/src/main/java/hudson/plugins/emailext/plugins/recipients/RecipientProviderUtilities.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/recipients/RecipientProviderUtilities.java
@@ -28,11 +28,13 @@ import com.google.common.collect.Iterables;
 import hudson.EnvVars;
 import hudson.model.AbstractBuild;
 import hudson.model.Cause;
+import hudson.model.Descriptor;
 import hudson.model.Item;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.User;
 import hudson.plugins.emailext.EmailRecipientUtils;
+import hudson.plugins.emailext.ExtendedEmailPublisher;
 import hudson.plugins.emailext.ExtendedEmailPublisherContext;
 import hudson.scm.ChangeLogSet;
 import hudson.tasks.MailSender;
@@ -199,7 +201,8 @@ public final class RecipientProviderUtilities {
                                 }
                             }
                         } catch (UsernameNotFoundException x) {
-                            if (SEND_TO_UNKNOWN_USERS) {
+                            
+                            if (SEND_TO_UNKNOWN_USERS || ExtendedEmailPublisher.descriptor().isAllowUnregisteredEnabled() ) {
                                 listener.getLogger().printf("Warning: %s is not a recognized user, but sending mail anyway%n", userAddress);
                             } else {
                                 listener.getLogger().printf("Not sending mail to unregistered user %s because your SCM"

--- a/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/global.groovy
+++ b/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/global.groovy
@@ -86,7 +86,8 @@ f.section(title: _("Extended E-mail Notification")) {
   f.optionalBlock(help: "/plugin/email-ext/help/globalConfig/debugMode.html", checked: descriptor.isDebugMode(), name: "ext_mailer_debug_mode", title: _("Enable Debug Mode")) 
   f.optionalBlock(help: "/plugin/email-ext/help/globalConfig/requireAdmin.html", checked: descriptor.isAdminRequiredForTemplateTesting(), name: "ext_mailer_require_admin_for_template_testing", title: _("Require Administrator for Template Testing"))
   f.optionalBlock(help: "/plugin/email-ext/help/globalConfig/watching.html", checked: descriptor.isWatchingEnabled(), name: "ext_mailer_watching_enabled", title: _("Enable watching for jobs"))
-
+  f.optionalBlock(help: "/plugin/email-ext/help/globalConfig/allowUnregistered.html", checked: descriptor.isAllowUnregisteredEnabled(), name: "ext_mailer_allow_unregistered_enabled", title: _("Allow sending to unregistered users"))
+  
   f.advanced(title: _("Default Triggers")) {
     f.entry(title: _("Default Triggers"), help: "/plugin/email-ext/help/globalConfig/defaultTriggers.html") {
       hudson.plugins.emailext.plugins.EmailTrigger.all().each { t ->

--- a/src/main/webapp/help/globalConfig/allowUnregistered.html
+++ b/src/main/webapp/help/globalConfig/allowUnregistered.html
@@ -1,0 +1,5 @@
+<div>
+	Check this to allow emails to be sent to unregistered email addresses. 
+        Security risk, see https://issues.jenkins-ci.org/browse/JENKINS-9016 for
+        more information
+</div>


### PR DESCRIPTION
A workaround for JENKINS-43268 adding global checkbox to allow sending to unregistered emails. This is a workaround to a SCM plugin issue, like JENKINS-9016 and probably others. 

In my case, I have a ldap backed gitlab instance, and jenkins instance, where username = firstLast(and sometimes firstInitialLast) but email is first.last@company.com The git plugin appears to not like this.