### PR TITLE
Mark ExtendedEmailPublisherDescriptor#authenticatorProvider transient

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -179,7 +179,7 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
     private transient Secret smtpAuthPassword;
     private transient boolean useSsl = false;
 
-    private Function<MailAccount, Authenticator> authenticatorProvider = (acc) -> new Authenticator() {
+    private transient Function<MailAccount, Authenticator> authenticatorProvider = (acc) -> new Authenticator() {
         @Override
         protected PasswordAuthentication getPasswordAuthentication() {
             return new PasswordAuthentication(acc.getSmtpUsername(), Secret.toString(acc.getSmtpPassword()));


### PR DESCRIPTION
Amends #217. Adds the `transient` keyword to `ExtendedEmailPublisherDescriptor#authenticatorProvider`, without which the following gets added to the serialized XML:

```xml
<authenticatorProvider class="hudson.plugins.emailext.ExtendedEmailPublisherDescriptor$$Lambda$131/1698888983">
  <arg_-1 reference="../.."/>
</authenticatorProvider>
```