### PR TITLE
Remove explicit references to Hamcrest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,13 +255,6 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>2.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Can rely on the plugin parent POM and the Jenkins test harness to provide these libraries without having to maintain explicit versions of them in this plugin's POM.