### PR TITLE
[JENKINS-64141] Restore localhost as default SMTP server

### DIFF
--- a/src/main/java/hudson/plugins/emailext/MailAccount.java
+++ b/src/main/java/hudson/plugins/emailext/MailAccount.java
@@ -50,7 +50,10 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount>{
     }
 
     public boolean isSmtpServerValid() {
-        return StringUtils.isNotBlank(smtpHost);
+        return true;
+        // Note: having no SMTP server is fine, it means localhost.
+        // More control could be implemented here when not null though,
+        // like checking the value looks like an FQDN or IP address.
     }
 
     public boolean isSmtpAuthValid() {

--- a/src/test/java/hudson/plugins/emailext/AttachmentUtilsTest.java
+++ b/src/test/java/hudson/plugins/emailext/AttachmentUtilsTest.java
@@ -16,7 +16,6 @@ import hudson.plugins.emailext.plugins.recipients.ListRecipientProvider;
 import hudson.plugins.emailext.plugins.trigger.SuccessTrigger;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -50,17 +49,6 @@ import static org.junit.Assert.assertTrue;
 public class AttachmentUtilsTest {
 
     @Rule public JenkinsRule j = new JenkinsRule();
-
-    @Before
-    public void setUp() {
-        ExtendedEmailPublisherDescriptor descriptor = ExtendedEmailPublisher.descriptor();
-        descriptor.setMailAccount(
-                new MailAccount() {
-                    {
-                        setSmtpHost("smtp.notreal.com");
-                    }
-                });
-    }
 
     @After
     public void tearDown() {

--- a/src/test/java/hudson/plugins/emailext/EmailExtStepTest.java
+++ b/src/test/java/hudson/plugins/emailext/EmailExtStepTest.java
@@ -11,7 +11,6 @@ import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepEx
 import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -35,17 +34,6 @@ import static org.junit.Assert.assertTrue;
 public class EmailExtStepTest {
 
     @Rule public JenkinsRule j = new JenkinsRule();
-
-    @Before
-    public void setUp() {
-        ExtendedEmailPublisherDescriptor descriptor = ExtendedEmailPublisher.descriptor();
-        descriptor.setMailAccount(
-                new MailAccount() {
-                    {
-                        setSmtpHost("smtp.notreal.com");
-                    }
-                });
-    }
 
     @After
     public void tearDown() {

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherMatrixTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherMatrixTest.java
@@ -50,14 +50,6 @@ public class ExtendedEmailPublisherMatrixTest {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
-        ExtendedEmailPublisherDescriptor descriptor = ExtendedEmailPublisher.descriptor();
-        descriptor.setMailAccount(
-                new MailAccount() {
-                    {
-                        setSmtpHost("smtp.notreal.com");
-                    }
-                });
-
         agents = new ArrayList<>();
         // TODO Windows ACI agents do not have enough memory to run this test.
         if (!Functions.isWindows()) {

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
@@ -97,14 +97,6 @@ public class ExtendedEmailPublisherTest {
 
     @Before
     public void setUp() throws Exception {
-        ExtendedEmailPublisherDescriptor descriptor = ExtendedEmailPublisher.descriptor();
-        descriptor.setMailAccount(
-                new MailAccount() {
-                    {
-                        setSmtpHost("smtp.notreal.com");
-                    }
-                });
-
         publisher = new ExtendedEmailPublisher();
         publisher.from = "";
         publisher.contentType = "default";

--- a/src/test/java/hudson/plugins/emailext/plugins/content/ScriptContentSecureTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/ScriptContentSecureTest.java
@@ -25,9 +25,6 @@
 package hudson.plugins.emailext.plugins.content;
 
 import hudson.model.Item;
-import hudson.plugins.emailext.ExtendedEmailPublisher;
-import hudson.plugins.emailext.ExtendedEmailPublisherDescriptor;
-import hudson.plugins.emailext.MailAccount;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.junit.Before;
@@ -47,13 +44,6 @@ public class ScriptContentSecureTest extends ScriptContentTest {
 
     @Before
     public void setup() {
-        ExtendedEmailPublisherDescriptor descriptor = ExtendedEmailPublisher.descriptor();
-        descriptor.setMailAccount(new MailAccount() {
-            {
-                setSmtpHost("smtp.notreal.com");
-            }
-        });
-
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
 
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()

--- a/src/test/java/hudson/plugins/emailext/plugins/content/ScriptContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/ScriptContentTest.java
@@ -14,7 +14,6 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.plugins.emailext.ExtendedEmailPublisher;
 import hudson.plugins.emailext.ExtendedEmailPublisherDescriptor;
-import hudson.plugins.emailext.MailAccount;
 import hudson.plugins.emailext.plugins.recipients.ListRecipientProvider;
 import hudson.plugins.emailext.plugins.trigger.SuccessTrigger;
 import hudson.util.DescribableList;
@@ -63,12 +62,6 @@ public class ScriptContentTest {
         @Override
         public void before() throws Throwable {
             super.before();
-            ExtendedEmailPublisherDescriptor descriptor = ExtendedEmailPublisher.descriptor();
-            descriptor.setMailAccount(new MailAccount() {
-                {
-                    setSmtpHost("smtp.notreal.com");
-                }
-            });
 
             Mailbox.clearAll();
             

--- a/src/test/java/hudson/plugins/emailext/plugins/content/TriggerNameContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/TriggerNameContentTest.java
@@ -4,8 +4,6 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.plugins.emailext.EmailType;
 import hudson.plugins.emailext.ExtendedEmailPublisher;
-import hudson.plugins.emailext.ExtendedEmailPublisherDescriptor;
-import hudson.plugins.emailext.MailAccount;
 import hudson.plugins.emailext.plugins.EmailTrigger;
 import hudson.plugins.emailext.plugins.RecipientProvider;
 import hudson.plugins.emailext.plugins.trigger.PreBuildTrigger;
@@ -36,14 +34,6 @@ public class TriggerNameContentTest {
 
     @Before
     public void setUp() throws Exception {
-        ExtendedEmailPublisherDescriptor descriptor = ExtendedEmailPublisher.descriptor();
-        descriptor.setMailAccount(
-                new MailAccount() {
-                    {
-                        setSmtpHost("smtp.notreal.com");
-                    }
-                });
-
         publisher = new ExtendedEmailPublisher();
         publisher.defaultSubject = "%DEFAULT_SUBJECT";
         publisher.defaultContent = "%DEFAULT_CONTENT";

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/UpstreamComitterRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/UpstreamComitterRecipientProviderTest.java
@@ -11,13 +11,10 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
 import hudson.model.Result;
 import hudson.plugins.emailext.ExtendedEmailPublisher;
-import hudson.plugins.emailext.ExtendedEmailPublisherDescriptor;
-import hudson.plugins.emailext.MailAccount;
 import hudson.plugins.emailext.plugins.trigger.SuccessTrigger;
 import hudson.tasks.BuildTrigger;
 
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.FakeChangeLogSCM;
@@ -34,17 +31,6 @@ import java.util.List;
 public class UpstreamComitterRecipientProviderTest {
 
     @Rule public JenkinsRule j = new JenkinsRule();
-
-    @Before
-    public void setUp() {
-        ExtendedEmailPublisherDescriptor descriptor = ExtendedEmailPublisher.descriptor();
-        descriptor.setMailAccount(
-                new MailAccount() {
-                    {
-                        setSmtpHost("smtp.notreal.com");
-                    }
-                });
-    }
 
     @After
     public void tearDown() {


### PR DESCRIPTION
See [JENKINS-64141](https://issues.jenkins.io/browse/JENKINS-64141).

This is a very minimal change to restore a pre-2.79 behavior: having no SMTP server address (the default setting) means `localhost` will be used, which is often the right choice.
I've kept the `MailAccount.isSmtpServerValid()` method around, because it could still be a place to implement other controls (like checking that the value, if any, looks like an FQDN or IP address), but it now always returns `true`.