### PR TITLE
Bumping jsoup to get over the XSS present in <=1.8.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.8.3</version>
+            <version>1.9.1</version>
         </dependency>
         <dependency>
             <groupId>net.htmlparser.jericho</groupId>


### PR DESCRIPTION
Hi,

Trying to just bump the jsoup dependency over the line, so that the XSS detailed at https://www.cvedetails.com/cve/CVE-2015-6748/ is fixed.

I didn't particularly test anything, only reviewed the released notes.

Thank you.