### PR TITLE
Update Parent POM to 3.2 and core requirement to 2.7.3 LTS.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.27</version>
+        <version>3.2</version>
         <relativePath />
     </parent>
 
@@ -33,7 +33,7 @@
         <workflow-step-api.version>2.9</workflow-step-api.version>
         <workflow-aggregator.version>2.5</workflow-aggregator.version>
         <workflow-job.version>2.11</workflow-job.version>
-        <jenkins.version>2.0</jenkins.version>
+        <jenkins.version>2.7.3</jenkins.version>
         <workflow-api.version>2.11</workflow-api.version>
         <workflow-cps.version>2.29</workflow-cps.version>
         <workflow-durable-task-step.version>2.11</workflow-durable-task-step.version>
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>mail</artifactId>
-            <version>1.4</version>
+            <version>1.4.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -273,13 +273,6 @@
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
             <version>3.20.0-GA</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-war</artifactId>
-            <type>war</type>
-            <version>${jenkins-war.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
I was trying to run [Plugin Compat Tester](https://github.com/jenkinsci/plugin-compat-tester) for this plugin in order to verify it's compatibility with [JEP-200](https://github.com/jenkinsci/jep/tree/master/jep/200) changes. 

The build failed on my machine due to some failing deps, and I decided to clean it up a bit. The main change is a removal of the explicit `jenkins-war` dependency which was somehow causing HtmlUnit failures.

I also bumped the plugin to the 2.7.3 just to have the default tests running against LTS

@reviewbybees @abayer @davidvanlaatum 
