### PR TITLE
fix: Use default suffix from global config with from address if only username specified

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -800,13 +800,17 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
 
     private InternetAddress getFromAddress() throws AddressException {
         ExtendedEmailPublisherDescriptor descriptor = getDescriptor();
-        InternetAddress fromAddress;
-        if (StringUtils.isBlank(from)) {
-            fromAddress = new InternetAddress(descriptor.getAdminAddress());
-        } else {
-            fromAddress = new InternetAddress(from);
+        final String defaultSuffix = descriptor.getDefaultSuffix();
+        String actualFrom = from;
+
+        if (StringUtils.isBlank(actualFrom)) {
+            actualFrom = descriptor.getAdminAddress();
         }
-        return fromAddress;
+
+        if(!actualFrom.contains("@") && defaultSuffix != null && defaultSuffix.contains("@")) {
+            actualFrom += defaultSuffix;
+        }
+        return new InternetAddress(actualFrom);
     }
 
     @Restricted(NoExternalUse.class)

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
@@ -1358,6 +1358,38 @@ public class ExtendedEmailPublisherTest {
         assertEquals("custom@example.com", from[0].toString());
     }
 
+    @Test
+    @Issue("JENKINS-63523")
+    public void testProjectFromWithDefaultSuffix() throws Exception {
+        publisher.getDescriptor().setDefaultSuffix("@example.com");
+
+        SuccessTrigger successTrigger =
+                new SuccessTrigger(
+                        recProviders,
+                        "$DEFAULT_RECIPIENTS",
+                        "$DEFAULT_REPLYTO",
+                        "$DEFAULT_SUBJECT",
+                        "$DEFAULT_CONTENT",
+                        "",
+                        0,
+                        "project");
+        addEmailType(successTrigger);
+        publisher.getConfiguredTriggers().add(successTrigger);
+        publisher.from = "custom";
+
+        FreeStyleBuild build = j.buildAndAssertSuccess(project);
+        j.assertLogContains("Email was triggered for: Success", build);
+
+        Mailbox mailbox = Mailbox.get("ashlux@gmail.com");
+        assertEquals(1, mailbox.size());
+
+        Message msg = mailbox.get(0);
+        Address[] from = msg.getFrom();
+        assertEquals(1, from.length);
+
+        assertEquals("custom@example.com", from[0].toString());
+    }
+
     /**
      * Similar to {@link SleepBuilder} but only on the first build. (Removing
      * the builder between builds is tricky since you would have to wait for the


### PR DESCRIPTION
This checks if the from address has an @ and if not uses the defaultSuffix from the descriptor.

https://issues.jenkins.io/browse/JENKINS-63523

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Hacktoberfest submission, please add the hacktoberfest-accepted label.