### PR TITLE
Stop build before moving on to the next test

### DIFF
--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
@@ -1128,6 +1128,8 @@ public class ExtendedEmailPublisherTest {
         assertTrue(build1.isBuilding());
         assertFalse(build2.isBuilding());
         j.assertLogContains(Messages.ExtendedEmailPublisher__is_still_in_progress_ignoring_for_purpo(build1.getDisplayName()), build2);
+        build1.doStop();
+        j.assertBuildStatus(Result.ABORTED, build1);
     }
 
     @Test


### PR DESCRIPTION
Not sure if this is related to failures like [#119](https://ci.jenkins.io/job/Plugins/job/email-ext-plugin/job/master/119/), but I noticed this in the logs:

```
  42.990 [id=2180]	INFO	hudson.model.Run#execute: testConcurrentBuilds #1 aborted
java.lang.InterruptedException: sleep interrupted
	at java.lang.Thread.sleep(Native Method)
	at hudson.plugins.emailext.ExtendedEmailPublisherTest$SleepOnceBuilder.perform(ExtendedEmailPublisherTest.java:1317)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:741)
	at hudson.model.Build$BuildExecution.build(Build.java:206)
	at hudson.model.Build$BuildExecution.doRun(Build.java:163)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:504)
	at hudson.model.Run.execute(Run.java:1894)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:428)
```

At the very least it is unhygienic for one test to leave a build running as we move on to subsequent tests. We should stop the build before moving on to the next test.