### PR TITLE
Deprecate integration with analysis-core

### DIFF
--- a/src/main/java/hudson/plugins/emailext/plugins/content/StaticAnalysisUtilities.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/StaticAnalysisUtilities.java
@@ -25,6 +25,7 @@ public class StaticAnalysisUtilities {
      * @return The static analysis actions for the specified build. The returned
      * list might be empty if there are no such actions.
      */
+    @Deprecated
     public List<Action> getActions(Run<?, ?> build) {
         ArrayList<Action> actions = new ArrayList<>();
         for (Action action : build.getActions(Action.class)) {

--- a/src/main/resources/hudson/plugins/emailext/templates/static-analysis.jelly
+++ b/src/main/resources/hudson/plugins/emailext/templates/static-analysis.jelly
@@ -414,6 +414,10 @@
               </tr>
             </j:forEach>
           </table>
+          <p>
+            Warning (see JENKINS-55744): Integration with the Static Analysis Utilities plugin has
+            been deprecated in the Email Extension plugin and will be removed in a future release.
+          </p>
         </div>
       </j:if>
 


### PR DESCRIPTION
See [JENKINS-55744](https://issues.jenkins-ci.org/browse/JENKINS-55744). The Static Analysis Utilities (`analysis-core`) plugin has been marked as end-of-life, and the relevant functionality has been integrated into the Warnings Next Generation Plugin (`warnings-ng`) plugin. At some point we will need to drop support for `analysis-core` integration from `email-ext`, ideally after `email-ext` _gains_ integration with `warnings-ng` (pull requests welcome!) to avoid dropping this functionality. This change announces the deprecation to users, directing them to the Jira issue for any further discussion. This way, there will be no surprises when it comes time to drop support for `analysis-core` integration from `email-ext`.