### PR TITLE
Adding space of description

### DIFF
--- a/src/main/resources/hudson/plugins/emailext/EmailExtTemplateAction/index.properties
+++ b/src/main/resources/hudson/plugins/emailext/EmailExtTemplateAction/index.properties
@@ -1,2 +1,2 @@
 description=Enter the template file name and select a build to test with then\
-  press the "Go!" button to render the template based on the selected build.
+   press the "Go!" button to render the template based on the selected build.


### PR DESCRIPTION
The previous description would render the text "thenpress".
An additional space fix the wrong text.

![image](https://user-images.githubusercontent.com/1585655/48936730-1376d100-ef0c-11e8-8608-637f63fdf918.png)
