### PR TITLE
[JENKINS-63522] Debug logs are incomplete when From address is invalid

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -508,7 +508,7 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
                                     }
                                     addresses = e.getValidUnsentAddresses();
                                     if (addresses != null && addresses.length > 0) {
-                                        buf = new StringBuilder("Error sending to the following VALID addresses:");
+                                        buf = new StringBuilder("Not sent to the following valid addresses:");
                                         for (Address a : addresses) {
                                             buf.append(' ').append(a);
                                         }
@@ -516,7 +516,7 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
                                     }
                                     addresses = e.getInvalidAddresses();
                                     if (addresses != null && addresses.length > 0) {
-                                        buf = new StringBuilder("Error sending to the following INVALID addresses:");
+                                        buf = new StringBuilder("Could not be sent to the following addresses:");
                                         for (Address a : addresses) {
                                             buf.append(' ').append(a);
                                         }

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -523,7 +523,18 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
                                         context.getListener().getLogger().println(buf);
                                     }
 
-                                    debug(context.getListener().getLogger(), "SendFailedException message: " + e.getMessage());
+                                    debug(context.getListener().getLogger(), e.getClass().getSimpleName() + " message: " + e.getMessage());
+                                    Exception next = e.getNextException();
+                                    while (next != null) {
+                                        debug(
+                                                context.getListener().getLogger(),
+                                                "Next " + next.getClass().getSimpleName() + " message: " + next.getMessage());
+                                        if (next instanceof MessagingException) {
+                                            next = ((MessagingException) next).getNextException();
+                                        } else {
+                                            next = null;
+                                        }
+                                    }
                                     break;
                                 }
                             } catch (MessagingException e) {
@@ -532,7 +543,18 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
                                     transport.close();
                                     Thread.sleep(10000);
                                 } else {
-                                    debug(context.getListener().getLogger(), "MessagingException message: " + e.getMessage());
+                                    debug(context.getListener().getLogger(), e.getClass().getSimpleName() + " message: " + e.getMessage());
+                                    Exception next = e.getNextException();
+                                    while (next != null) {
+                                        debug(
+                                                context.getListener().getLogger(),
+                                                "Next " + next.getClass().getSimpleName() + " message: " + next.getMessage());
+                                        if (next instanceof MessagingException) {
+                                            next = ((MessagingException) next).getNextException();
+                                        } else {
+                                            next = null;
+                                        }
+                                    }
                                     break;
                                 }
                             }


### PR DESCRIPTION
See [JENKINS-63522](https://issues.jenkins-ci.org/browse/JENKINS-63522). When debug logs are enabled and the **From** address is invalid (for example, if the **System Admin e-mail address** has not been configured yet in the **Jenkins Location** section of the **Configure System** page and is still set to the default value of `nobody@nowhere`), the outer [`MessagingException`](https://javaee.github.io/javamail/docs/api/javax/mail/MessagingException.html) (typically a [`SendFailedException`](https://javaee.github.io/javamail/docs/api/javax/mail/SendFailedException.html)) is printed to the debug logs but inner exceptions (e.g., [`SMTPAddressFailedException`](https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/SMTPAddressFailedException.html), [`SMTPSenderFailedException`](https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/SMTPSenderFailedException.html), or [`SMTPSendFailedException`](https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/SMTPSendFailedException.html)) are not. The cause is usually found in an inner exception, so it would be helpful to print the inner exceptions to the debug logs when debug logging is enabled.

To test this change, I reproduced the problem and verified that the inner exception is now printed to the debug logs:

```
Successfully created MimeMessage
Sending email to: test@example.com
Error sending to the following INVALID addresses: test@example.com
SendFailedException message: Invalid Addresses
Next SMTPAddressFailedException message: 553 5.1.8 <test@example.com>... Domain of sender address nobody@nowhere does not exist
```