### PR TITLE
Consider ALL upstream causes in upstream recipient provider

### DIFF
--- a/src/main/java/hudson/plugins/emailext/plugins/recipients/UpstreamComitterRecipientProvider.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/recipients/UpstreamComitterRecipientProvider.java
@@ -50,7 +50,7 @@ public class UpstreamComitterRecipientProvider extends RecipientProvider {
         final Debug debug = new Debug();
         debug.send("Sending email to upstream committer(s).");
 
-        for ( Run<?, ?> run : getUniqueUpstreamRuns() ) {
+        for ( Run<?, ?> run : getUniqueUpstreamRuns(context) ) {
             addUpstreamCommittersTriggeringBuild(run, to, cc, bcc, env, context, debug);
         }
     }
@@ -91,7 +91,7 @@ public class UpstreamComitterRecipientProvider extends RecipientProvider {
         RecipientProviderUtilities.addUsers(Collections.singleton(user), context, env, to, cc, bcc, debug);
     }
 
-    private Set<Run<?, ?>> getUniqueUpstreamRuns() {
+    private Set<Run<?, ?>> getUniqueUpstreamRuns(ExtendedEmailPublisherContext context) {
         List<Run<?, ?>> upstreamRuns = new ArrayList<Run<?, ?>>();
         collectUpstreamRuns(context, upstreamRuns);
         return new HashSet<Run<?, ?>>(upstreamRuns);

--- a/src/main/java/hudson/plugins/emailext/plugins/recipients/UpstreamComitterRecipientProvider.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/recipients/UpstreamComitterRecipientProvider.java
@@ -111,7 +111,8 @@ public class UpstreamComitterRecipientProvider extends RecipientProvider {
 
             Cause.UpstreamCause upc = (Cause.UpstreamCause) cause;
 
-            Job<?, ?> job = (Job<?, ?>) Jenkins.get().getItemByFullName( upc.getUpstreamProject() );
+            Job<?, ?> job = (Job<?, ?>) Jenkins.get()
+                .getItemByFullName( upc.getUpstreamProject() );
 
             if (job == null) {
                 continue;

--- a/src/main/java/hudson/plugins/emailext/plugins/recipients/UpstreamComitterRecipientProvider.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/recipients/UpstreamComitterRecipientProvider.java
@@ -97,7 +97,7 @@ public class UpstreamComitterRecipientProvider extends RecipientProvider {
         return new HashSet<Run<?, ?>>(upstreamRuns);
     }
 
-    private void collectUpstreamRuns(ExtendedEmailPublisher context,
+    private void collectUpstreamRuns(ExtendedEmailPublisherContext context,
                                      List<Run<?, ?>> runs) {
 
         Run<?, ?> currentRun = runs.isEmpty() ?

--- a/src/main/java/hudson/plugins/emailext/plugins/recipients/UpstreamComitterRecipientProvider.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/recipients/UpstreamComitterRecipientProvider.java
@@ -97,7 +97,9 @@ public class UpstreamComitterRecipientProvider extends RecipientProvider {
         return new HashSet<Run<?, ?>>(upstreamRuns);
     }
 
-    private void collectUpstreamRuns(Context context, List<Run<?, ?>> runs) {
+    private void collectUpstreamRuns(ExtendedEmailPublisher context,
+                                     List<Run<?, ?>> runs) {
+
         Run<?, ?> currentRun = runs.isEmpty() ?
             context.getRun() :
             runs.get( runs.size() - 1 );


### PR DESCRIPTION
The current implementation of upstream recipient provider will not consider all upstream causes if a run has more than one upstream cause. In order to consider all causes I changed the implementation to find all causes recursively.