### PR TITLE
[JENKINS-63846] From address can't be changed

### DIFF
--- a/src/main/java/hudson/plugins/emailext/MailAccount.java
+++ b/src/main/java/hudson/plugins/emailext/MailAccount.java
@@ -42,7 +42,7 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount>{
     }
 
     public boolean isValid() {
-        return StringUtils.isNotBlank(address) && StringUtils.isNotBlank(smtpHost) && (!isAuth() || (StringUtils.isNotBlank(smtpUsername) && smtpPassword != null));
+        return (isDefaultAccount() || StringUtils.isNotBlank(address)) && StringUtils.isNotBlank(smtpHost) && (!isAuth() || (StringUtils.isNotBlank(smtpUsername) && smtpPassword != null));
     }
 
     public boolean isDefaultAccount() {

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
@@ -510,7 +510,7 @@ public class ExtendedEmailPublisherDescriptorTest {
         descriptor.setEmergencyReroute("");
         j.submit(j.createWebClient().goTo("configure").getFormByName("config"));
 
-        assertEquals("address not configured yet <nobody@nowhere>",descriptor.getMailAccount().getAddress());
+        assertNull(descriptor.getMailAccount().getAddress());
         assertNull(descriptor.getMailAccount().getSmtpHost());
         assertEquals("25",descriptor.getMailAccount().getSmtpPort());
         assertNull(descriptor.getMailAccount().getSmtpUsername());
@@ -534,7 +534,7 @@ public class ExtendedEmailPublisherDescriptorTest {
         descriptor.setEmergencyReroute(null);
         j.submit(j.createWebClient().goTo("configure").getFormByName("config"));
 
-        assertEquals("address not configured yet <nobody@nowhere>",descriptor.getMailAccount().getAddress());
+        assertNull(descriptor.getMailAccount().getAddress());
         assertNull(descriptor.getMailAccount().getSmtpHost());
         assertEquals("25",descriptor.getMailAccount().getSmtpPort());
         assertNull(descriptor.getMailAccount().getSmtpUsername());
@@ -877,8 +877,8 @@ public class ExtendedEmailPublisherDescriptorTest {
         */
         ExtendedEmailPublisherDescriptor descriptor =
                 j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
-        // TODO: Fails pending the fix for JENKINS-63846
-        // assertEquals("admin@example.com", descriptor.getAdminAddress());
+        assertEquals("admin@example.com", descriptor.getAdminAddress());
+        assertNull(descriptor.getMailAccount().getAddress());
         assertEquals("smtp.example.com", descriptor.getMailAccount().getSmtpHost());
         assertEquals("@example.com", descriptor.getDefaultSuffix());
         assertEquals("admin", descriptor.getMailAccount().getSmtpUsername());


### PR DESCRIPTION
See [JENKINS-63846](https://issues.jenkins-ci.org/browse/JENKINS-63846). Versions 2.71 and earlier persisted the address for additional accounts but not the default account. Starting in 2.72, the admin address is copied from the Jenkins Location configuration into the default account at the time `ExtendedEmailPublisherDescriptor` is first saved, but this value is not editable in the UI nor does it get updated when the admin address is subsequently updated in the Jenkins Location configuration. Compare the persisted XML [before](https://github.com/jenkinsci/email-ext-plugin/blob/master/src/test/resources/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest/persistedConfigurationBeforeJCasC/hudson.plugins.emailext.ExtendedEmailPublisher.xml) and [after](https://github.com/jenkinsci/email-ext-plugin/blob/master/src/test/resources/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest/persistedConfigurationBeforeDefaultAddress/hudson.plugins.emailext.ExtendedEmailPublisher.xml). In the second example, you can see that `address` has been persisted for the default account at the time `ExtendedEmailPublisherDescriptor` was saved. Even though [the Jenkins Location configuration](https://github.com/jenkinsci/email-ext-plugin/blob/master/src/test/resources/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest/persistedConfigurationBeforeDefaultAddress/jenkins.model.JenkinsLocationConfiguration.xml) was later modified, that change was never propagated back to `ExtendedEmailPublisherDescriptor`.

This change reverts us back to the old (working) design where only additional accounts have a persisted address and the default account has a `null` address, delegating to the Jenkins Location configuration. In order to clear up the bad state that was persisted between 2.72 and 2.77, we unconditionally clear the address for the default account in `ExtendedEmailPublisherDescriptor#readResolve`.

I have added two new tests to verify the correctness of this fix. `ExtendedEmailPublisherTest#testSystemAdminEmailChange` verifies that admin address changes work on the current release, and `ExtendedEmailPublisherDescriptorTest#persistedConfigurationBeforeDefaultAddress` verifies that the persistent state from 2.72 is correctly cleaned up in `ExtendedEmailPublisherDescriptor#readResolve`.