### PR TITLE
Added escapeHtml flag to FAILED_TESTS

### DIFF
--- a/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
@@ -13,9 +13,11 @@ import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 
 import java.io.IOException;
 
+import static org.apache.commons.lang.StringEscapeUtils.escapeHtml;
+
 /**
  * An EmailContent for failing tests. Only shows tests that have failed.
- * 
+ *
  * @author markltbaker
  */
 @Extension
@@ -35,6 +37,9 @@ public class FailedTestsContent extends DataBoundTokenMacro {
 
     @Parameter
     public int maxLength = Integer.MAX_VALUE;
+
+    @Parameter
+    public boolean escapeHtml = false;
 
     public static final String MACRO_NAME = "FAILED_TESTS";
 
@@ -108,9 +113,9 @@ public class FailedTestsContent extends DataBoundTokenMacro {
     private int outputTest(StringBuilder buffer, TestResult failedTest,
             boolean showStack, boolean showMessage, int lengthLeft) {
         StringBuilder local = new StringBuilder();
-        
+
         local.append(failedTest.isPassed() ? "PASSED" : "FAILED").append(":  ");
-        
+
         if(failedTest instanceof CaseResult) {
             local.append(((CaseResult)failedTest).getClassName());
         } else {
@@ -119,11 +124,13 @@ public class FailedTestsContent extends DataBoundTokenMacro {
         local.append('.').append(failedTest.getDisplayName()).append('\n');
 
         if (showMessage) {
-            local.append("\nError Message:\n").append(failedTest.getErrorDetails()).append('\n');
+            String errorDetails = escapeHtml ? escapeHtml(failedTest.getErrorDetails()) : failedTest.getErrorDetails();
+            local.append("\nError Message:\n").append(errorDetails).append('\n');
         }
-        
+
         if (showStack) {
-            local.append("\nStack Trace:\n").append(failedTest.getErrorStackTrace()).append('\n');
+            String stackTrace = escapeHtml ? escapeHtml(failedTest.getErrorStackTrace()) : failedTest.getErrorStackTrace();
+            local.append("\nStack Trace:\n").append(stackTrace).append('\n');
         }
 
         if (showMessage || showStack) {

--- a/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
@@ -9,9 +9,6 @@ import hudson.tasks.junit.CaseResult;
 import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TestResult;
 import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;
-import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
-
-import java.io.IOException;
 
 import static org.apache.commons.lang.StringEscapeUtils.escapeHtml;
 
@@ -49,15 +46,12 @@ public class FailedTestsContent extends DataBoundTokenMacro {
     }
 
     @Override
-    public String evaluate(AbstractBuild<?, ?> build, TaskListener listener, String macroName)
-            throws MacroEvaluationException, IOException, InterruptedException {
+    public String evaluate(AbstractBuild<?, ?> build, TaskListener listener, String macroName) {
         return evaluate(build, build.getWorkspace(), listener, macroName);
     }
 
     @Override
-    public String evaluate(Run<?, ?> run, FilePath workspace, TaskListener listener, String macroName)
-            throws MacroEvaluationException, IOException, InterruptedException {
-
+    public String evaluate(Run<?, ?> run, FilePath workspace, TaskListener listener, String macroName) {
         StringBuilder buffer = new StringBuilder();
         AbstractTestResultAction<?> testResult = run.getAction(AbstractTestResultAction.class);
 
@@ -70,7 +64,8 @@ public class FailedTestsContent extends DataBoundTokenMacro {
         if (failCount == 0) {
             buffer.append("All tests passed");
         } else {
-            buffer.append(failCount).append(" tests failed.\n");
+            String lineBreak = getLineBreak();
+            buffer.append(failCount).append(" tests failed.").append(lineBreak);
 
             boolean showOldFailures = !onlyRegressions;
             if(maxLength < Integer.MAX_VALUE) {
@@ -89,10 +84,11 @@ public class FailedTestsContent extends DataBoundTokenMacro {
                     }
                 }
                 if (failCount > printedTests) {
-                    buffer.append("... and ").append(failCount - printedTests).append(" other failed tests.\n\n");
+                    buffer.append("... and ").append(failCount - printedTests).append(" other failed tests.")
+                        .append(lineBreak);
                 }
                 if (printedLength >= maxLength) {
-                    buffer.append("\n\n... output truncated.\n\n");
+                    buffer.append(lineBreak).append("... output truncated.").append(lineBreak);
                 }
             }
         }
@@ -113,6 +109,7 @@ public class FailedTestsContent extends DataBoundTokenMacro {
     private int outputTest(StringBuilder buffer, TestResult failedTest,
             boolean showStack, boolean showMessage, int lengthLeft) {
         StringBuilder local = new StringBuilder();
+        String lineBreak = getLineBreak();
 
         local.append(failedTest.isPassed() ? "PASSED" : "FAILED").append(":  ");
 
@@ -121,20 +118,20 @@ public class FailedTestsContent extends DataBoundTokenMacro {
         } else {
             local.append(failedTest.getFullName());
         }
-        local.append('.').append(failedTest.getDisplayName()).append('\n');
+        local.append('.').append(failedTest.getDisplayName()).append(lineBreak);
 
         if (showMessage) {
             String errorDetails = escapeHtml ? escapeHtml(failedTest.getErrorDetails()) : failedTest.getErrorDetails();
-            local.append("\nError Message:\n").append(errorDetails).append('\n');
+            local.append(lineBreak).append("Error Message:").append(lineBreak).append(errorDetails).append(lineBreak);
         }
 
         if (showStack) {
             String stackTrace = escapeHtml ? escapeHtml(failedTest.getErrorStackTrace()) : failedTest.getErrorStackTrace();
-            local.append("\nStack Trace:\n").append(stackTrace).append('\n');
+            local.append(lineBreak).append("Stack Trace:").append(lineBreak).append(stackTrace).append(lineBreak);
         }
 
         if (showMessage || showStack) {
-            local.append('\n');
+            local.append(lineBreak);
         }
 
         if(local.length() > lengthLeft) {
@@ -143,5 +140,9 @@ public class FailedTestsContent extends DataBoundTokenMacro {
 
         buffer.append(local.toString());
         return local.length();
+    }
+
+    private String getLineBreak() {
+        return escapeHtml ? "<br/>" : "\n";
     }
 }

--- a/src/main/resources/hudson/plugins/emailext/plugins/content/FailedTestsContent/help.groovy
+++ b/src/main/resources/hudson/plugins/emailext/plugins/content/FailedTestsContent/help.groovy
@@ -13,5 +13,8 @@ dd() {
 
     dt("onlyRegressions")
     dd("Display only the failing tests that are different from previous builds. Defaults to false.")
+
+    dt("escapeHtml")
+    dd("If set to true escapes characters in errors details and stack traces using HTML entities. Defaults to false.")
   }
 }

--- a/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
@@ -18,10 +18,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Collections.singletonList;
-import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -249,9 +247,9 @@ public class FailedTestsContentTest
     }
 
     @Test
-    public void testGetContent_withMessage_withStack_htmlEscaped() throws Exception {
+    public void testGetContent_withMessage_withStack_htmlEscaped() {
         AbstractTestResultAction<?> testResults = mock( AbstractTestResultAction.class );
-        when( testResults.getFailCount() ).thenReturn( 2 );
+        when( testResults.getFailCount() ).thenReturn( 1 );
 
         TestResult result = mock( TestResult.class );
         when( result.isPassed() ).thenReturn( false );
@@ -268,8 +266,11 @@ public class FailedTestsContentTest
         failedTestContent.escapeHtml = true;
         String content = failedTestContent.evaluate( build, listener, FailedTestsContent.MACRO_NAME );
 
-        assertThat( content, containsString("FAILED:  hudson.plugins.emailext.ExtendedEmailPublisherTest.Test") );
-        assertThat( content, containsString("expected:&lt;ABORTED&gt; but was:&lt;COMPLETED&gt;") );
-        assertThat( content, containsString("Stack Trace:\nat org.nexusformat.NexusFile.&lt;clinit&gt;(NexusFile.java:99)") );
+        assertEquals(content, "1 tests failed.<br/>" +
+            "FAILED:  hudson.plugins.emailext.ExtendedEmailPublisherTest.Test<br/><br/>" +
+            "Error Message:<br/>" +
+            "expected:&lt;ABORTED&gt; but was:&lt;COMPLETED&gt; <br/><br/>" +
+            "Stack Trace:<br/>" +
+            "at org.nexusformat.NexusFile.&lt;clinit&gt;(NexusFile.java:99)<br/><br/>");
     }
 }


### PR DESCRIPTION
This PR adds flag for escaping characters in errors details and stack traces using HTML entities in `FAILED_TESTS` plugin macro token.

Examples:
```
expected:<ABORTED> but was:<COMPLETED>
at org.nexusformat.NexusFile.<clinit>(NexusFile.java:99)
```
will be replaced to:
```
expected:&lt;ABORTED&gt; but was:&lt;COMPLETED&gt;
at org.nexusformat.NexusFile.&lt;clinit&gt;(NexusFile.java:99)
```

It will be useful when content type is set to text/html.