### PR TITLE
JENKINS-61380

### DIFF
--- a/src/main/java/hudson/plugins/emailext/plugins/recipients/BuildUserRecipientProvider.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/recipients/BuildUserRecipientProvider.java
@@ -69,7 +69,7 @@ public class BuildUserRecipientProvider extends RecipientProvider {
 
         @Override
         public String getDisplayName() {
-            return Messages.RequesterRecipientProvider_DisplayName();
+            return Messages.BuildUserRecipientProvider_DisplayName();
         }
     }
 }

--- a/src/main/java/hudson/plugins/emailext/plugins/recipients/BuildUserRecipientProvider.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/recipients/BuildUserRecipientProvider.java
@@ -1,0 +1,78 @@
+package hudson.plugins.emailext.plugins.recipients;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.Cause;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.User;
+import hudson.plugins.emailext.ExtendedEmailPublisherContext;
+import hudson.plugins.emailext.ExtendedEmailPublisherDescriptor;
+import hudson.plugins.emailext.Messages;
+import hudson.plugins.emailext.plugins.RecipientProvider;
+import hudson.plugins.emailext.plugins.RecipientProviderDescriptor;
+import java.io.PrintStream;
+import java.util.Collections;
+import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.mail.internet.InternetAddress;
+import java.util.Set;
+
+/**
+ * Created by skroell on 03/03/2020.
+ */
+
+public class BuildUserRecipientProvider extends RecipientProvider {
+
+    @DataBoundConstructor
+    public BuildUserRecipientProvider() {
+
+    }
+
+    @Override
+    public void addRecipients(final ExtendedEmailPublisherContext context, EnvVars env, Set<InternetAddress> to, Set<InternetAddress> cc, Set<InternetAddress> bcc) {
+        
+        final class Debug implements RecipientProviderUtilities.IDebug {
+            private final ExtendedEmailPublisherDescriptor descriptor = Jenkins.get().getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
+
+            private final PrintStream logger = context.getListener().getLogger();
+
+            public void send(final String format, final Object... args) {
+                descriptor.debug(logger, format, args);
+            }
+        }
+
+        final Debug debug = new Debug();
+
+        // Dont look upstream, find cause of current build
+        // Difference between this and RequesterRecipientProvider is that we send emails to the
+        // user triggering ex. a rebuild and not the original upstream user.
+        Run<?, ?> cur = context.getRun();
+        Cause.UserIdCause upc = cur.getCause(Cause.UserIdCause);
+        if(upc == null){
+            context.getListener().getLogger().print("The build was not caused by a user!");
+        }
+        addUserTriggeringTheBuild(cur, to, cc, bcc, env, context, debug);
+    }
+
+    private static void addUserTriggeringTheBuild(Run<?, ?> run, Set<InternetAddress> to,
+        Set<InternetAddress> cc, Set<InternetAddress> bcc, EnvVars env, final ExtendedEmailPublisherContext context, RecipientProviderUtilities.IDebug debug) {
+
+        final User user = RecipientProviderUtilities.getUserTriggeringTheBuild(run);
+        if (user != null) {
+            RecipientProviderUtilities.addUsers(Collections.singleton(user), context, env, to, cc, bcc, debug);
+        }
+    }
+
+    @Extension
+    @Symbol("buildUser")
+    public static final class DescriptorImpl extends RecipientProviderDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.RequesterRecipientProvider_DisplayName();
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/emailext/plugins/recipients/BuildUserRecipientProvider.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/recipients/BuildUserRecipientProvider.java
@@ -2,10 +2,7 @@ package hudson.plugins.emailext.plugins.recipients;
 
 import hudson.EnvVars;
 import hudson.Extension;
-import hudson.model.Cause;
-import hudson.model.Job;
-import hudson.model.Run;
-import hudson.model.User;
+import hudson.model.*;
 import hudson.plugins.emailext.ExtendedEmailPublisherContext;
 import hudson.plugins.emailext.ExtendedEmailPublisherDescriptor;
 import hudson.plugins.emailext.Messages;
@@ -50,7 +47,7 @@ public class BuildUserRecipientProvider extends RecipientProvider {
         // Difference between this and RequesterRecipientProvider is that we send emails to the
         // user triggering ex. a rebuild and not the original upstream user.
         Run<?, ?> cur = context.getRun();
-        Cause.UserIdCause upc = cur.getCause(Cause.UserIdCause);
+        Cause.UserIdCause upc = cur.getCause(hudson.model.Cause.UserIdCause.class);
         if(upc == null){
             context.getListener().getLogger().print("The build was not caused by a user!");
         }

--- a/src/main/resources/hudson/plugins/emailext/Messages.properties
+++ b/src/main/resources/hudson/plugins/emailext/Messages.properties
@@ -26,4 +26,5 @@ FailingTestSuspectsRecipientProvider.DisplayName=Suspects causing unit tests to 
 FirstFailingBuildSuspectsRecipientProvider.DisplayName=Suspects causing the build to begin failing
 ListRecipientProvider.DisplayName=Recipient List
 RequesterRecipientProvider.DisplayName=Requestor
+BuildUserRecipientProvider.DisplayName=Build User
 UpstreamComitterRecipientProvider.DisplayName=Upstream Committers


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-61380

When using the rebuild plugin and configuring email notifications to use the RequestorRecipientProvider, the email-ext plugin will email the original upstream build requestor and not the user who requested the rebuild.

Either RequestorRecipientProvider should take rebuilds into account somehow
or a BuildUserRecipientProvider (Maybe named differently) should be provided to notify the requestor of the current build without taking upstream causes into account.
