### PR TITLE
Use Functions.printStackTrace where possible

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -9,6 +9,7 @@ import groovy.lang.GroovyClassLoader;
 import groovy.lang.GroovyShell;
 import hudson.EnvVars;
 import hudson.FilePath;
+import hudson.Functions;
 import hudson.Launcher;
 import hudson.matrix.MatrixAggregatable;
 import hudson.matrix.MatrixAggregator;
@@ -561,7 +562,7 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
                 return true;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Could not send email.", e);
-            e.printStackTrace(context.getListener().error("Could not send email as a part of the post-build publishers."));
+            Functions.printStackTrace(e, context.getListener().error("Could not send email as a part of the post-build publishers."));
         }
 
         debug(context.getListener().getLogger(), "Some error occurred trying to send the email...check the Jenkins log");
@@ -642,7 +643,7 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
                 logger.println(StringUtils.capitalize(scriptName) + " script tried to access secured objects: " + e.getMessage());
                 throw e;
             } catch (Throwable t) {
-                t.printStackTrace(pw);
+                Functions.printStackTrace(t, pw);
                 logger.println(out.toString());
                 // should we cancel the sending of the email???
             }

--- a/src/main/java/hudson/plugins/emailext/plugins/content/ScriptContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/ScriptContent.java
@@ -7,6 +7,7 @@ import groovy.lang.Script;
 import groovy.text.SimpleTemplateEngine;
 import groovy.text.Template;
 import hudson.FilePath;
+import hudson.Functions;
 import hudson.model.Item;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -167,7 +168,7 @@ public class ScriptContent extends AbstractEvalContent {
         } catch(Exception e) {
             StringWriter sw = new StringWriter();
             PrintWriter pw = new PrintWriter(sw);
-            e.printStackTrace(pw);
+            Functions.printStackTrace(e, pw);
             result = "Exception raised during template rendering: " + e.getMessage() + "\n\n" + sw.toString();
         }
         return result;

--- a/src/main/java/hudson/plugins/emailext/plugins/trigger/AbstractScriptTrigger.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/trigger/AbstractScriptTrigger.java
@@ -2,6 +2,7 @@ package hudson.plugins.emailext.plugins.trigger;
 
 import groovy.lang.Binding;
 import groovy.lang.GroovyShell;
+import hudson.Functions;
 import hudson.model.AbstractBuild;
 import hudson.model.Item;
 import hudson.model.TaskListener;
@@ -97,7 +98,7 @@ public abstract class AbstractScriptTrigger extends EmailTrigger {
                     result = (Boolean) res;
                 }
             } catch (IOException e) {
-                e.printStackTrace(listener.fatalError("Failed evaluating script trigger %s%n", e.getMessage()));
+                Functions.printStackTrace(e, listener.fatalError("Failed evaluating script trigger %s%n", e.getMessage()));
             }
         }
         return result;

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
@@ -1357,7 +1357,7 @@ public class ExtendedEmailPublisherTest {
         }
     }
 
-    private void addEmailType(EmailTrigger trigger) {
+    private static void addEmailType(EmailTrigger trigger) {
         trigger.setEmail(new EmailType() {
             {
                 setRecipientList("ashlux@gmail.com");


### PR DESCRIPTION
Use the `printStackTrace` methods from [`hudson.Functions`](https://javadoc.jenkins.io/hudson/Functions.html) where possible for consistency with how Jenkins prints stack traces elsewhere.

Tested that the change to line 646 of `ExtendedEmailPublisher` works by hitting the following breakpoint while running integration tests:

```
executeScript:646, ExtendedEmailPublisher (hudson.plugins.emailext)
executePresendScript:580, ExtendedEmailPublisher (hudson.plugins.emailext)
sendMail:460, ExtendedEmailPublisher (hudson.plugins.emailext)
_perform:442, ExtendedEmailPublisher (hudson.plugins.emailext)
perform:350, ExtendedEmailPublisher (hudson.plugins.emailext)
perform:20, BuildStepMonitor$1 (hudson.tasks)
perform:744, AbstractBuild$AbstractBuildExecution (hudson.model)
performAllBuildSteps:690, AbstractBuild$AbstractBuildExecution (hudson.model)
cleanUp:196, Build$BuildExecution (hudson.model)
execute:1863, Run (hudson.model)
run:43, FreeStyleBuild (hudson.model)
execute:97, ResourceController (hudson.model)
run:429, Executor (hudson.model)
```