### PR TITLE
[JENKINS-64629] Fix uncaught exception for unauthorized users

### DIFF
--- a/src/main/java/hudson/plugins/emailext/plugins/recipients/RecipientProviderUtilities.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/recipients/RecipientProviderUtilities.java
@@ -37,7 +37,7 @@ import hudson.tasks.MailSender;
 import jenkins.model.Jenkins;
 import jenkins.scm.RunWithSCM;
 import org.acegisecurity.Authentication;
-import org.acegisecurity.userdetails.UsernameNotFoundException;
+import org.acegisecurity.AuthenticationException;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import javax.mail.internet.InternetAddress;
@@ -177,7 +177,7 @@ public final class RecipientProviderUtilities {
                                     continue;
                                 }
                             }
-                        } catch (UsernameNotFoundException x) {
+                        } catch (AuthenticationException x) {
                             
                             if (SEND_TO_UNKNOWN_USERS || ExtendedEmailPublisher.descriptor().isAllowUnregisteredEnabled() ) {
                                 listener.getLogger().printf("Warning: %s is not a recognized user, but sending mail anyway%n", userAddress);


### PR DESCRIPTION
When attempting to email a user with a locked, disabled, or otherwise unauthorized account, different types of AuthenticationException were not caught which would cause the mail to fail.

https://issues.jenkins.io/browse/JENKINS-64629

Related to similar update in https://github.com/jenkinsci/mailer-plugin/pull/104

@jeffret-b @basil @jglick @l3ender