### PR TITLE
[FIX JENKINS-5206] Configuration to use TLS

### DIFF
--- a/src/main/java/hudson/plugins/emailext/MailAccount.java
+++ b/src/main/java/hudson/plugins/emailext/MailAccount.java
@@ -17,6 +17,7 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount>{
     private String smtpUsername;
     private Secret smtpPassword;
     private boolean useSsl;
+    private boolean useTls;
     private String advProperties;
     private boolean defaultAccount;
 
@@ -33,6 +34,7 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount>{
             }
         }
         useSsl = jo.optBoolean("useSsl", false);
+        useTls = jo.optBoolean("useTls", false);
         advProperties = Util.nullify(jo.optString("advProperties", null));
     }
 
@@ -133,6 +135,15 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount>{
     @DataBoundSetter
     public void setUseSsl(boolean useSsl){
         this.useSsl = useSsl;
+    }
+
+    public boolean isUseTls(){
+        return useTls;
+    }
+
+    @DataBoundSetter
+    public void setUseTls(boolean useTls){
+        this.useTls = useTls;
     }
 
     public String getAdvProperties(){

--- a/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/global_zh_TW.properties
+++ b/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/global_zh_TW.properties
@@ -30,6 +30,7 @@ Use\ SMTP\ Authentication=\u4f7f\u7528 SMTP \u8a8d\u8b49
 User\ Name=\u4f7f\u7528\u8005\u540d\u7a31
 Password=\u5bc6\u78bc
 Use\ SSL=\u4f7f\u7528 SSL
+Use\ TLS=\u4f7f\u7528 TLS
 SMTP\ port=SMTP \u9023\u63a5\u57e0
 Charset=\u5b57\u5143\u96c6
 

--- a/src/main/resources/hudson/plugins/emailext/MailAccount/config.groovy
+++ b/src/main/resources/hudson/plugins/emailext/MailAccount/config.groovy
@@ -29,6 +29,9 @@ f.advanced {
     f.entry(field: "useSsl", title: _("Use SSL")) {
         f.checkbox()
     }
+    f.entry(field: "useTls", title: _("Use TLS")) {
+        f.checkbox()
+    }
     f.entry(field: "advProperties", title: _("Advanced Email Properties")) {
         f.textarea()
     }

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorJCasCTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorJCasCTest.java
@@ -43,6 +43,7 @@ public class ExtendedEmailPublisherDescriptorJCasCTest {
         assertEquals("smtp-username", account.getSmtpUsername());
         assertEquals("smtp-password", account.getSmtpPassword().getPlainText());
         assertTrue(account.isUseSsl());
+        assertTrue(account.isUseTls());
         assertEquals("avd-properties", account.getAdvProperties());
 
         assertEquals("UTF-8", descriptor.getCharset());
@@ -60,6 +61,7 @@ public class ExtendedEmailPublisherDescriptorJCasCTest {
         assertEquals("smtp-password-xyz", account.getSmtpPassword().getPlainText());
         assertEquals("adv-properties-xyz", account.getAdvProperties());
         assertTrue(account.isUseSsl());
+        assertTrue(account.isUseTls());
 
         assertEquals("first-account@domain.extension", descriptor.getDefaultRecipients());
         assertEquals("@domain.extension", descriptor.getAllowedDomains());

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
@@ -576,6 +576,8 @@ public class ExtendedEmailPublisherDescriptorTest {
         advProperties.setText("mail.smtp.ssl.trust=example.com");
         HtmlCheckBoxInput smtpUseSsl = page.getElementByName("ext_mailer_smtp_use_ssl");
         smtpUseSsl.click();
+        HtmlCheckBoxInput smtpUseTls = page.getElementByName("ext_mailer_smtp_use_tls");
+        smtpUseTls.click();
         HtmlTextInput smtpPort = page.getElementByName("ext_mailer_smtp_port");
         smtpPort.setValueAttribute("2525");
         HtmlTextInput charset = page.getElementByName("ext_mailer_charset");
@@ -592,6 +594,8 @@ public class ExtendedEmailPublisherDescriptorTest {
         smtpPassword2.setValueAttribute("honeycomb2");
         HtmlCheckBoxInput smtpUseSsl2 = page.getElementByName("_.useSsl");
         smtpUseSsl2.click();
+        HtmlCheckBoxInput smtpUseTls2 = page.getElementByName("_.useTls");
+        smtpUseTls2.click();
         HtmlTextArea advProperties2 = page.getElementByName("_.advProperties");
         advProperties2.setText("mail.smtp.ssl.trust=example2.com");
         HtmlSelect defaultContentType = page.getElementByName("ext_mailer_default_content_type");
@@ -651,6 +655,7 @@ public class ExtendedEmailPublisherDescriptorTest {
         assertEquals(Secret.fromString("honeycomb"), descriptor.getMailAccount().getSmtpPassword());
         assertEquals("mail.smtp.ssl.trust=example.com", descriptor.getMailAccount().getAdvProperties());
         assertTrue(descriptor.getMailAccount().isUseSsl());
+        assertTrue(descriptor.getMailAccount().isUseTls());
         assertTrue(descriptor.getMailAccount().isDefaultAccount());
         assertEquals("2525", descriptor.getMailAccount().getSmtpPort());
         assertEquals("UTF-8", descriptor.getCharset());
@@ -662,6 +667,7 @@ public class ExtendedEmailPublisherDescriptorTest {
         assertEquals("admin2", additionalAccount.getSmtpUsername());
         assertEquals(Secret.fromString("honeycomb2"), additionalAccount.getSmtpPassword());
         assertTrue(additionalAccount.isUseSsl());
+        assertTrue(additionalAccount.isUseTls());
         assertFalse(additionalAccount.isDefaultAccount());
         assertEquals("mail.smtp.ssl.trust=example2.com", additionalAccount.getAdvProperties());
         assertEquals("text/html", descriptor.getDefaultContentType());
@@ -791,6 +797,9 @@ public class ExtendedEmailPublisherDescriptorTest {
         List<DomElement> smtpUseSsls = page.getElementsByName("_.useSsl");
         HtmlCheckBoxInput smtpUseSsl = (HtmlCheckBoxInput) smtpUseSsls.get(0);
         smtpUseSsl.click();
+        List<DomElement> smtpUseTlss = page.getElementsByName("_.useTls");
+        HtmlCheckBoxInput smtpUseTls = (HtmlCheckBoxInput) smtpUseTlss.get(0);
+        smtpUseTls.click();
         List<DomElement> advPropertiesElements = page.getElementsByName("_.advProperties");
         HtmlTextArea advProperties = (HtmlTextArea) advPropertiesElements.get(0);
         advProperties.setText("mail.smtp.ssl.trust=example.com");
@@ -811,6 +820,8 @@ public class ExtendedEmailPublisherDescriptorTest {
         smtpPassword2.setValueAttribute("honeycomb2");
         HtmlCheckBoxInput smtpUseSsl2 = (HtmlCheckBoxInput) smtpUseSsls.get(1);
         smtpUseSsl2.click();
+        HtmlCheckBoxInput smtpUseTls2 = (HtmlCheckBoxInput) smtpUseTlss.get(1);
+        smtpUseTls2.click();
         HtmlTextArea advProperties2 = (HtmlTextArea) advPropertiesElements.get(1);
         advProperties2.setText("mail.smtp.ssl.trust=example2.com");
         HtmlSelect defaultContentType = page.getElementByName("_.defaultContentType");
@@ -868,6 +879,7 @@ public class ExtendedEmailPublisherDescriptorTest {
         assertEquals(Secret.fromString("honeycomb"), descriptor.getMailAccount().getSmtpPassword());
         assertEquals("mail.smtp.ssl.trust=example.com", descriptor.getMailAccount().getAdvProperties());
         assertTrue(descriptor.getMailAccount().isUseSsl());
+        assertTrue(descriptor.getMailAccount().isUseTls());
         assertTrue(descriptor.getMailAccount().isDefaultAccount());
         assertEquals("2525", descriptor.getMailAccount().getSmtpPort());
         assertEquals("UTF-8", descriptor.getCharset());
@@ -879,6 +891,7 @@ public class ExtendedEmailPublisherDescriptorTest {
         assertEquals("admin2", additionalAccount.getSmtpUsername());
         assertEquals(Secret.fromString("honeycomb2"), additionalAccount.getSmtpPassword());
         assertTrue(additionalAccount.isUseSsl());
+        assertTrue(additionalAccount.isUseTls());
         assertFalse(additionalAccount.isDefaultAccount());
         assertEquals("mail.smtp.ssl.trust=example2.com", additionalAccount.getAdvProperties());
         assertEquals("text/html", descriptor.getDefaultContentType());

--- a/src/test/resources/configuration-as-code.yml
+++ b/src/test/resources/configuration-as-code.yml
@@ -8,6 +8,7 @@ unclassified:
         smtpUsername: "smtp-username"
         smtpPassword: "smtp-password"
         useSsl: true
+        useTls: true
         advProperties: "avd-properties"
     charset: "UTF-8"
     defaultContentType: "text/html"
@@ -22,6 +23,7 @@ unclassified:
       smtpPassword: "smtp-password-xyz"
       advProperties: "adv-properties-xyz"
       useSsl: true
+      useTls: true
     defaultRecipients: "first-account@domain.extension"
     allowedDomains: "@domain.extension"
     excludedCommitters: "not-this-committer"

--- a/src/test/resources/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest/persistedConfigurationBeforeDefaultAddress/hudson.plugins.emailext.ExtendedEmailPublisher.xml
+++ b/src/test/resources/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest/persistedConfigurationBeforeDefaultAddress/hudson.plugins.emailext.ExtendedEmailPublisher.xml
@@ -8,6 +8,7 @@
     <smtpUsername>admin</smtpUsername>
     <smtpPassword>honeycomb</smtpPassword>
     <useSsl>true</useSsl>
+    <useTls>true</useTls>
     <advProperties>mail.smtp.ssl.trust=example.com</advProperties>
     <defaultAccount>true</defaultAccount>
   </mailAccount>
@@ -19,6 +20,7 @@
       <smtpUsername>admin2</smtpUsername>
       <smtpPassword>honeycomb2</smtpPassword>
       <useSsl>true</useSsl>
+      <useTls>true</useTls>
       <advProperties>mail.smtp.ssl.trust=example2.com</advProperties>
       <defaultAccount>false</defaultAccount>
     </hudson.plugins.emailext.MailAccount>

--- a/src/test/resources/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest/persistedConfigurationBeforeJCasC/hudson.plugins.emailext.ExtendedEmailPublisher.xml
+++ b/src/test/resources/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest/persistedConfigurationBeforeJCasC/hudson.plugins.emailext.ExtendedEmailPublisher.xml
@@ -7,6 +7,7 @@
     <smtpUsername>admin</smtpUsername>
     <smtpPassword>honeycomb</smtpPassword>
     <useSsl>true</useSsl>
+    <useTls>true</useTls>
     <advProperties>mail.smtp.ssl.trust=example.com</advProperties>
   </mailAccount>
   <addAccounts>
@@ -17,6 +18,7 @@
       <smtpUsername>admin2</smtpUsername>
       <smtpPassword>honeycomb2</smtpPassword>
       <useSsl>true</useSsl>
+      <useTls>true</useTls>
       <advProperties>mail.smtp.ssl.trust=example2.com</advProperties>
     </hudson.plugins.emailext.MailAccount>
   </addAccounts>


### PR DESCRIPTION
- copied the TLS configuration code from jenkinsci/mailer-plugin#76
- copied existing code for SSL configuration into new TLS configuration

The relevant Jira issue for this is https://issues.jenkins.io/browse/JENKINS-5206.

This adds a checkbox in the email-ext configuration to enable STARTTLS, so the jenkins admin doesn't need to add this manually via java system properties.
I'm not a Java expert and this is my first attempt at modifying a Jenkins plugin, so I've just copied the relevant property-setting changes from jenkinsci/mailer-plugin#76 and copied the existing SSL configuration code in this plugin into new TLS configuration.

Tested locally with java8 and java11 and was able to send an email successfully to smtp-relay.gmail.com.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
