### PR TITLE
Minor test cleanup

### DIFF
--- a/src/test/java/hudson/plugins/emailext/AttachmentUtilsTest.java
+++ b/src/test/java/hudson/plugins/emailext/AttachmentUtilsTest.java
@@ -15,6 +15,8 @@ import hudson.model.FreeStyleProject;
 import hudson.plugins.emailext.plugins.recipients.ListRecipientProvider;
 import hudson.plugins.emailext.plugins.trigger.SuccessTrigger;
 import org.apache.commons.io.IOUtils;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -47,20 +49,23 @@ import static org.junit.Assert.assertTrue;
  */
 public class AttachmentUtilsTest {
 
-    @Rule
-    public final JenkinsRule j = new JenkinsRule() {
-        @Override
-        public void before() throws Throwable {
-            super.before();
-            Mailbox.clearAll();
-            ExtendedEmailPublisherDescriptor descriptor = ExtendedEmailPublisher.descriptor();
-            descriptor.setMailAccount(new MailAccount() {
-                {
-                    setSmtpHost("smtp.notreal.com");
-                }
-            });
-        }
-    };
+    @Rule public JenkinsRule j = new JenkinsRule();
+
+    @Before
+    public void setUp() {
+        ExtendedEmailPublisherDescriptor descriptor = ExtendedEmailPublisher.descriptor();
+        descriptor.setMailAccount(
+                new MailAccount() {
+                    {
+                        setSmtpHost("smtp.notreal.com");
+                    }
+                });
+    }
+
+    @After
+    public void tearDown() {
+        Mailbox.clearAll();
+    }
 
     @Test
     public void testBuildLogAttachment() throws Exception {

--- a/src/test/java/hudson/plugins/emailext/EmailExtStepTest.java
+++ b/src/test/java/hudson/plugins/emailext/EmailExtStepTest.java
@@ -10,6 +10,8 @@ import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
 import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -32,26 +34,23 @@ import static org.junit.Assert.assertTrue;
  */
 public class EmailExtStepTest {
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule()  {
-        @Override
-        public void before() throws Throwable {
-            super.before();
-            ExtendedEmailPublisherDescriptor descriptor = ExtendedEmailPublisher.descriptor();
-            descriptor.setMailAccount(new MailAccount() {
-                {
-                    setSmtpHost("smtp.notreal.com");
-                }
-            });
-            Mailbox.clearAll();
-        }
+    @Rule public JenkinsRule j = new JenkinsRule();
 
-        @Override
-        public void after() throws Exception {
-            super.after();
-            Mailbox.clearAll();
-        }
-    };
+    @Before
+    public void setUp() {
+        ExtendedEmailPublisherDescriptor descriptor = ExtendedEmailPublisher.descriptor();
+        descriptor.setMailAccount(
+                new MailAccount() {
+                    {
+                        setSmtpHost("smtp.notreal.com");
+                    }
+                });
+    }
+
+    @After
+    public void tearDown() {
+        Mailbox.clearAll();
+    }
 
     @Test
     public void configRoundTrip() throws Exception {

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherMatrixTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherMatrixTest.java
@@ -68,7 +68,7 @@ public class ExtendedEmailPublisherMatrixTest {
     }
 
     @Before
-    public void before() throws Exception {
+    public void setUp() throws Exception {
         publisher = new ExtendedEmailPublisher();
         publisher.defaultSubject = "%DEFAULT_SUBJECT";
         publisher.defaultContent = "%DEFAULT_CONTENT";
@@ -79,7 +79,7 @@ public class ExtendedEmailPublisherMatrixTest {
     }
 
     @After
-    public void after() {
+    public void tearDown() {
         Mailbox.clearAll();
     }
 

--- a/src/test/java/hudson/plugins/emailext/plugins/RecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/RecipientProviderTest.java
@@ -8,10 +8,7 @@ import org.hamcrest.CoreMatchers;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.text.MessageFormat;
 import java.util.Arrays;
@@ -21,12 +18,9 @@ import static org.junit.Assert.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.xml.*", "org.apache.xerces.*", "org.xml.sax.*"}) // workaround inspired by https://github.com/powermock/powermock/issues/864#issuecomment-410182836
 public class RecipientProviderTest {
 
-    @Rule
-    private JenkinsRule j = new JenkinsRule();
+    @Rule public JenkinsRule j = new JenkinsRule();
 
     @Test
     public void allSupporting() {

--- a/src/test/java/hudson/plugins/emailext/plugins/content/TriggerNameContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/TriggerNameContentTest.java
@@ -9,6 +9,8 @@ import hudson.plugins.emailext.MailAccount;
 import hudson.plugins.emailext.plugins.EmailTrigger;
 import hudson.plugins.emailext.plugins.RecipientProvider;
 import hudson.plugins.emailext.plugins.trigger.PreBuildTrigger;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -29,32 +31,35 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TriggerNameContentTest {
     private ExtendedEmailPublisher publisher;
     private FreeStyleProject project;
-    
-    @Rule
-    public JenkinsRule j = new JenkinsRule() {
-        @Override
-        public void before() throws Throwable {
-            super.before();
-            ExtendedEmailPublisherDescriptor descriptor = ExtendedEmailPublisher.descriptor();
-            descriptor.setMailAccount(new MailAccount() {
-                {
-                    setSmtpHost("smtp.notreal.com");
-                }
-            });
 
-            Mailbox.clearAll();
-            publisher = new ExtendedEmailPublisher();
-            publisher.defaultSubject = "%DEFAULT_SUBJECT";
-            publisher.defaultContent = "%DEFAULT_CONTENT";
-            publisher.attachmentsPattern = "";
-            publisher.recipientList = "%DEFAULT_RECIPIENTS";
-            publisher.setPresendScript("");
-            publisher.setPostsendScript("");
+    @Rule public JenkinsRule j = new JenkinsRule();
 
-            project = createFreeStyleProject();
-            project.getPublishersList().add(publisher);
-        }
-    };
+    @Before
+    public void setUp() throws Exception {
+        ExtendedEmailPublisherDescriptor descriptor = ExtendedEmailPublisher.descriptor();
+        descriptor.setMailAccount(
+                new MailAccount() {
+                    {
+                        setSmtpHost("smtp.notreal.com");
+                    }
+                });
+
+        publisher = new ExtendedEmailPublisher();
+        publisher.defaultSubject = "%DEFAULT_SUBJECT";
+        publisher.defaultContent = "%DEFAULT_CONTENT";
+        publisher.attachmentsPattern = "";
+        publisher.recipientList = "%DEFAULT_RECIPIENTS";
+        publisher.setPresendScript("");
+        publisher.setPostsendScript("");
+
+        project = j.createFreeStyleProject();
+        project.getPublishersList().add(publisher);
+    }
+
+    @After
+    public void tearDown() {
+        Mailbox.clearAll();
+    }
 
     
     @Test

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/UpstreamComitterRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/UpstreamComitterRecipientProviderTest.java
@@ -36,7 +36,7 @@ public class UpstreamComitterRecipientProviderTest {
     @Rule public JenkinsRule j = new JenkinsRule();
 
     @Before
-    public void before() {
+    public void setUp() {
         ExtendedEmailPublisherDescriptor descriptor = ExtendedEmailPublisher.descriptor();
         descriptor.setMailAccount(
                 new MailAccount() {
@@ -47,7 +47,7 @@ public class UpstreamComitterRecipientProviderTest {
     }
 
     @After
-    public void after() {
+    public void tearDown() {
         Mailbox.clearAll();
     }
 

--- a/src/test/java/hudson/plugins/emailext/plugins/trigger/AbstractScriptTriggerTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/trigger/AbstractScriptTriggerTest.java
@@ -41,7 +41,7 @@ public class AbstractScriptTriggerTest {
     public JenkinsRule j = new JenkinsRule();
 
     @Before
-    public void setup() {
+    public void setUp() {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
                 // otherwise we would need to create users for each email address tested, to bypass SECURITY-372 fix:

--- a/src/test/java/hudson/plugins/emailext/recipients/EmailRecipientUtilsTest.java
+++ b/src/test/java/hudson/plugins/emailext/recipients/EmailRecipientUtilsTest.java
@@ -7,6 +7,7 @@ import hudson.plugins.emailext.ExtendedEmailPublisher;
 import hudson.tasks.Mailer;
 import hudson.util.FormValidation;
 import org.apache.commons.collections.CollectionUtils;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -26,16 +27,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class EmailRecipientUtilsTest {
 
-    @Rule 
-    public JenkinsRule j = new JenkinsRule() {
-        @Override
-        public void before() throws Throwable {
-            emailRecipientUtils = new EmailRecipientUtils();
-            envVars = new EnvVars();
-            super.before();
-        }        
-    };
-    
+    @Rule public JenkinsRule j = new JenkinsRule();
+
+    @Before
+    public void setUp() {
+        emailRecipientUtils = new EmailRecipientUtils();
+        envVars = new EnvVars();
+    }
+
     private EmailRecipientUtils emailRecipientUtils;
     private EnvVars envVars;
 


### PR DESCRIPTION
- Use `@Before` and `@After` methods where possible
- Name `@Before` and `@After` methods consistently
- Minimize use of `PowerMockRunner` where possible
- Remove unnecessary use of reflection where possible