### PR TITLE
Remove javassist from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,22 +273,10 @@
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.javassist</groupId>
-                    <artifactId>javassist</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.javassist</groupId>
-            <artifactId>javassist</artifactId>
-            <version>3.20.0-GA</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
We don't directly depend on this library, so we can remove any references to it from our `pom.xml`. As far as I can tell, it seems to have been originally added to resolve a `RequireUpperBoundDeps` violation that is no longer present.