### PR TITLE
Add additional parameter to `FAILED_TESTS` token to enable yaml output generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,12 +119,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.3.0</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.2.3</version>
+            <version>2.10.0</version>
         </dependency>
 
         <!-- other plugins -->

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,16 @@
             <artifactId>jericho-html</artifactId>
             <version>3.3</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.2.3</version>
+        </dependency>
 
         <!-- other plugins -->
         <dependency>

--- a/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
@@ -212,7 +212,6 @@ public class FailedTestsContent extends DataBoundTokenMacro {
         public String name;
         public String errorMessage;
         public String stackTrace;
-        public FailedTest() {}
         public FailedTest(String name, String errorMessage, String stackTrace){
             this.errorMessage = errorMessage;
             this.name = name;

--- a/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
@@ -50,7 +50,7 @@ public class FailedTestsContent extends DataBoundTokenMacro {
     public boolean escapeHtml = false;
 
     @Parameter
-    public String outputYaml = "";
+    public String outputFormat = "";
 
     @Parameter
     public String testNamePattern = "";
@@ -73,7 +73,7 @@ public class FailedTestsContent extends DataBoundTokenMacro {
         AbstractTestResultAction<?> testResult = run.getAction(AbstractTestResultAction.class);
         SummarizedTestResult result = prepareSummarizedTestResult(testResult);
 
-        switch (outputYaml) {
+        switch (outputFormat) {
             case "yaml":
                 try {
                     return result.toYamlString();

--- a/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
@@ -219,6 +219,11 @@ public class FailedTestsContent extends DataBoundTokenMacro {
             this.name = name;
             this.stackTrace = stackTrace;
         }
+
+        @Override
+        public String toString() {
+            return String.format("Name:%s, Error message: %s, Stack trace:%s", this.name, this.errorMessage, this.stackTrace);
+        }
     }
 
     @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
@@ -245,6 +250,16 @@ public class FailedTestsContent extends DataBoundTokenMacro {
 
         public void addTest(FailedTest t) {
             this.tests.add(t);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder b = new StringBuilder();
+            for(FailedTest t: this.tests) {
+                b.append(t.toString()).append("\n");
+            }
+            return String.format("Summary:%s, Tests: %s, Other failed tests:%s, Output truncated: %s",
+                    this.summary, b.toString(), this.otherFailedTests, this.truncatedOutput);
         }
     }
 }

--- a/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
@@ -112,24 +112,25 @@ public class FailedTestsContent extends DataBoundTokenMacro {
         else {
             result.summary = String.format("%d tests failed.", failCount);
             setMaxLength();
-            if(maxTests == 0) return result;
-            int printSize = 0;
-            for (TestResult failedTest : testResult.getFailedTests()) {
-                if (regressionFilter(failedTest)) {
-                    String stackTrace = showStack ? (escapeHtml ? escapeHtml(failedTest.getErrorStackTrace()) : failedTest.getErrorStackTrace()) : null;
-                    String errorDetails = showMessage ? (escapeHtml ? escapeHtml(failedTest.getErrorDetails()) : failedTest.getErrorDetails()) : null;
-                    String name = String.format( "%s.%s", (failedTest instanceof CaseResult) ? ((CaseResult)failedTest).getClassName() : failedTest.getFullName(),
-                            failedTest.getDisplayName());
-                    FailedTest t = new FailedTest(name, failedTest.isPassed(), errorDetails, stackTrace);
-                    String testYaml = t.toString();
-                    if(printSize <= maxLength && result.tests.size() < maxTests) {
-                        result.tests.add(t);
-                        printSize += testYaml.length();
+            if(maxTests > 0) {
+                int printSize = 0;
+                for (TestResult failedTest : testResult.getFailedTests()) {
+                    if (regressionFilter(failedTest)) {
+                        String stackTrace = showStack ? (escapeHtml ? escapeHtml(failedTest.getErrorStackTrace()) : failedTest.getErrorStackTrace()) : null;
+                        String errorDetails = showMessage ? (escapeHtml ? escapeHtml(failedTest.getErrorDetails()) : failedTest.getErrorDetails()) : null;
+                        String name = String.format("%s.%s", (failedTest instanceof CaseResult) ? ((CaseResult) failedTest).getClassName() : failedTest.getFullName(),
+                                failedTest.getDisplayName());
+                        FailedTest t = new FailedTest(name, failedTest.isPassed(), errorDetails, stackTrace);
+                        String testYaml = t.toString();
+                        if (printSize <= maxLength && result.tests.size() < maxTests) {
+                            result.tests.add(t);
+                            printSize += testYaml.length();
+                        }
                     }
                 }
+                result.otherFailedTests = (failCount > result.tests.size());
+                result.truncatedOutput = (printSize > maxLength);
             }
-            result.otherFailedTests = (failCount > result.tests.size());
-            result.truncatedOutput = (printSize > maxLength);
         }
         return result;
     }
@@ -175,8 +176,9 @@ public class FailedTestsContent extends DataBoundTokenMacro {
         public String toString() {
             StringBuilder builder = new StringBuilder();
             builder.append(this.summary);
-            if(tests.size() == 0) return builder.toString();
-            builder.append(lineBreak);
+            if(tests.size() != 0) {
+                builder.append(lineBreak);
+            }
             for(FailedTest t: tests) {
                 outputTest(builder, lineBreak, t);
             }

--- a/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
@@ -78,8 +78,10 @@ public class FailedTestsContent extends DataBoundTokenMacro {
             case "yaml":
                 try {
                     return result.toYamlString();
+                } catch (JsonProcessingException e) {
+                    throw new MacroEvaluationException("Unable to serialize to yaml", MACRO_NAME, e.getCause());
                 } catch (Exception e) {
-                    throw new MacroEvaluationException("Bad format", MACRO_NAME, e.getCause());
+                    throw e;
                 }
             default:
                 return result.toString();

--- a/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
@@ -14,7 +14,6 @@ import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TestResult;
 import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;
 
-import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/FailedTestsContent.java
@@ -14,6 +14,7 @@ import hudson.tasks.junit.CaseResult;
 import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TestResult;
 import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;
+import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -64,12 +65,12 @@ public class FailedTestsContent extends DataBoundTokenMacro {
 
 
     @Override
-    public String evaluate(AbstractBuild<?, ?> build, TaskListener listener, String macroName) {
+    public String evaluate(AbstractBuild<?, ?> build, TaskListener listener, String macroName) throws MacroEvaluationException{
         return evaluate(build, build.getWorkspace(), listener, macroName);
     }
 
     @Override
-    public String evaluate(Run<?, ?> run, FilePath workspace, TaskListener listener, String macroName) {
+    public String evaluate(Run<?, ?> run, FilePath workspace, TaskListener listener, String macroName) throws MacroEvaluationException {
         AbstractTestResultAction<?> testResult = run.getAction(AbstractTestResultAction.class);
         SummarizedTestResult result = prepareSummarizedTestResult(testResult);
 
@@ -77,8 +78,9 @@ public class FailedTestsContent extends DataBoundTokenMacro {
             case "yaml":
                 try {
                     return result.toYamlString();
-                } catch (Exception e) { }
-                return "Bad format";
+                } catch (Exception e) {
+                    throw new MacroEvaluationException("Bad format", MACRO_NAME, e.getCause());
+                }
             default:
                 return result.toString();
         }

--- a/src/main/resources/hudson/plugins/emailext/plugins/content/FailedTestsContent/help.groovy
+++ b/src/main/resources/hudson/plugins/emailext/plugins/content/FailedTestsContent/help.groovy
@@ -17,8 +17,8 @@ dd() {
     dt("escapeHtml")
     dd("If set to true escapes characters in errors details and stack traces using HTML entities. Defaults to false.")
 
-    dt("outputYaml")
-    dd("If set to true outputs the failed tests in a YAML format")
+    dt("outputFormat")
+    dd("Outputs the test reports in yaml if set to \"yaml\". Defaults to empty string which would print the tests in plain text format")
 
     dt("testNamePattern")
     dd("Display failed tests of the modules whose name match the regex given. Defaults to showing all failed tests")

--- a/src/main/resources/hudson/plugins/emailext/plugins/content/FailedTestsContent/help.groovy
+++ b/src/main/resources/hudson/plugins/emailext/plugins/content/FailedTestsContent/help.groovy
@@ -16,5 +16,8 @@ dd() {
 
     dt("escapeHtml")
     dd("If set to true escapes characters in errors details and stack traces using HTML entities. Defaults to false.")
+
+    dt("outputYaml")
+    dd("If set to true outputs the failed tests in a YAML format")
   }
 }

--- a/src/main/resources/hudson/plugins/emailext/plugins/content/FailedTestsContent/help.groovy
+++ b/src/main/resources/hudson/plugins/emailext/plugins/content/FailedTestsContent/help.groovy
@@ -18,7 +18,7 @@ dd() {
     dd("If set to true escapes characters in errors details and stack traces using HTML entities. Defaults to false.")
 
     dt("outputFormat")
-    dd("Outputs the test reports in yaml if set to \"yaml\". Defaults to empty string which would print the tests in plain text format")
+    dd("Outputs the test reports in yaml if set to \"yaml\". For example \${FAILED_TESTS, outputFormat=\"yaml\"}, Defaults to empty string which would print the tests in plain text format.")
 
     dt("testNamePattern")
     dd("Display failed tests of the modules whose name match the regex given. Defaults to showing all failed tests")

--- a/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
@@ -236,7 +236,6 @@ public class FailedTestsContentTest
         when( build.getAction(AbstractTestResultAction.class) ).thenReturn( testResults );
 
         failedTestContent.maxLength = 10;
-        //failedTestContent.outputYaml = true;
         String content = failedTestContent.evaluate( build, listener, FailedTestsContent.MACRO_NAME );
         assertTrue( content.length() < (3 * 1024 * 5) );
 

--- a/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
@@ -89,7 +89,7 @@ public class FailedTestsContentTest
         failedTestContent.maxTests = 0;
         String content = failedTestContent.evaluate( build, listener, FailedTestsContent.MACRO_NAME );
 
-        assertEquals( "123 tests failed.\n", content );
+        assertEquals( "123 tests failed.", content );
     }
 
     @Test
@@ -294,9 +294,10 @@ public class FailedTestsContentTest
         failedTestContent.showStack = true;
         failedTestContent.outputYaml = true;
         String content = failedTestContent.evaluate(build, listener, failedTestContent.MACRO_NAME);
-        assertEquals(content, "summary: \"1 tests failed\"\n" +
+        assertEquals(content, "summary: \"1 tests failed.\"\n" +
                 "tests:\n" +
                 "- name: \"hudson.plugins.emailext.ExtendedEmailPublisherTest.Test\"\n" +
+                "  status: \"FAILED\"\n" +
                 "  errorMessage: \"expected:<ABORTED> but was:<COMPLETED> \"\n" +
                 "  stackTrace: \"at org.nexusformat.NexusFile.<clinit>(NexusFile.java:99)\"\n" +
                 "otherFailedTests: false\n" +

--- a/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
@@ -354,7 +354,7 @@ public class FailedTestsContentTest
 
         failedTestContent.showMessage = true;
         failedTestContent.showStack = true;
-        failedTestContent.outputYaml = "yaml";
+        failedTestContent.outputFormat = "yaml";
         String content = failedTestContent.evaluate(build, listener, failedTestContent.MACRO_NAME);
         assertEquals(content, "summary: \"1 tests failed.\"\n" +
                 "tests:\n" +

--- a/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
@@ -19,7 +19,9 @@ import java.util.List;
 
 import static java.util.Collections.singletonList;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
@@ -298,7 +298,7 @@ public class FailedTestsContentTest
                 "  errorMessage: \"expected:<ABORTED> but was:<COMPLETED> \"\n" +
                 "  stackTrace: \"at org.nexusformat.NexusFile.<clinit>(NexusFile.java:99)\"\n" +
                 "otherFailedTests: false\n" +
-                "truncatedOutPut: false\n");
+                "truncatedOutput: false\n");
 
     }
 }

--- a/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
@@ -279,27 +279,89 @@ public class FailedTestsContentTest
     public void testGetContent_withMessage_withStack_outputYaml() {
         AbstractTestResultAction<?> testResults = mock(AbstractTestResultAction.class);
         when(testResults.getFailCount()).thenReturn(1);
+        String testStackTrace = "javax.servlet.ServletException: Something bad happened\n" +
+                "    at com.example.myproject.OpenSessionInViewFilter.doFilter(OpenSessionInViewFilter.java:60)\n" +
+                "    at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)\n" +
+                "    at com.example.myproject.ExceptionHandlerFilter.doFilter(ExceptionHandlerFilter.java:28)\n" +
+                "    at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)\n" +
+                "    at com.example.myproject.OutputBufferFilter.doFilter(OutputBufferFilter.java:33)\n" +
+                "    at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)\n" +
+                "    at org.mortbay.jetty.servlet.ServletHandler.handle(ServletHandler.java:388)\n" +
+                "    at org.mortbay.jetty.security.SecurityHandler.handle(SecurityHandler.java:216)\n" +
+                "    at org.mortbay.jetty.servlet.SessionHandler.handle(SessionHandler.java:182)\n" +
+                "    at org.mortbay.jetty.handler.ContextHandler.handle(ContextHandler.java:765)\n" +
+                "    at org.mortbay.jetty.webapp.WebAppContext.handle(WebAppContext.java:418)\n" +
+                "    at org.mortbay.jetty.handler.HandlerWrapper.handle(HandlerWrapper.java:152)\n" +
+                "    at org.mortbay.jetty.Server.handle(Server.java:326)\n" +
+                "    at org.mortbay.jetty.HttpConnection.handleRequest(HttpConnection.java:542)\n" +
+                "    at org.mortbay.jetty.HttpConnection$RequestHandler.content(HttpConnection.java:943)\n" +
+                "    at org.mortbay.jetty.HttpParser.parseNext(HttpParser.java:756)\n" +
+                "    at org.mortbay.jetty.HttpParser.parseAvailable(HttpParser.java:218)\n" +
+                "    at org.mortbay.jetty.HttpConnection.handle(HttpConnection.java:404)\n" +
+                "    at org.mortbay.jetty.bio.SocketConnector$Connection.run(SocketConnector.java:228)\n" +
+                "    at org.mortbay.thread.QueuedThreadPool$PoolThread.run(QueuedThreadPool.java:582)\n" +
+                "Caused by: com.example.myproject.MyProjectServletException\n" +
+                "    at com.example.myproject.MyServlet.doPost(MyServlet.java:169)\n" +
+                "    at javax.servlet.http.HttpServlet.service(HttpServlet.java:727)\n" +
+                "    at javax.servlet.http.HttpServlet.service(HttpServlet.java:820)\n" +
+                "    at org.mortbay.jetty.servlet.ServletHolder.handle(ServletHolder.java:511)\n" +
+                "    at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1166)\n" +
+                "    at com.example.myproject.OpenSessionInViewFilter.doFilter(OpenSessionInViewFilter.java:30)\n" +
+                "    ... 27 more\n" +
+                "Caused by: org.hibernate.exception.ConstraintViolationException: could not insert: [com.example.myproject.MyEntity]\n" +
+                "    at org.hibernate.exception.SQLStateConverter.convert(SQLStateConverter.java:96)\n" +
+                "    at org.hibernate.exception.JDBCExceptionHelper.convert(JDBCExceptionHelper.java:66)\n" +
+                "    at org.hibernate.id.insert.AbstractSelectingDelegate.performInsert(AbstractSelectingDelegate.java:64)\n" +
+                "    at org.hibernate.persister.entity.AbstractEntityPersister.insert(AbstractEntityPersister.java:2329)\n" +
+                "    at org.hibernate.persister.entity.AbstractEntityPersister.insert(AbstractEntityPersister.java:2822)\n" +
+                "    at org.hibernate.action.EntityIdentityInsertAction.execute(EntityIdentityInsertAction.java:71)\n" +
+                "    at org.hibernate.engine.ActionQueue.execute(ActionQueue.java:268)\n" +
+                "    at org.hibernate.event.def.AbstractSaveEventListener.performSaveOrReplicate(AbstractSaveEventListener.java:321)\n" +
+                "    at org.hibernate.event.def.AbstractSaveEventListener.performSave(AbstractSaveEventListener.java:204)\n" +
+                "    at org.hibernate.event.def.AbstractSaveEventListener.saveWithGeneratedId(AbstractSaveEventListener.java:130)\n" +
+                "    at org.hibernate.event.def.DefaultSaveOrUpdateEventListener.saveWithGeneratedOrRequestedId(DefaultSaveOrUpdateEventListener.java:210)\n" +
+                "    at org.hibernate.event.def.DefaultSaveEventListener.saveWithGeneratedOrRequestedId(DefaultSaveEventListener.java:56)\n" +
+                "    at org.hibernate.event.def.DefaultSaveOrUpdateEventListener.entityIsTransient(DefaultSaveOrUpdateEventListener.java:195)\n" +
+                "    at org.hibernate.event.def.DefaultSaveEventListener.performSaveOrUpdate(DefaultSaveEventListener.java:50)\n" +
+                "    at org.hibernate.event.def.DefaultSaveOrUpdateEventListener.onSaveOrUpdate(DefaultSaveOrUpdateEventListener.java:93)\n" +
+                "    at org.hibernate.impl.SessionImpl.fireSave(SessionImpl.java:705)\n" +
+                "    at org.hibernate.impl.SessionImpl.save(SessionImpl.java:693)\n" +
+                "    at org.hibernate.impl.SessionImpl.save(SessionImpl.java:689)\n" +
+                "    at sun.reflect.GeneratedMethodAccessor5.invoke(Unknown Source)\n" +
+                "    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\n" +
+                "    at java.lang.reflect.Method.invoke(Method.java:597)\n" +
+                "    at org.hibernate.context.ThreadLocalSessionContext$TransactionProtectionWrapper.invoke(ThreadLocalSessionContext.java:344)\n" +
+                "    at $Proxy19.save(Unknown Source)\n" +
+                "    at com.example.myproject.MyEntityService.save(MyEntityService.java:59) <-- relevant call (see notes below)\n" +
+                "    at com.example.myproject.MyServlet.doPost(MyServlet.java:164)\n" +
+                "    ... 32 more\n" +
+                "Caused by: java.sql.SQLException: Violation of unique constraint MY_ENTITY_UK_1: duplicate value(s) for column(s) MY_COLUMN in statement [...]\n" +
+                "    at org.hsqldb.jdbc.Util.throwError(Unknown Source)\n" +
+                "    at org.hsqldb.jdbc.jdbcPreparedStatement.executeUpdate(Unknown Source)\n" +
+                "    at com.mchange.v2.c3p0.impl.NewProxyPreparedStatement.executeUpdate(NewProxyPreparedStatement.java:105)\n" +
+                "    at org.hibernate.id.insert.AbstractSelectingDelegate.performInsert(AbstractSelectingDelegate.java:57)\n" +
+                "    ... 54 more";
 
         TestResult result = mock(TestResult.class);
         when(result.isPassed()).thenReturn(false);
         when(result.getFullName()).thenReturn("hudson.plugins.emailext.ExtendedEmailPublisherTest");
         when(result.getDisplayName()).thenReturn("Test");
         when(result.getErrorDetails()).thenReturn("expected:<ABORTED> but was:<COMPLETED> ");
-        when(result.getErrorStackTrace()).thenReturn("at org.nexusformat.NexusFile.<clinit>(NexusFile.java:99)");
+        when(result.getErrorStackTrace()).thenReturn(testStackTrace);
 
         Mockito.<List<? extends TestResult>>when(testResults.getFailedTests()).thenReturn(singletonList(result));
         when(build.getAction(AbstractTestResultAction.class)).thenReturn(testResults);
 
         failedTestContent.showMessage = true;
         failedTestContent.showStack = true;
-        failedTestContent.outputYaml = true;
+        failedTestContent.outputYaml = "yaml";
         String content = failedTestContent.evaluate(build, listener, failedTestContent.MACRO_NAME);
         assertEquals(content, "summary: \"1 tests failed.\"\n" +
                 "tests:\n" +
                 "- name: \"hudson.plugins.emailext.ExtendedEmailPublisherTest.Test\"\n" +
                 "  status: \"FAILED\"\n" +
                 "  errorMessage: \"expected:<ABORTED> but was:<COMPLETED> \"\n" +
-                "  stackTrace: \"at org.nexusformat.NexusFile.<clinit>(NexusFile.java:99)\"\n" +
+                "  stackTrace: |-\n" + testStackTrace.replaceAll("(?m)^", "    ") + "\n" +
                 "otherFailedTests: false\n" +
                 "truncatedOutput: false\n");
     }

--- a/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
@@ -248,7 +248,7 @@ public class FailedTestsContentTest
     }
 
     @Test
-    public void testGetContent_withMessage_withStack_htmlEscaped() {
+    public void testGetContent_withMessage_withStack_htmlEscaped() throws Exception {
         AbstractTestResultAction<?> testResults = mock( AbstractTestResultAction.class );
         when( testResults.getFailCount() ).thenReturn( 1 );
 
@@ -276,7 +276,7 @@ public class FailedTestsContentTest
     }
 
     @Test
-    public void testGetContent_withMessage_withStack_outputYaml() {
+    public void testGetContent_withMessage_withStack_outputYaml() throws Exception {
         AbstractTestResultAction<?> testResults = mock(AbstractTestResultAction.class);
         when(testResults.getFailCount()).thenReturn(1);
         String testStackTrace = "javax.servlet.ServletException: Something bad happened\n" +


### PR DESCRIPTION
`FAILED_TESTS` token is often used to generate emails of build failures. 
The output is currently a plain text file. It is very hard to iterate through this text file to read the failures case by case. Hence, a format easily readable and iterable would be beneficial. 
YAML is a human readable as well as machine readable format. 