### PR TITLE
Fix build configuration for Java 11 validation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,9 @@
-buildPlugin(failFast: false, jdkVersions: [8, 11])
+buildPlugin(
+    failFast: false,
+    configurations: [
+        [ platform: 'linux', jdk: "8", jenkins: null ],
+        [ platform: 'windows', jdk: "8", jenkins: null ],
+        [ platform: 'linux', jdk: "11", jenkins: "2.163", javaLevel: "8" ],
+        [ platform: 'windows', jdk: "11", jenkins: "2.163", javaLevel: "8" ],
+    ]
+)


### PR DESCRIPTION
Currently, the build of Master is failing because of the Java 11 branches configuration.

This is a follow-up from jenkinsci/email-ext-plugin#175 were I introduce the build
on Java 11 but misconfigured it. Sorry for that.

@jenkinsci/java11-support 