### PR TITLE
Remove com.google.code.findbugs:annotations from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,15 +318,6 @@
             <version>${configuration-as-code.version}</version>
             <scope>test</scope>
         </dependency>
-
-        <!-- static analysys -->
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
-            <version>3.0.0</version>
-            <scope>provided</scope>
-        </dependency>
-
     </dependencies>
 
     <scm>


### PR DESCRIPTION
The SpotBugs annotations are now in the plugin parent POM, so this is no longer needed.