### PR TITLE
Deprecated methods without charset updated

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -394,7 +394,7 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
 
         if (jprop != null) {
             for (String u : jprop.getWatchers()) {
-                User user = User.get(u);
+                User user = User.getById(u, false);
                 if (user != null) {
                     EmailExtWatchAction.UserProperty prop = user.getProperty(EmailExtWatchAction.UserProperty.class);
                     if (prop != null) {

--- a/src/main/java/hudson/plugins/emailext/plugins/content/JellyScriptContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/JellyScriptContent.java
@@ -27,6 +27,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 
 @EmailToken
 public class JellyScriptContent extends AbstractEvalContent {
@@ -66,7 +67,7 @@ public class JellyScriptContent extends AbstractEvalContent {
 
     private String renderContent(@NonNull Run<?, ?> build, InputStream inputStream, @NonNull TaskListener listener)
             throws JellyException, IOException {
-        String rawScript = IOUtils.toString(inputStream);
+        String rawScript = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
         if (inputStream instanceof UserProvidedContentInputStream) {
             Item parent = build.getParent();
             ScriptApproval.get().configuring(rawScript, JellyLanguage.get(), ApprovalContext.create().withItem(parent));

--- a/src/main/java/hudson/plugins/emailext/plugins/content/ScriptContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/ScriptContent.java
@@ -40,6 +40,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -123,7 +124,7 @@ public class ScriptContent extends AbstractEvalContent {
         binding.put("workspace", workspace);
 
         try {
-            String text = IOUtils.toString(templateStream);
+            String text = IOUtils.toString(templateStream, StandardCharsets.UTF_8);
             boolean approvedScript = false;
             if (templateStream instanceof UserProvidedContentInputStream && !AbstractEvalContent.isApprovedScript(text, GroovyLanguage.get())) {
                 approvedScript = false;

--- a/src/main/java/hudson/plugins/emailext/plugins/content/TemplateContent.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/content/TemplateContent.java
@@ -13,6 +13,7 @@ import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -42,7 +43,7 @@ public class TemplateContent extends AbstractEvalContent {
         
         try {
             if (!StringUtils.isEmpty(file)) {
-                result = IOUtils.toString(getFileInputStream(run, workspace, file, ".txt"));
+                result = IOUtils.toString(getFileInputStream(run, workspace, file, ".txt"), StandardCharsets.UTF_8);
             }
         } catch (FileNotFoundException e) {
             String missingFileError = generateMissingFile("Plain Text", file);

--- a/src/test/java/hudson/plugins/emailext/AttachmentUtilsTest.java
+++ b/src/test/java/hudson/plugins/emailext/AttachmentUtilsTest.java
@@ -31,6 +31,7 @@ import javax.mail.internet.MimeUtility;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
 import static org.hamcrest.Matchers.allOf;
@@ -79,7 +80,7 @@ public class AttachmentUtilsTest {
 
         BodyPart attach = part.getBodyPart(1);
         assertThat(attach.getSize(), greaterThan(0));
-        assertThat(IOUtils.toString(attach.getInputStream()), containsString("mickey@disney.com"));
+        assertThat(IOUtils.toString(attach.getInputStream(), StandardCharsets.UTF_8), containsString("mickey@disney.com"));
         assertEquals("build.log", attach.getFileName());
     }
 
@@ -123,7 +124,7 @@ public class AttachmentUtilsTest {
         assertThat(attach.getSize(), allOf(greaterThan(0),
                 lessThanOrEqualTo((Long.valueOf(b.getLogFile().length()).intValue()))));
         assertEquals("build.zip", attach.getFileName());
-        assertThat(IOUtils.toString(attach.getInputStream()), containsString("build.log")); // zips have plain text filename in them
+        assertThat(IOUtils.toString(attach.getInputStream(), StandardCharsets.UTF_8), containsString("build.log")); // zips have plain text filename in them
     }
 
     @Test

--- a/src/test/java/hudson/plugins/emailext/plugins/ContentBuilderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/ContentBuilderTest.java
@@ -16,6 +16,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +36,7 @@ public class ContentBuilderTest {
         public void before() throws Throwable {
             super.before();
 
-            listener = new StreamBuildListener(System.out);
+            listener = new StreamBuildListener(System.out, StandardCharsets.UTF_8);
 
             publisher = new ExtendedEmailPublisher();
             publisher.defaultContent = "For only 10 easy payment of $69.99 , AWESOME-O 4000 can be yours!";

--- a/src/test/java/hudson/plugins/emailext/plugins/content/ScriptContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/ScriptContentTest.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Scanner;
@@ -267,7 +268,7 @@ public class ScriptContentTest {
 
     @Test public void templateOnDisk() throws Exception {
         scriptContent.template = "testing1.template";
-        FileUtils.write(new File(ScriptContent.scriptsFolder(), "testing1.template"), "2+2=${2+2}");
+        FileUtils.write(new File(ScriptContent.scriptsFolder(), "testing1.template"), "2+2=${2+2}", StandardCharsets.UTF_8);
         assertEquals("2+2=4", scriptContent.evaluate(build, listener, ScriptContent.MACRO_NAME));
         long start = System.currentTimeMillis();
         for (int i = 0; i < 1000; i++) {
@@ -275,10 +276,10 @@ public class ScriptContentTest {
         }
         long end = System.currentTimeMillis();
         System.out.printf("average time %.2fmsec%n", (end - start) / 1000.0);
-        FileUtils.write(new File(ScriptContent.scriptsFolder(), "testing1.template"), "2 + 2 = ${2+2}");
+        FileUtils.write(new File(ScriptContent.scriptsFolder(), "testing1.template"), "2 + 2 = ${2+2}", StandardCharsets.UTF_8);
         assertEquals("2 + 2 = 4", scriptContent.evaluate(build, listener, ScriptContent.MACRO_NAME));
         scriptContent.template = "testing2.template";
-        FileUtils.write(new File(ScriptContent.scriptsFolder(), "testing2.template"), "2 + 2 is ${2+2}");
+        FileUtils.write(new File(ScriptContent.scriptsFolder(), "testing2.template"), "2 + 2 is ${2+2}", StandardCharsets.UTF_8);
         assertEquals("2 + 2 is 4", scriptContent.evaluate(build, listener, ScriptContent.MACRO_NAME));
         scriptContent.template = "testing1.template";
         assertEquals("2 + 2 = 4", scriptContent.evaluate(build, listener, ScriptContent.MACRO_NAME));


### PR DESCRIPTION
Updates deprecated calls to methods without explicit charsets.

In addition, usage of deprecated `User.get()` replaced by `User.getById()`. Since `getById()` can return `null`, but `get()` doesn't, the test for `null` is valid now.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
