### PR TITLE
JENKINS-62060 - Add testSuiteName parameter to filter tests of unwanted packages

### DIFF
--- a/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
@@ -158,11 +158,10 @@ public class FailedTestsContent extends DataBoundTokenMacro {
     }
 
     private List<TestResult> filterTests(List<? extends TestResult> failedTests, String regexPattern) {
-        List<TestResult> filteredTests = failedTests.stream().collect(Collectors.toList());
         if(regexPattern.length() != 0) {
             Pattern pattern = Pattern.compile(regexPattern);
-            filteredTests = filteredTests.stream().filter(t -> pattern.matcher(t.getFullName()).matches()).collect(Collectors.toList());
+            failedTests = failedTests.stream().filter(t -> pattern.matcher(t.getFullName()).matches()).collect(Collectors.toList());
         }
-        return filteredTests;
+        return (List<TestResult>)failedTests;
     }
 }

--- a/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
@@ -53,7 +53,6 @@ public class FailedTestsContent extends DataBoundTokenMacro {
     }
 
 
-
     @Override
     public String evaluate(AbstractBuild<?, ?> build, TaskListener listener, String macroName) {
         return evaluate(build, build.getWorkspace(), listener, macroName);

--- a/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
@@ -43,7 +43,7 @@ public class FailedTestsContent extends DataBoundTokenMacro {
     public boolean escapeHtml = false;
 
     @Parameter
-    public String testNameRegexPattern = "";
+    public String testNamePattern = "";
 
     public static final String MACRO_NAME = "FAILED_TESTS";
 
@@ -69,8 +69,8 @@ public class FailedTestsContent extends DataBoundTokenMacro {
 
         int failCount = testResult.getFailCount();
 
-        List<TestResult> failedAndFilteredTests = filterTests(testResult.getFailedTests(), testNameRegexPattern);
-        failCount = testNameRegexPattern.length() == 0 ? failCount : failedAndFilteredTests.size();
+        List<TestResult> failedAndFilteredTests = filterTests(testResult.getFailedTests(), testNamePattern);
+        failCount = testNamePattern.length() == 0 ? failCount : failedAndFilteredTests.size();
 
         if (failCount == 0) {
             buffer.append("All tests passed");

--- a/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
@@ -69,7 +69,7 @@ public class FailedTestsContent extends DataBoundTokenMacro {
 
         int failCount = testResult.getFailCount();
 
-        List<TestResult> failedAndFilteredTests = filterTests(testResult.getFailedTests(), testNamePattern);
+        List<? extends TestResult> failedAndFilteredTests = filterTests(testResult.getFailedTests(), testNamePattern);
         failCount = testNamePattern.length() == 0 ? failCount : failedAndFilteredTests.size();
 
         if (failCount == 0) {
@@ -157,11 +157,11 @@ public class FailedTestsContent extends DataBoundTokenMacro {
         return escapeHtml ? "<br/>" : "\n";
     }
 
-    private List<TestResult> filterTests(List<? extends TestResult> failedTests, String regexPattern) {
+    private List<? extends TestResult> filterTests(List<? extends TestResult> failedTests, String regexPattern) {
         if(regexPattern.length() != 0) {
             Pattern pattern = Pattern.compile(regexPattern);
             failedTests = failedTests.stream().filter(t -> pattern.matcher(t.getFullName()).matches()).collect(Collectors.toList());
         }
-        return (List<TestResult>)failedTests;
+        return failedTests;
     }
 }

--- a/src/main/resources/hudson/plugins/emailext/plugins/content/FailedTestsContent/help.groovy
+++ b/src/main/resources/hudson/plugins/emailext/plugins/content/FailedTestsContent/help.groovy
@@ -17,7 +17,7 @@ dd() {
     dt("escapeHtml")
     dd("If set to true escapes characters in errors details and stack traces using HTML entities. Defaults to false.")
 
-    dt("testSuiteName")
-    dd("Display failed tests of the given module name. Defaults to showing all failed tests")
+    dt("testNameRegexPattern")
+    dd("Display failed tests of the modules whose name match the regex given. Defaults to showing all failed tests")
   }
 }

--- a/src/main/resources/hudson/plugins/emailext/plugins/content/FailedTestsContent/help.groovy
+++ b/src/main/resources/hudson/plugins/emailext/plugins/content/FailedTestsContent/help.groovy
@@ -17,7 +17,7 @@ dd() {
     dt("escapeHtml")
     dd("If set to true escapes characters in errors details and stack traces using HTML entities. Defaults to false.")
 
-    dt("testNameRegexPattern")
+    dt("testNamePattern")
     dd("Display failed tests of the modules whose name match the regex given. Defaults to showing all failed tests")
   }
 }

--- a/src/main/resources/hudson/plugins/emailext/plugins/content/FailedTestsContent/help.groovy
+++ b/src/main/resources/hudson/plugins/emailext/plugins/content/FailedTestsContent/help.groovy
@@ -16,5 +16,8 @@ dd() {
 
     dt("escapeHtml")
     dd("If set to true escapes characters in errors details and stack traces using HTML entities. Defaults to false.")
+
+    dt("testSuiteName")
+    dd("Display failed tests of the given module name. Defaults to showing all failed tests")
   }
 }

--- a/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
@@ -69,6 +69,7 @@ public class FailedTestsContentTest
             throws Exception {
         AbstractTestResultAction testResults = mock( AbstractTestResultAction.class );
         when( testResults.getFailCount() ).thenReturn( 0 );
+
         when( build.getAction(AbstractTestResultAction.class) ).thenReturn( testResults );
 
         String content = failedTestContent.evaluate( build, listener, FailedTestsContent.MACRO_NAME );
@@ -81,6 +82,7 @@ public class FailedTestsContentTest
             throws Exception {
         AbstractTestResultAction<?> testResults = mock( AbstractTestResultAction.class );
         when( testResults.getFailCount() ).thenReturn( 123 );
+
         when( build.getAction(AbstractTestResultAction.class) ).thenReturn( testResults );
 
         failedTestContent.maxTests = 0;

--- a/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
@@ -275,10 +275,9 @@ public class FailedTestsContentTest
     }
 
     @Test
-    public void testGetContent_withMessage_withStack_specificTestSuit()
+    public void testGetContent_withMessage_withStack_specificTestSuite()
             throws Exception {
         AbstractTestResultAction<?> testResults = mock( AbstractTestResultAction.class );
-        when( testResults.getFailCount() ).thenReturn( 4 );
 
         List<TestResult> failedTests = new ArrayList<>();
 
@@ -323,7 +322,7 @@ public class FailedTestsContentTest
     }
 
     @Test
-    public void testGetContent_withMessage_withStack_allTestSuit()
+    public void testGetContent_withMessage_withStack_allTestSuites()
             throws Exception {
         AbstractTestResultAction<?> testResults = mock( AbstractTestResultAction.class );
 
@@ -354,7 +353,7 @@ public class FailedTestsContentTest
         failedTestContent.maxTests = 4;
         failedTestContent.showMessage = true;
         failedTestContent.showStack = true;
-        failedTestContent.testNamePattern = ".*ExtendedEmailPublisherTest.*|.*OtherPackageTest.*";
+        failedTestContent.testNamePattern = ".*";
         String content = failedTestContent.evaluate( build, listener, FailedTestsContent.MACRO_NAME );
 
         assertTrue( content.contains(4 + " tests failed"));

--- a/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
@@ -68,7 +68,7 @@ public class FailedTestsContentTest
     public void testGetContent_whenAllTestsPassedShouldGiveMeaningfulMessage()
             throws Exception {
         AbstractTestResultAction testResults = mock( AbstractTestResultAction.class );
-
+        when( testResults.getFailCount() ).thenReturn( 0 );
         when( build.getAction(AbstractTestResultAction.class) ).thenReturn( testResults );
 
         String content = failedTestContent.evaluate( build, listener, FailedTestsContent.MACRO_NAME );
@@ -80,14 +80,7 @@ public class FailedTestsContentTest
     public void testGetContent_whenSomeTestsFailedShouldGiveMeaningfulMessage()
             throws Exception {
         AbstractTestResultAction<?> testResults = mock( AbstractTestResultAction.class );
-        List<TestResult> failedTests = new ArrayList<>();
-        for(int i = 0; i < 123; i++) {
-            TestResult result = mock( TestResult.class );
-            when( result.isPassed() ).thenReturn( false );
-            failedTests.add(result);
-        }
-
-        Mockito.<List<? extends TestResult>>when( testResults.getFailedTests() ).thenReturn( failedTests );
+        when( testResults.getFailCount() ).thenReturn( 123 );
         when( build.getAction(AbstractTestResultAction.class) ).thenReturn( testResults );
 
         failedTestContent.maxTests = 0;
@@ -100,6 +93,7 @@ public class FailedTestsContentTest
     public void testGetContent_withMessage_withStack()
             throws Exception {
         AbstractTestResultAction<?> testResults = mock( AbstractTestResultAction.class );
+        when( testResults.getFailCount() ).thenReturn( 2 );
 
         List<TestResult> failedTests = new ArrayList<>();
         for(int i = 0; i < 2; i++) {
@@ -131,6 +125,7 @@ public class FailedTestsContentTest
     public void testGetContent_noMessage_withStack()
             throws Exception {
         AbstractTestResultAction<?> testResults = mock( AbstractTestResultAction.class );
+        when( testResults.getFailCount() ).thenReturn( 2 );
 
         List<TestResult> failedTests = new ArrayList<>();
         for(int i = 0; i < 2; i++) {
@@ -161,6 +156,7 @@ public class FailedTestsContentTest
     public void testGetContent_withMessage_noStack()
             throws Exception {
         AbstractTestResultAction<?> testResults = mock( AbstractTestResultAction.class );
+        when( testResults.getFailCount() ).thenReturn( 2 );
 
         List<TestResult> failedTests = new ArrayList<>();
         for(int i = 0; i < 2; i++) {
@@ -191,6 +187,7 @@ public class FailedTestsContentTest
     public void testGetContent_noMessage_noStack()
             throws Exception {
         AbstractTestResultAction<?> testResults = mock( AbstractTestResultAction.class );
+        when( testResults.getFailCount() ).thenReturn( 2 );
 
         List<TestResult> failedTests = new ArrayList<>();
         for(int i = 0; i < 2; i++) {
@@ -221,6 +218,7 @@ public class FailedTestsContentTest
     public void testGetContent_whenContentLargerThanMaxLengthShouldTruncate()
             throws Exception {
         AbstractTestResultAction<?> testResults = mock( AbstractTestResultAction.class );
+        when( testResults.getFailCount() ).thenReturn( 5 );
 
         List<TestResult> failedTests = new ArrayList<>();
         for(int i = 0; i < 5; i++) {
@@ -249,6 +247,7 @@ public class FailedTestsContentTest
     @Test
     public void testGetContent_withMessage_withStack_htmlEscaped() {
         AbstractTestResultAction<?> testResults = mock( AbstractTestResultAction.class );
+        when( testResults.getFailCount() ).thenReturn( 1 );
 
         TestResult result = mock( TestResult.class );
         when( result.isPassed() ).thenReturn( false );
@@ -277,6 +276,7 @@ public class FailedTestsContentTest
     public void testGetContent_withMessage_withStack_specificTestSuit()
             throws Exception {
         AbstractTestResultAction<?> testResults = mock( AbstractTestResultAction.class );
+        when( testResults.getFailCount() ).thenReturn( 4 );
 
         List<TestResult> failedTests = new ArrayList<>();
 
@@ -306,7 +306,7 @@ public class FailedTestsContentTest
         failedTestContent.maxTests = 4;
         failedTestContent.showMessage = true;
         failedTestContent.showStack = true;
-        failedTestContent.testSuiteName = "ExtendedEmailPublisherTest";
+        failedTestContent.testNameRegexPattern = ".*ExtendedEmailPublisherTest.*";
         String content = failedTestContent.evaluate( build, listener, FailedTestsContent.MACRO_NAME );
 
         assertTrue( content.contains(2 + " tests failed"));
@@ -352,6 +352,7 @@ public class FailedTestsContentTest
         failedTestContent.maxTests = 4;
         failedTestContent.showMessage = true;
         failedTestContent.showStack = true;
+        failedTestContent.testNameRegexPattern = ".*ExtendedEmailPublisherTest.*|.*OtherPackageTest.*";
         String content = failedTestContent.evaluate( build, listener, FailedTestsContent.MACRO_NAME );
 
         assertTrue( content.contains(4 + " tests failed"));

--- a/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
@@ -308,7 +308,7 @@ public class FailedTestsContentTest
         failedTestContent.maxTests = 4;
         failedTestContent.showMessage = true;
         failedTestContent.showStack = true;
-        failedTestContent.testNameRegexPattern = ".*ExtendedEmailPublisherTest.*";
+        failedTestContent.testNamePattern = ".*ExtendedEmailPublisherTest.*";
         String content = failedTestContent.evaluate( build, listener, FailedTestsContent.MACRO_NAME );
 
         assertTrue( content.contains(2 + " tests failed"));
@@ -354,7 +354,7 @@ public class FailedTestsContentTest
         failedTestContent.maxTests = 4;
         failedTestContent.showMessage = true;
         failedTestContent.showStack = true;
-        failedTestContent.testNameRegexPattern = ".*ExtendedEmailPublisherTest.*|.*OtherPackageTest.*";
+        failedTestContent.testNamePattern = ".*ExtendedEmailPublisherTest.*|.*OtherPackageTest.*";
         String content = failedTestContent.evaluate( build, listener, FailedTestsContent.MACRO_NAME );
 
         assertTrue( content.contains(4 + " tests failed"));


### PR DESCRIPTION
Add `testSuiteName` parameter to enable `FAILED_TESTS` macro for filtering out tests of unwanted packages. 