### PR TITLE
Add additional debug logging when valid mail account cannot be found

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -25,13 +25,14 @@ import org.jenkinsci.plugins.scriptsecurity.scripts.ApprovalContext;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ClasspathEntry;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.jenkinsci.plugins.scriptsecurity.scripts.languages.GroovyLanguage;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 
 import javax.mail.Authenticator;
-import javax.mail.MessagingException;
 import javax.mail.PasswordAuthentication;
 import javax.mail.Session;
 import javax.mail.internet.AddressException;
@@ -285,22 +286,9 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
         this.defaultSuffix = Util.fixEmptyAndTrim(defaultSuffix);
     }
 
-    public Session createSession(String from) throws MessagingException {
+    @Restricted(NoExternalUse.class)
+    Session createSession(MailAccount acc) {
         Properties props = new Properties(System.getProperties());
-
-        MailAccount acc = mailAccount;
-        if(StringUtils.isNotBlank(from)){
-            InternetAddress fromAddress = new InternetAddress(from);
-            for(MailAccount ma : addAccounts) {
-                if(ma == null || !ma.isValid() || !ma.getAddress().equalsIgnoreCase(fromAddress.getAddress())) continue;
-                acc = ma;
-                break;
-            }
-        }
-
-        if(!acc.isValid()) {
-            return null;
-        }
 
         if (acc.getSmtpHost() != null) {
             props.put("mail.smtp.host", acc.getSmtpHost());

--- a/src/main/java/hudson/plugins/emailext/MailAccount.java
+++ b/src/main/java/hudson/plugins/emailext/MailAccount.java
@@ -42,7 +42,20 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount>{
     }
 
     public boolean isValid() {
-        return (isDefaultAccount() || StringUtils.isNotBlank(address)) && StringUtils.isNotBlank(smtpHost) && (!isAuth() || (StringUtils.isNotBlank(smtpUsername) && smtpPassword != null));
+        return isFromAddressValid() && isSmtpServerValid() && isSmtpAuthValid();
+    }
+
+    public boolean isFromAddressValid() {
+        return isDefaultAccount() || StringUtils.isNotBlank(address);
+    }
+
+    public boolean isSmtpServerValid() {
+        return StringUtils.isNotBlank(smtpHost);
+    }
+
+    public boolean isSmtpAuthValid() {
+        return StringUtils.isBlank(smtpUsername)
+                || (StringUtils.isNotBlank(smtpUsername) && smtpPassword != null);
     }
 
     public boolean isDefaultAccount() {
@@ -59,10 +72,6 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount>{
         public String getDisplayName(){
             return "";
         }
-    }
-
-    public boolean isAuth(){
-        return smtpUsername != null;
     }
 
     public String getAddress(){

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
@@ -402,7 +402,7 @@ public class ExtendedEmailPublisherDescriptorTest {
         descriptor.setAddAccounts(Collections.singletonList(ma));
         Function<MailAccount, Authenticator> authenticatorProvider = Mockito.mock(Function.class);
         descriptor.setAuthenticatorProvider(authenticatorProvider);
-        descriptor.createSession(from);
+        descriptor.createSession(ma);
         ArgumentCaptor<MailAccount> mailAccountCaptor = ArgumentCaptor.forClass(MailAccount.class);
         Mockito.verify(authenticatorProvider, Mockito.times(1)).apply(mailAccountCaptor.capture());
         assertNotNull(mailAccountCaptor.getValue());
@@ -422,7 +422,7 @@ public class ExtendedEmailPublisherDescriptorTest {
         descriptor.setAddAccounts(Collections.singletonList(ma));
         Function<MailAccount, Authenticator> authenticatorProvider = Mockito.mock(Function.class);
         descriptor.setAuthenticatorProvider(authenticatorProvider);
-        descriptor.createSession(from);
+        descriptor.createSession(ma);
         ArgumentCaptor<MailAccount> mailAccountCaptor = ArgumentCaptor.forClass(MailAccount.class);
         Mockito.verify(authenticatorProvider, Mockito.times(1)).apply(mailAccountCaptor.capture());
         assertNotNull(mailAccountCaptor.getValue());
@@ -442,7 +442,7 @@ public class ExtendedEmailPublisherDescriptorTest {
         descriptor.setAddAccounts(Collections.singletonList(ma));
         Function<MailAccount, Authenticator> authenticatorProvider = Mockito.mock(Function.class);
         descriptor.setAuthenticatorProvider(authenticatorProvider);
-        descriptor.createSession(from);
+        descriptor.createSession(ma);
         ArgumentCaptor<MailAccount> mailAccountCaptor = ArgumentCaptor.forClass(MailAccount.class);
         Mockito.verify(authenticatorProvider, Mockito.never()).apply(mailAccountCaptor.capture());
     }

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
@@ -11,6 +11,7 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.Result;
+import hudson.model.TaskListener;
 import hudson.model.User;
 import hudson.plugins.emailext.plugins.EmailTrigger;
 import hudson.plugins.emailext.plugins.RecipientProvider;
@@ -1167,7 +1168,9 @@ public class ExtendedEmailPublisherTest {
                 form.put("project_from", "mail@test1.com");
                 publisher = (ExtendedEmailPublisher) descriptor.newInstance(Stapler.getCurrentRequest(), form);
                 assertEquals("mail@test1.com", publisher.from);
-                Session session = descriptor.createSession(publisher.from);
+                ExtendedEmailPublisherContext context =
+                        new ExtendedEmailPublisherContext(publisher, null, null, null, TaskListener.NULL);
+                Session session = descriptor.createSession(publisher.getMailAccount(context));
                 assertEquals("smtp.test0.com", session.getProperty("mail.smtp.host"));
                 assertEquals("587", session.getProperty("mail.smtp.port"));
                 assertEquals("test0.com", session.getProperty("mail.smtp.ssl.trust"));
@@ -1188,7 +1191,7 @@ public class ExtendedEmailPublisherTest {
 
                 publisher = (ExtendedEmailPublisher) descriptor.newInstance(Stapler.getCurrentRequest(), form);
                 assertEquals("mail@test1.com", publisher.from);
-                session = descriptor.createSession(publisher.from);
+                session = descriptor.createSession(publisher.getMailAccount(context));
                 assertEquals("smtp.test1.com", session.getProperty("mail.smtp.host"));
                 assertEquals("25", session.getProperty("mail.smtp.port"));
                 assertEquals("test1.com", session.getProperty("mail.smtp.ssl.trust"));
@@ -1196,7 +1199,7 @@ public class ExtendedEmailPublisherTest {
                 form.put("project_from", "mail@test2.com");
                 publisher = (ExtendedEmailPublisher) descriptor.newInstance(Stapler.getCurrentRequest(), form);
                 assertEquals("mail@test2.com", publisher.from);
-                session = descriptor.createSession(publisher.from);
+                session = descriptor.createSession(publisher.getMailAccount(context));
                 assertEquals("smtp.test2.com", session.getProperty("mail.smtp.host"));
                 assertEquals("465", session.getProperty("mail.smtp.port"));
                 assertEquals("test2.com", session.getProperty("mail.smtp.ssl.trust"));


### PR DESCRIPTION
See [JENKINS-64095](https://issues.jenkins-ci.org/browse/JENKINS-64095). #217 added more draconian enforcement of valid mail accounts. At least one user has encountered an invalid mail account and been unable to send mail. One possible area of concern is the check for `smtpUsername != null`, which would erroneously classify a mail account with an empty (not null!) SMTP username as invalid. More generally, users need a way to debug invalid mail account failures. This change adds detailed debug logs covering mail account selection and mail account validation, with which a user who encounters an invalid mail account failure can get detailed information about what is wrong with their mail account.