### PR TITLE
Update Jenkins baseline, switch to jackson2-api, eliminate reflection, and test against latest LTS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,9 +8,9 @@ buildPlugin(useAci: true, configurations: [
   [ platform: 'linux', jdk: '8', jenkins: null ],
 
   // Test the common case (i.e., a recent LTS release) on both Linux and Windows.
-  [ platform: 'linux', jdk: '8', jenkins: '2.263.1', javaLevel: '8' ],
-  [ platform: 'windows', jdk: '8', jenkins: '2.263.1', javaLevel: '8' ],
+  [ platform: 'linux', jdk: '8', jenkins: '2.263.1' ],
+  [ platform: 'windows', jdk: '8', jenkins: '2.263.1' ],
 
   // Test the bleeding edge of the compatibility spectrum (i.e., the latest supported Java runtime).
-  [ platform: 'linux', jdk: '11', jenkins: '2.263.1', javaLevel: '8' ],
+  [ platform: 'linux', jdk: '11', jenkins: '2.263.1' ],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,9 +8,9 @@ buildPlugin(useAci: true, configurations: [
   [ platform: 'linux', jdk: '8', jenkins: null ],
 
   // Test the common case (i.e., a recent LTS release) on both Linux and Windows.
-  [ platform: 'linux', jdk: '8', jenkins: '2.249.2', javaLevel: '8' ],
-  [ platform: 'windows', jdk: '8', jenkins: '2.249.2', javaLevel: '8' ],
+  [ platform: 'linux', jdk: '8', jenkins: '2.263.1', javaLevel: '8' ],
+  [ platform: 'windows', jdk: '8', jenkins: '2.263.1', javaLevel: '8' ],
 
   // Test the bleeding edge of the compatibility spectrum (i.e., the latest supported Java runtime).
-  [ platform: 'linux', jdk: '11', jenkins: '2.249.2', javaLevel: '8' ],
+  [ platform: 'linux', jdk: '11', jenkins: '2.263.1', javaLevel: '8' ],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -33,12 +33,12 @@
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/email-ext-plugin</gitHubRepo>
         <java.level>8</java.level>
-        <jenkins.version>2.164.3</jenkins.version>
+        <jenkins.version>2.222.4</jenkins.version>
         <hpi.compatibleSinceVersion>2.57.2</hpi.compatibleSinceVersion>
         <concurrency>1</concurrency>
         <argLine>-Dfile.encoding=UTF-8</argLine>
-        <configuration-as-code.version>1.36</configuration-as-code.version>
-        <jackson.version>2.11.3</jackson.version>
+        <!-- To be removed once Jenkins.MANAGE gets out of beta -->
+        <useBeta>true</useBeta>
     </properties>
 
     <developers>
@@ -110,8 +110,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.164.x</artifactId>
-                <version>10</version>
+                <artifactId>bom-2.222.x</artifactId>
+                <version>18</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -136,18 +136,12 @@
             <artifactId>jericho-html</artifactId>
             <version>3.4</version>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
 
         <!-- other plugins -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jackson2-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
@@ -290,13 +284,11 @@
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
-            <version>${configuration-as-code.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.jenkins.configuration-as-code</groupId>
             <artifactId>test-harness</artifactId>
-            <version>${configuration-as-code.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -13,7 +13,6 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
-import hudson.util.ReflectionUtils;
 import hudson.util.Secret;
 import hudson.Util;
 import jenkins.model.Jenkins;
@@ -41,7 +40,6 @@ import javax.servlet.ServletException;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.StringReader;
-import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -805,21 +803,9 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
     }
 
     @NonNull
-    //Not overriding until the core base is 2.222.1
-    //@Override
+    @Override
     public Permission getRequiredGlobalConfigPagePermission() {
-        return getJenkinsManageOrAdmin();
-    }
-
-    // TODO: remove when Jenkins core baseline is 2.222+
-    Permission getJenkinsManageOrAdmin() {
-        Permission manage;
-        try { // Manage is available starting from Jenkins 2.222 (https://jenkins.io/changelog/#v2.222). See JEP-224 for more info
-            manage = (Permission) ReflectionUtils.getPublicProperty(Jenkins.get(), "MANAGE");
-        } catch (IllegalArgumentException | InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
-            manage = Jenkins.ADMINISTER;
-        }
-        return manage;
+        return Jenkins.MANAGE;
     }
 
     Function<MailAccount, Authenticator> getAuthenticatorProvider() {

--- a/src/main/resources/hudson/plugins/emailext/EmailExtTemplateAction/action.groovy
+++ b/src/main/resources/hudson/plugins/emailext/EmailExtTemplateAction/action.groovy
@@ -1,7 +1,7 @@
 def l = namespace(lib.LayoutTagLib)
 
 def requiresAdmin = app.getDescriptor('hudson.plugins.emailext.ExtendedEmailPublisher').adminRequiredForTemplateTesting
-def hasPermission = requiresAdmin ? h.hasPermission(app.getDescriptor("hudson.plugins.emailext.ExtendedEmailPublisher").getJenkinsManageOrAdmin()) : h.hasPermission(this.action.project, this.action.project.CONFIGURE)
+def hasPermission = requiresAdmin ? h.hasPermission(app.MANAGE) : h.hasPermission(this.action.project, this.action.project.CONFIGURE)
 
 if(hasPermission) {
     l.task(icon: "/plugin/email-ext/images/template-debugger.png", title: this.action.displayName, 

--- a/src/main/resources/hudson/plugins/emailext/EmailExtTemplateAction/index.groovy
+++ b/src/main/resources/hudson/plugins/emailext/EmailExtTemplateAction/index.groovy
@@ -9,7 +9,7 @@ def d = namespace("jelly:define")
 import hudson.Functions
 
 def requiresAdmin = app.getDescriptor("hudson.plugins.emailext.ExtendedEmailPublisher").adminRequiredForTemplateTesting
-def hasPermission = requiresAdmin ? hudson.Functions.hasPermission(app.getDescriptor("hudson.plugins.emailext.ExtendedEmailPublisher").getJenkinsManageOrAdmin()) : hudson.Functions.hasPermission(it.project, it.project.CONFIGURE);
+def hasPermission = requiresAdmin ? hudson.Functions.hasPermission(app.MANAGE) : hudson.Functions.hasPermission(it.project, it.project.CONFIGURE);
 l.layout {
     st.include(it: my.project, page: "sidepanel")
     l.main_panel {

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
@@ -37,11 +37,8 @@ import hudson.plugins.emailext.plugins.trigger.UnstableTrigger;
 import hudson.plugins.emailext.plugins.trigger.XNthFailureTrigger;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
-import hudson.security.Permission;
-import hudson.util.ReflectionUtils;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -51,7 +48,6 @@ import org.jvnet.hudson.test.recipes.LocalData;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -352,13 +348,6 @@ public class ExtendedEmailPublisherDescriptorTest {
 
     @Test
     public void managePermissionShouldAccess() {
-        Permission jenkinsManage;
-        try {
-            jenkinsManage = getJenkinsManage();
-        } catch (Exception e) {
-            Assume.assumeTrue("Jenkins baseline is too old for this test (requires Jenkins.MANAGE)", false);
-            return;
-        }
         final String USER = "user";
         final String MANAGER = "manager";
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
@@ -368,7 +357,7 @@ public class ExtendedEmailPublisherDescriptorTest {
 
                 // Read and Manage
                 .grant(Jenkins.READ).everywhere().to(MANAGER)
-                .grant(jenkinsManage).everywhere().to(MANAGER)
+                .grant(Jenkins.MANAGE).everywhere().to(MANAGER)
         );
         try (ACLContext c = ACL.as(User.getById(USER, true))) {
             Collection<Descriptor> descriptors = Functions.getSortedDescriptorsForGlobalConfigUnclassified();
@@ -379,12 +368,6 @@ public class ExtendedEmailPublisherDescriptorTest {
             Optional<Descriptor> found = descriptors.stream().filter(descriptor -> descriptor instanceof ExtendedEmailPublisherDescriptor).findFirst();
             assertTrue("Global configuration should be accessible to MANAGE users", found.isPresent());
         }
-    }
-
-    // TODO: remove when Jenkins core baseline is 2.222+
-    private Permission getJenkinsManage() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-        // Jenkins.MANAGE is available starting from Jenkins 2.222 (https://jenkins.io/changelog/#v2.222). See JEP-223 for more info
-        return (Permission) ReflectionUtils.getPublicProperty(Jenkins.get(), "MANAGE");
     }
 
     @Test


### PR DESCRIPTION
- Update the Jenkins baseline to 2.222.x, including updating to the latest plugin BOM.
- Depend on the `jackson2-api` plugin rather than directly on Jackson as suggested in [#229 (comment)](https://github.com/jenkinsci/email-ext-plugin/pull/229#pullrequestreview-515207359).
- Now that the baseline is 2.222.x, remove the no-longer-necessary use of reflection introduced in #208.
- Update the `Jenkinsfile` to test against the latest LTS release.