### PR TITLE
Java 11 readiness

### DIFF
--- a/src/test/java/hudson/plugins/emailext/plugins/RecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/RecipientProviderTest.java
@@ -10,6 +10,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.text.MessageFormat;
@@ -21,6 +22,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.xml.*", "org.apache.xerces.*", "org.xml.sax.*"}) // workaround inspired by https://github.com/powermock/powermock/issues/864#issuecomment-410182836
 public class RecipientProviderTest {
 
     @Rule

--- a/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -26,6 +27,7 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings({"unchecked"})
 @RunWith(PowerMockRunner.class)
 @PrepareForTest( { TestResult.class })
+@PowerMockIgnore({"javax.xml.*"}) // workaround inspired by https://github.com/powermock/powermock/issues/864#issuecomment-410182836
 public class FailedTestsContentTest
 {
     private FailedTestsContent failedTestContent;

--- a/src/test/java/hudson/plugins/emailext/plugins/content/ScriptContentBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/ScriptContentBuildWrapperTest.java
@@ -11,6 +11,7 @@ import hudson.tasks.test.AggregatedTestResultAction.ChildReport;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -27,6 +28,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith( PowerMockRunner.class )
 @PrepareForTest( value = { AggregatedTestResultAction.class, AggregatedTestResultAction.ChildReport.class } )
+@PowerMockIgnore({"javax.xml.*"}) // workaround inspired by https://github.com/powermock/powermock/issues/864#issuecomment-410182836
 public class ScriptContentBuildWrapperTest
 {
     private ScriptContentBuildWrapper buildWrapper;

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/CulpritsRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/CulpritsRecipientProviderTest.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -28,6 +29,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
         WorkflowJob.class,
         Job.class
 })
+@PowerMockIgnore({"javax.xml.*"}) // workaround inspired by https://github.com/powermock/powermock/issues/864#issuecomment-410182836
 public class CulpritsRecipientProviderTest {
 
     @Before

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/DevelopersRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/DevelopersRecipientProviderTest.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -28,6 +29,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
         WorkflowJob.class,
         FreeStyleProject.class
 })
+@PowerMockIgnore({"javax.xml.*"}) // workaround inspired by https://github.com/powermock/powermock/issues/864#issuecomment-410182836
 public class DevelopersRecipientProviderTest {
 
     @Before

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/FailingTestSuspectsRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/FailingTestSuspectsRecipientProviderTest.java
@@ -36,6 +36,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
@@ -51,6 +52,7 @@ import org.powermock.reflect.Whitebox;
     FreeStyleProject.class,
     PluginManager.class
 })
+@PowerMockIgnore({"javax.xml.*"}) // workaround inspired by https://github.com/powermock/powermock/issues/864#issuecomment-410182836
 public class FailingTestSuspectsRecipientProviderTest {
 
     @Before

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/FirstFailingBuildSuspectsRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/FirstFailingBuildSuspectsRecipientProviderTest.java
@@ -35,6 +35,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
@@ -50,6 +51,7 @@ import org.powermock.reflect.Whitebox;
     FreeStyleProject.class,
     PluginManager.class
 })
+@PowerMockIgnore({"javax.xml.*"}) // workaround inspired by https://github.com/powermock/powermock/issues/864#issuecomment-410182836
 public class FirstFailingBuildSuspectsRecipientProviderTest {
 
     @Before

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/RecipientProviderUtilitiesTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/RecipientProviderUtilitiesTest.java
@@ -9,6 +9,7 @@ import org.hamcrest.collection.IsCollectionWithSize;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -26,6 +27,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @PrepareForTest({
         WorkflowRun.class
 })
+@PowerMockIgnore({"javax.xml.*"}) // workaround inspired by https://github.com/powermock/powermock/issues/864#issuecomment-410182836
 public class RecipientProviderUtilitiesTest {
     public class Debug implements RecipientProviderUtilities.IDebug {
 


### PR DESCRIPTION
This PR is, hopefully, the final attempt to make the plugin build fully on Java 11.

@slide cc @jenkinsci/java11-support 

Once this succeeds, we'll want a final PR from this `java11-readiness` branch to `master`.