### PR TITLE
Mark older fields as deprecated and migrate callers to non-deprecated equivalents

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -144,7 +144,7 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
      */
     private String excludedCommitters = "";
 
-    private boolean overrideGlobalSettings;
+    private transient boolean overrideGlobalSettings;
 
     /**
      * If non-null, set a List-ID email header.
@@ -357,6 +357,7 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
         this.addAccounts = addAccounts;
     }
 
+    @Deprecated
     public String getSmtpServer() {
         return mailAccount.getSmtpHost();
     }
@@ -384,6 +385,7 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
 
     @SuppressWarnings("unused")
     @DataBoundSetter
+    @Deprecated
     public void setSmtpPassword(String password) {
         mailAccount.setSmtpPassword(password);
     }
@@ -391,8 +393,8 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
     // Make API match Mailer plugin
     @SuppressWarnings("unused")
     public void setSmtpAuth(String userName, String password) {
-        setSmtpUsername(userName);
-        setSmtpPassword(password);
+        mailAccount.setSmtpUsername(userName);
+        mailAccount.setSmtpPassword(password);
     }
 
     @Deprecated
@@ -417,6 +419,7 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
         mailAccount.setSmtpPort(nullify(port));
     }
 
+    @Deprecated
     public String getAdvProperties() {
         return mailAccount.getAdvProperties();
     }
@@ -572,6 +575,7 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
         this.excludedCommitters = ((excluded == null) ? "" : excluded);
     }
 
+    @Deprecated
     public boolean getOverrideGlobalSettings() {
         return overrideGlobalSettings;
     }

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
@@ -240,7 +240,7 @@ public class ExtendedEmailPublisherDescriptorTest {
         advProperties.setText("mail.smtp.starttls.enable=true");
         j.submit(page.getFormByName("config"));
 
-        assertEquals("mail.smtp.starttls.enable=true", descriptor.getAdvProperties());
+        assertEquals("mail.smtp.starttls.enable=true", descriptor.getMailAccount().getAdvProperties());
     }
 
     @Test
@@ -666,7 +666,7 @@ public class ExtendedEmailPublisherDescriptorTest {
         assertEquals("@example.com", descriptor.getDefaultSuffix());
         assertEquals("admin", descriptor.getMailAccount().getSmtpUsername());
         assertEquals(Secret.fromString("honeycomb"), descriptor.getMailAccount().getSmtpPassword());
-        assertEquals("mail.smtp.ssl.trust=example.com", descriptor.getAdvProperties());
+        assertEquals("mail.smtp.ssl.trust=example.com", descriptor.getMailAccount().getAdvProperties());
         assertTrue(descriptor.getMailAccount().isUseSsl());
         assertTrue(descriptor.getMailAccount().isDefaultAccount());
         assertEquals("2525", descriptor.getMailAccount().getSmtpPort());

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
@@ -1166,9 +1166,9 @@ public class ExtendedEmailPublisherTest {
         j.createWebClient().executeOnServer(new Callable<Object>() {
             public Void call() throws Exception {
                 ExtendedEmailPublisherDescriptor descriptor = ExtendedEmailPublisher.descriptor();
-                descriptor.setSmtpServer("smtp.test0.com");
-                descriptor.setSmtpPort("587");
-                descriptor.setAdvProperties("mail.smtp.ssl.trust=test0.com");
+                descriptor.getMailAccount().setSmtpHost("smtp.test0.com");
+                descriptor.getMailAccount().setSmtpPort("587");
+                descriptor.getMailAccount().setAdvProperties("mail.smtp.ssl.trust=test0.com");
 
                 JSONObject form = new JSONObject();
                 form.put("project_from", "mail@test1.com");


### PR DESCRIPTION
A number of fields were moved from `ExtendedEmailPublisherDescriptor` to `MailAccount` at some point in the past. Most of the original getters and setters were then deprecated, but not all of them were. This change deprecates all of the original getters and setters and then updates any remaining callers to call the non-deprecated versions from `MailAccount`.

While I was here, I noticed that all references to `ExtendedEmailPublisherDescriptor#overrideGlobalSettings` were removed when JCasC support was added. This means we can drop `overrideGlobalSettings` from the serialized XML, so I've added the `transient` keyword to that field and deprecated its getter.