### PR TITLE
feat: Use credentials plugin for managing authentication credentials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,10 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+        </dependency>
 
         <!-- workflow stuff -->
         <dependency>
@@ -238,11 +242,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>credentials</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -483,25 +483,10 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
                                         + mailAccount.getAddress()
                                         + " has invalid SMTP server");
                     }
-                } else if (!mailAccount.isSmtpAuthValid()) {
-                    context.getListener()
-                            .getLogger()
-                            .println("Mail account has invalid SMTP authentication settings");
-                    if (mailAccount.isDefaultAccount()) {
-                        debug(
-                                context.getListener().getLogger(),
-                                "Default account has invalid SMTP authentication settings");
-                    } else {
-                        debug(
-                                context.getListener().getLogger(),
-                                "Additional account "
-                                        + mailAccount.getAddress()
-                                        + " has invalid SMTP authentication settings");
-                    }
                 }
                 return false;
             }
-            Session session = getDescriptor().createSession(mailAccount);
+            Session session = getDescriptor().createSession(mailAccount, context);
             if (session == null) {
                 context.getListener().getLogger().println("Could not create session");
                 return false;
@@ -839,12 +824,6 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
                             "Ignoring additional account "
                                     + addAccount.getAddress()
                                     + " with invalid SMTP server");
-                } else if (!addAccount.isSmtpAuthValid()) {
-                    debug(
-                            context.getListener().getLogger(),
-                            "Ignoring additional account "
-                                    + addAccount.getAddress()
-                                    + " with invalid SMTP authentication");
                 }
                 continue;
             }

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -1,8 +1,6 @@
 package hudson.plugins.emailext;
 
-import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
-import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -13,10 +11,8 @@ import hudson.init.Initializer;
 import hudson.matrix.MatrixProject;
 import hudson.model.AbstractProject;
 import hudson.model.Run;
-import hudson.model.queue.Tasks;
 import hudson.plugins.emailext.plugins.EmailTriggerDescriptor;
 import hudson.plugins.emailext.plugins.trigger.FailureTrigger;
-import hudson.security.ACL;
 import hudson.security.Permission;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Publisher;

--- a/src/main/java/hudson/plugins/emailext/MailAccount.java
+++ b/src/main/java/hudson/plugins/emailext/MailAccount.java
@@ -29,6 +29,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
+import java.util.Collections;
 import java.util.List;
 
 public class MailAccount extends AbstractDescribableImpl<MailAccount>{
@@ -125,7 +126,7 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount>{
                             item instanceof Queue.Task ? Tasks.getAuthenticationOf((Queue.Task) item) : ACL.SYSTEM,
                             item,
                             StandardUsernamePasswordCredentials.class,
-                            null,
+                            Collections.emptyList(),
                             CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class))
                     .includeCurrentValue(credentialsId);
         }

--- a/src/main/java/hudson/plugins/emailext/MailAccount.java
+++ b/src/main/java/hudson/plugins/emailext/MailAccount.java
@@ -1,22 +1,43 @@
 package hudson.plugins.emailext;
 
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import com.cloudbees.plugins.credentials.domains.HostnamePortRequirement;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import hudson.model.Item;
+import hudson.model.Queue;
+import hudson.model.queue.Tasks;
+import hudson.security.ACL;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 import hudson.util.Secret;
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+import java.util.List;
 
 public class MailAccount extends AbstractDescribableImpl<MailAccount>{
     private String address;
     private String smtpHost;
     private String smtpPort = "25";
-    private String smtpUsername;
-    private Secret smtpPassword;
+    private transient String smtpUsername;
+    private transient Secret smtpPassword;
+    private String credentialsId;
     private boolean useSsl;
     private boolean useTls;
     private String advProperties;
@@ -28,11 +49,7 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount>{
         smtpHost = Util.nullify(jo.optString("smtpHost", null));
         smtpPort = Util.nullify(jo.optString("smtpPort", null));
         if(jo.optBoolean("auth", false)){
-            smtpUsername = Util.nullify(jo.optString("smtpUsername", null));
-            String pass = Util.nullify(jo.optString("smtpPassword", null));
-            if(pass != null) {
-                smtpPassword = Secret.fromString(pass);
-            }
+            credentialsId = Util.nullify(jo.optString("credentialsId", null));
         }
         useSsl = jo.optBoolean("useSsl", false);
         useTls = jo.optBoolean("useTls", false);
@@ -45,7 +62,7 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount>{
     }
 
     public boolean isValid() {
-        return isFromAddressValid() && isSmtpServerValid() && isSmtpAuthValid();
+        return isFromAddressValid() && isSmtpServerValid();
     }
 
     public boolean isFromAddressValid() {
@@ -60,16 +77,22 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount>{
     }
 
     public boolean isSmtpAuthValid() {
-        return StringUtils.isBlank(smtpUsername)
-                || (StringUtils.isNotBlank(smtpUsername) && smtpPassword != null);
+        return true;
+        // Note: we either have credentials or not, there isn't
+        // two pieces to look at
     }
 
     public boolean isDefaultAccount() {
         return defaultAccount;
     }
 
+    @DataBoundSetter
     void setDefaultAccount(boolean defaultAccount) {
         this.defaultAccount = defaultAccount;
+    }
+
+    public MailAccountDescriptor getDescriptor() {
+        return (MailAccountDescriptor) Jenkins.get().getDescriptor(getClass());
     }
 
     @Extension
@@ -78,6 +101,61 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount>{
         @Override
         public String getDisplayName(){
             return "";
+        }
+
+        @SuppressWarnings("unused") // Used by stapler
+        public ListBoxModel doFillCredentialsIdItems(
+                @AncestorInPath Item item,
+                @QueryParameter String credentialsId) {
+
+            final StandardListBoxModel result = new StandardListBoxModel();
+            if (item == null) {
+                if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+                    return result.includeCurrentValue(credentialsId);
+                }
+            } else {
+                if (!item.hasPermission(Item.EXTENDED_READ)
+                        && !item.hasPermission(CredentialsProvider.USE_ITEM)) {
+                    return result.includeCurrentValue(credentialsId);
+                }
+            }
+            return result
+                    .includeEmptyValue()
+                    .includeMatchingAs(
+                            item instanceof Queue.Task ? Tasks.getAuthenticationOf((Queue.Task) item) : ACL.SYSTEM,
+                            item,
+                            StandardUsernamePasswordCredentials.class,
+                            null,
+                            CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class))
+                    .includeCurrentValue(credentialsId);
+        }
+
+        public FormValidation doCheckCredentialsId(
+                @AncestorInPath Item item,
+                @QueryParameter String value) {
+            if (item == null) {
+                if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+                    return FormValidation.ok();
+                }
+            } else {
+                if (!item.hasPermission(Item.EXTENDED_READ)
+                        && !item.hasPermission(CredentialsProvider.USE_ITEM)) {
+                    return FormValidation.ok();
+                }
+            }
+            if (StringUtils.isBlank(value)) {
+                return FormValidation.ok();
+            }
+
+            if (CredentialsProvider.listCredentials(
+                    StandardUsernamePasswordCredentials.class,
+                    item,
+                    item instanceof Queue.Task ? Tasks.getAuthenticationOf((Queue.Task)item) : ACL.SYSTEM,
+                    null,
+                    CredentialsMatchers.withId(value)).isEmpty()) {
+                return FormValidation.error("Cannot find currently selected credentials");
+            }
+            return FormValidation.ok();
         }
     }
 
@@ -108,6 +186,7 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount>{
         this.smtpPort = Util.fixEmptyAndTrim(smtpPort);
     }
 
+    @Deprecated
     public String getSmtpUsername(){
         return smtpUsername;
     }
@@ -117,6 +196,7 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount>{
         this.smtpUsername = Util.fixEmptyAndTrim(smtpUsername);
     }
 
+    @Deprecated
     public Secret getSmtpPassword(){
         return smtpPassword;
     }
@@ -128,6 +208,18 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount>{
 
     public void setSmtpPassword(String smtpPassword) {
         this.smtpPassword = Secret.fromString(smtpPassword);
+    }
+
+    public String getCredentialsId() {
+        if(StringUtils.isBlank(credentialsId) && StringUtils.isNotBlank(smtpUsername) && smtpPassword != null) {
+            migrateCredentials();
+        }
+        return credentialsId;
+    }
+
+    @DataBoundSetter
+    public void setCredentialsId(String credentialsId) {
+        this.credentialsId = Util.fixEmptyAndTrim(credentialsId);
     }
 
     public boolean isUseSsl(){
@@ -155,5 +247,50 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount>{
     @DataBoundSetter
     public void setAdvProperties(String advProperties){
         this.advProperties = advProperties;
+    }
+
+    private Object readResolve() {
+        if(StringUtils.isBlank(credentialsId) && StringUtils.isNotBlank(smtpUsername) && smtpPassword != null) {
+            migrateCredentials();
+        }
+        return this;
+    }
+
+    private void migrateCredentials() {
+        DomainRequirement domainRequirement = null;
+        if(StringUtils.isNotBlank(smtpHost) && StringUtils.isNotBlank(smtpPort)) {
+            domainRequirement = new HostnamePortRequirement(smtpHost, Integer.parseInt(smtpPort));
+        }
+        final List<StandardUsernamePasswordCredentials> credentials =
+                CredentialsMatchers.filter(
+                        CredentialsProvider.lookupCredentials(
+                                StandardUsernamePasswordCredentials.class,
+                                Jenkins.get(),
+                                ACL.SYSTEM,
+                                domainRequirement),
+                        CredentialsMatchers.withUsername(smtpUsername));
+        for (final StandardUsernamePasswordCredentials cred : credentials) {
+            if (StringUtils.equals(smtpPassword.getPlainText(), Secret.toString(cred.getPassword()))) {
+                // If some credentials have the same username/password, use those.
+                credentialsId = cred.getId();
+                break;
+            }
+        }
+        if (StringUtils.isBlank(credentialsId)) {
+            // If we couldn't find any existing credentials,
+            // create new credentials with the principal and secret and use it.
+            final StandardUsernamePasswordCredentials newCredentials =
+                    new UsernamePasswordCredentialsImpl(
+                            CredentialsScope.SYSTEM,
+                            null,
+                            "Migrated from email-ext username/password",
+                            smtpUsername,
+                            smtpPassword.getPlainText());
+            SystemCredentialsProvider.getInstance().getCredentials().add(newCredentials);
+            credentialsId = newCredentials.getId();
+        }
+
+        smtpUsername = null;
+        smtpPassword = null;
     }
 }

--- a/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/global.groovy
+++ b/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/global.groovy
@@ -26,7 +26,7 @@ f.section(title: _("Extended E-mail Notification")) {
           f.repeatableDeleteButton()
         }
       }
-      }
+    }
   }
 
   f.entry(field: "defaultContentType", help: "/plugin/email-ext/help/globalConfig/contentType.html", title: _("Default Content Type")) {

--- a/src/main/resources/hudson/plugins/emailext/MailAccount/config.groovy
+++ b/src/main/resources/hudson/plugins/emailext/MailAccount/config.groovy
@@ -20,12 +20,10 @@ f.entry(field: "smtpPort", title: _("SMTP Port")) {
 }
 
 f.advanced {
-    f.entry(field: "smtpUsername", title: _("SMTP Username")) {
-        f.textbox()
+    f.entry(field: "credentialsId", title: _("Credentials")) {
+        c.select()
     }
-    f.entry(field: "smtpPassword", title: _("SMTP Password")) {
-        f.password()
-    }
+
     f.entry(field: "useSsl", title: _("Use SSL")) {
         f.checkbox()
     }

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorJCasCTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorJCasCTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.ExtensionList;
 import hudson.plugins.emailext.plugins.trigger.AbortedTrigger;
 import hudson.plugins.emailext.plugins.trigger.FixedTrigger;
@@ -146,7 +146,7 @@ public class ExtendedEmailPublisherDescriptorJCasCTest {
         List<Credentials> creds = CredentialsProvider.lookupCredentials(com.cloudbees.plugins.credentials.Credentials.class);
         assertEquals(2, creds.size());
         for (Credentials c : creds) {
-            assertEquals(c.getClass(), StandardUsernamePasswordCredentials.class);
+            assertEquals(UsernamePasswordCredentialsImpl.class, c.getClass());
         }
 
         assertEquals("first-account@domain.extension", descriptor.getDefaultRecipients());

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
@@ -58,13 +59,11 @@ import hudson.plugins.emailext.plugins.trigger.UnstableTrigger;
 import hudson.plugins.emailext.plugins.trigger.XNthFailureTrigger;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
-import hudson.util.Secret;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import javax.mail.Authenticator;
 import jenkins.model.Jenkins;
 import org.junit.Rule;
@@ -74,7 +73,6 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.recipes.LocalData;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 
 public class ExtendedEmailPublisherDescriptorTest {
@@ -632,7 +630,13 @@ public class ExtendedEmailPublisherDescriptorTest {
         assertEquals("admin@example.com", descriptor.getAdminAddress());
         assertEquals("smtp.example.com", descriptor.getMailAccount().getSmtpHost());
         assertEquals("@example.com", descriptor.getDefaultSuffix());
-        assertEquals("email-ext-credentials-honeycomb", descriptor.getMailAccount().getCredentialsId());
+        assertNotNull(descriptor.getMailAccount().getCredentialsId());
+        List<StandardCredentials> creds = CredentialsProvider.lookupCredentials(StandardCredentials.class);
+        assertEquals(2, creds.size());
+        for (StandardCredentials c : creds) {
+            assertEquals(UsernamePasswordCredentialsImpl.class, c.getClass());
+            assertEquals("Migrated from email-ext username/password", c.getDescription());
+        }
         assertEquals("mail.smtp.ssl.trust=example.com", descriptor.getMailAccount().getAdvProperties());
         assertTrue(descriptor.getMailAccount().isUseSsl());
         assertTrue(descriptor.getMailAccount().isDefaultAccount());
@@ -643,7 +647,7 @@ public class ExtendedEmailPublisherDescriptorTest {
         assertEquals("admin@example2.com", additionalAccount.getAddress());
         assertEquals("smtp.example2.com", additionalAccount.getSmtpHost());
         assertEquals("2626", additionalAccount.getSmtpPort());
-        assertEquals("email-ext-credentials-honeycomb2", additionalAccount.getCredentialsId());
+        assertNotNull(additionalAccount.getCredentialsId());
         assertTrue(additionalAccount.isUseSsl());
         assertFalse(additionalAccount.isDefaultAccount());
         assertEquals("mail.smtp.ssl.trust=example2.com", additionalAccount.getAdvProperties());
@@ -847,7 +851,13 @@ public class ExtendedEmailPublisherDescriptorTest {
         assertNull(descriptor.getMailAccount().getAddress());
         assertEquals("smtp.example.com", descriptor.getMailAccount().getSmtpHost());
         assertEquals("@example.com", descriptor.getDefaultSuffix());
-        assertEquals("email-ext-credentials-honeycomb", descriptor.getMailAccount().getCredentialsId());
+        assertNotNull(descriptor.getMailAccount().getCredentialsId());
+        List<StandardCredentials> creds = CredentialsProvider.lookupCredentials(StandardCredentials.class);
+        assertEquals(2, creds.size());
+        for (StandardCredentials c : creds) {
+            assertEquals(UsernamePasswordCredentialsImpl.class, c.getClass());
+            assertEquals("Migrated from email-ext username/password", c.getDescription());
+        }
         assertEquals("mail.smtp.ssl.trust=example.com", descriptor.getMailAccount().getAdvProperties());
         assertTrue(descriptor.getMailAccount().isUseSsl());
         assertTrue(descriptor.getMailAccount().isDefaultAccount());
@@ -858,7 +868,227 @@ public class ExtendedEmailPublisherDescriptorTest {
         assertEquals("admin@example2.com", additionalAccount.getAddress());
         assertEquals("smtp.example2.com", additionalAccount.getSmtpHost());
         assertEquals("2626", additionalAccount.getSmtpPort());
-        assertEquals("email-ext-credentials-honeycomb2", additionalAccount.getCredentialsId());
+        assertNotNull(additionalAccount.getCredentialsId());
+        assertTrue(additionalAccount.isUseSsl());
+        assertFalse(additionalAccount.isDefaultAccount());
+        assertEquals("mail.smtp.ssl.trust=example2.com", additionalAccount.getAdvProperties());
+        assertEquals("text/html", descriptor.getDefaultContentType());
+        assertEquals("<list.example.com>", descriptor.getListId());
+        assertTrue(descriptor.getPrecedenceBulk());
+        assertEquals("default@example.com", descriptor.getDefaultRecipients());
+        assertEquals("noreply@example.com", descriptor.getDefaultReplyTo());
+        assertEquals("emergency@example.com", descriptor.getEmergencyReroute());
+        assertEquals("@example.com", descriptor.getAllowedDomains());
+        assertEquals("excluded@example.com", descriptor.getExcludedCommitters());
+        assertEquals(
+                "$PROJECT_NAME - Build #$BUILD_NUMBER - $BUILD_STATUS",
+                descriptor.getDefaultSubject());
+        assertEquals(44040192, descriptor.getMaxAttachmentSize());
+        assertEquals(
+                "$PROJECT_NAME - Build # $BUILD_NUMBER - $BUILD_STATUS",
+                descriptor.getDefaultBody());
+        assertEquals(
+                "build.previousBuild.result.toString().equals('FAILURE')",
+                descriptor.getDefaultPresendScript());
+        assertEquals(
+                "build.result.toString().equals('FAILURE')", descriptor.getDefaultPostsendScript());
+        assertEquals(1, descriptor.getDefaultClasspath().size());
+        assertEquals("classes", descriptor.getDefaultClasspath().get(0).getPath());
+        assertTrue(descriptor.isDebugMode());
+        assertTrue(descriptor.isAdminRequiredForTemplateTesting());
+        assertTrue(descriptor.isWatchingEnabled());
+        assertTrue(descriptor.isAllowUnregisteredEnabled());
+        assertEquals(20, descriptor.getDefaultTriggerIds().size());
+        assertThat(
+                descriptor.getDefaultTriggerIds(),
+                containsInAnyOrder(
+                        AbortedTrigger.class.getName(),
+                        AlwaysTrigger.class.getName(),
+                        BuildingTrigger.class.getName(),
+                        FirstFailureTrigger.class.getName(),
+                        FirstUnstableTrigger.class.getName(),
+                        FixedTrigger.class.getName(),
+                        FixedUnhealthyTrigger.class.getName(),
+                        ImprovementTrigger.class.getName(),
+                        NotBuiltTrigger.class.getName(),
+                        PreBuildScriptTrigger.class.getName(),
+                        PreBuildTrigger.class.getName(),
+                        RegressionTrigger.class.getName(),
+                        ScriptTrigger.class.getName(),
+                        SecondFailureTrigger.class.getName(),
+                        StatusChangedTrigger.class.getName(),
+                        StillFailingTrigger.class.getName(),
+                        StillUnstableTrigger.class.getName(),
+                        SuccessTrigger.class.getName(),
+                        UnstableTrigger.class.getName(),
+                        XNthFailureTrigger.class.getName()));
+    }
+
+    @Test
+    @LocalData
+    public void persistedConfigurationWithCredentialId() throws Exception {
+        // Local data created using Email Extension 2.72 with the following code:
+        /*
+        // add two credentials to the GLOBAL scope
+        UsernamePasswordCredentials c1 = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "email-ext-admin", "Username/password for SMTP", "admin", "honeycomb");
+        UsernamePasswordCredentials c2 = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "email-ext-admin2", "Username/password for SMTP", "admin2", "honeycomb2");
+        CredentialsProvider.lookupStores(j.jenkins).iterator().next().addCredentials(Domain.global(), c1);
+        CredentialsProvider.lookupStores(j.jenkins).iterator().next().addCredentials(Domain.global(), c2);
+
+        HtmlPage page = j.createWebClient().goTo("configure");
+        HtmlForm config = page.getFormByName("config");
+        j.submit(config);
+
+        page = j.createWebClient().goTo("configure");
+        config = page.getFormByName("config");
+        for (HtmlElement button : config.getElementsByTagName("button")) {
+            if (button.getTextContent().trim().equals("Advanced...")) {
+                button.click();
+            }
+        }
+        j.getButtonByCaption(config, "Default Triggers...").click();
+        WebClientUtil.waitForJSExec(page.getWebClient());
+        Set<HtmlButton> buttons = new HashSet<>();
+        for (HtmlElement button : config.getElementsByTagName("button")) {
+            buttons.add((HtmlButton) button);
+        }
+        for (HtmlButton button : buttons) {
+            DomNode ancestor =
+                    button.getParentNode().getParentNode().getParentNode().getParentNode();
+            if(ancestor.getPreviousSibling() == null) {
+                continue;
+            }
+            String key = ancestor.getPreviousSibling().getTextContent().trim();
+            if (key.equals("Additional accounts") || key.equals("Additional groovy classpath")) {
+                button.click();
+            }
+        }
+        WebClientUtil.waitForJSExec(page.getWebClient());
+        buttons = new HashSet<>();
+        for (HtmlElement button : config.getElementsByTagName("button")) {
+            buttons.add((HtmlButton) button);
+        }
+        for (HtmlButton button : buttons) {
+            String textContent = button.getTextContent().trim();
+            if (textContent.equals("Advanced...")) {
+                DomNode ancestor =
+                        button.getParentNode()
+                                .getParentNode()
+                                .getParentNode()
+                                .getParentNode()
+                                .getParentNode()
+                                .getParentNode()
+                                .getParentNode()
+                                .getParentNode()
+                                .getParentNode()
+                                .getParentNode();
+                String key = ancestor.getPreviousSibling().getTextContent().trim();
+                if (key.equals("Additional accounts")) {
+                    button.click();
+                }
+            }
+        }
+        WebClientUtil.waitForJSExec(page.getWebClient());
+
+        HtmlTextInput address = page.getElementByName("_.adminAddress");
+        address.setValueAttribute("admin@example.com");
+        List<DomElement> smtpServers = page.getElementsByName("_.smtpHost");
+        HtmlTextInput smtpServer = (HtmlTextInput) smtpServers.get(0);
+        smtpServer.setValueAttribute("smtp.example.com");
+        List<DomElement> smtpPorts = page.getElementsByName("_.smtpPort");
+        HtmlNumberInput smtpPort = (HtmlNumberInput) smtpPorts.get(0);
+        smtpPort.setValueAttribute("2525");
+        List<DomElement> credentialsIds = page.getElementsByName("_.credentialsId");
+        HtmlSelect credentialsId = (HtmlSelect)credentialsIds.get(0);
+        List<HtmlOption> options = credentialsId.getOptions();
+        credentialsId.setSelectedIndex(1);
+        List<DomElement> smtpUseSsls = page.getElementsByName("_.useSsl");
+        HtmlCheckBoxInput smtpUseSsl = (HtmlCheckBoxInput) smtpUseSsls.get(0);
+        smtpUseSsl.click();
+        List<DomElement> advPropertiesElements = page.getElementsByName("_.advProperties");
+        HtmlTextArea advProperties = (HtmlTextArea) advPropertiesElements.get(0);
+        advProperties.setText("mail.smtp.ssl.trust=example.com");
+        HtmlTextInput defaultSuffix = page.getElementByName("_.defaultSuffix");
+        defaultSuffix.setValueAttribute("@example.com");
+        HtmlTextInput charset = page.getElementByName("_.charset");
+        charset.setValueAttribute("UTF-8");
+        List<DomElement> addresses = page.getElementsByName("_.address");
+        HtmlTextInput address2 = (HtmlTextInput) addresses.get(1);
+        address2.setValueAttribute("admin@example2.com");
+        HtmlTextInput smtpServer2 = (HtmlTextInput) smtpServers.get(1);
+        smtpServer2.setValueAttribute("smtp.example2.com");
+        HtmlNumberInput smtpPort2 = (HtmlNumberInput) smtpPorts.get(1);
+        smtpPort2.setValueAttribute("2626");
+        HtmlSelect credentialId2 = (HtmlSelect)credentialsIds.get(1);
+        credentialId2.setSelectedIndex(2);
+        HtmlCheckBoxInput smtpUseSsl2 = (HtmlCheckBoxInput) smtpUseSsls.get(1);
+        smtpUseSsl2.click();
+        HtmlTextArea advProperties2 = (HtmlTextArea) advPropertiesElements.get(1);
+        advProperties2.setText("mail.smtp.ssl.trust=example2.com");
+        HtmlSelect defaultContentType = page.getElementByName("_.defaultContentType");
+        defaultContentType.setSelectedAttribute("text/html", true);
+        HtmlTextInput listId = page.getElementByName("_.listId");
+        listId.setValueAttribute("<list.example.com>");
+        HtmlCheckBoxInput addPrecedenceBulk = page.getElementByName("_.precedenceBulk");
+        addPrecedenceBulk.click();
+        HtmlTextInput defaultRecipients = page.getElementByName("_.defaultRecipients");
+        defaultRecipients.setValueAttribute("default@example.com");
+        HtmlTextInput defaultReplyto = page.getElementByName("_.defaultReplyTo");
+        defaultReplyto.setValueAttribute("noreply@example.com");
+        HtmlTextInput emergencyReroute = page.getElementByName("_.emergencyReroute");
+        emergencyReroute.setValueAttribute("emergency@example.com");
+        HtmlTextInput allowedDomains = page.getElementByName("_.allowedDomains");
+        allowedDomains.setValueAttribute("@example.com");
+        HtmlTextInput excludedCommitters = page.getElementByName("_.excludedCommitters");
+        excludedCommitters.setValueAttribute("excluded@example.com");
+        HtmlTextInput defaultSubject = page.getElementByName("_.defaultSubject");
+        defaultSubject.setValueAttribute("$PROJECT_NAME - Build #$BUILD_NUMBER - $BUILD_STATUS");
+        HtmlNumberInput maxAttachmentSize = page.getElementByName("_.maxAttachmentSizeMb");
+        maxAttachmentSize.setValueAttribute("42");
+        HtmlTextArea defaultBody = page.getElementByName("_.defaultBody");
+        defaultBody.setText("$PROJECT_NAME - Build # $BUILD_NUMBER - $BUILD_STATUS");
+        HtmlTextArea defaultPresendScript = page.getElementByName("_.defaultPresendScript");
+        defaultPresendScript.setText("build.previousBuild.result.toString().equals('FAILURE')");
+        HtmlTextArea defaultPostsendScript = page.getElementByName("_.defaultPostsendScript");
+        defaultPostsendScript.setText("build.result.toString().equals('FAILURE')");
+        HtmlTextInput defaultClasspath = page.getElementByName("_.path");
+        defaultClasspath.setValueAttribute("classes");
+        HtmlCheckBoxInput debugMode = page.getElementByName("_.debugMode");
+        debugMode.click();
+        HtmlCheckBoxInput requireAdminForTemplateTesting =
+                page.getElementByName("_.adminRequiredForTemplateTesting");
+        requireAdminForTemplateTesting.click();
+        HtmlCheckBoxInput watchingEnabled = page.getElementByName("_.watchingEnabled");
+        watchingEnabled.click();
+        HtmlCheckBoxInput allowUnregisteredEnabled =
+                page.getElementByName("_.allowUnregisteredEnabled");
+        allowUnregisteredEnabled.click();
+        for (HtmlInput input : config.getInputsByName("_.defaultTriggerIds")) {
+            input.click();
+        }
+
+        WebClientUtil.waitForJSExec(page.getWebClient());
+        j.submit(config);
+        */
+
+        ExtendedEmailPublisherDescriptor descriptor =
+                j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
+        assertEquals("admin@example.com", descriptor.getAdminAddress());
+        assertNull(descriptor.getMailAccount().getAddress());
+        assertEquals("smtp.example.com", descriptor.getMailAccount().getSmtpHost());
+        assertEquals("@example.com", descriptor.getDefaultSuffix());
+        assertEquals("email-ext-admin", descriptor.getMailAccount().getCredentialsId());
+        assertEquals("mail.smtp.ssl.trust=example.com", descriptor.getMailAccount().getAdvProperties());
+        assertTrue(descriptor.getMailAccount().isUseSsl());
+        assertTrue(descriptor.getMailAccount().isDefaultAccount());
+        assertEquals("2525", descriptor.getMailAccount().getSmtpPort());
+        assertEquals("UTF-8", descriptor.getCharset());
+        assertEquals(1, descriptor.getAddAccounts().size());
+        MailAccount additionalAccount = descriptor.getAddAccounts().get(0);
+        assertEquals("admin@example2.com", additionalAccount.getAddress());
+        assertEquals("smtp.example2.com", additionalAccount.getSmtpHost());
+        assertEquals("2626", additionalAccount.getSmtpPort());
+        assertEquals("email-ext-admin2", additionalAccount.getCredentialsId());
         assertTrue(additionalAccount.isUseSsl());
         assertFalse(additionalAccount.isDefaultAccount());
         assertEquals("mail.smtp.ssl.trust=example2.com", additionalAccount.getAdvProperties());

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
@@ -1164,7 +1164,7 @@ public class ExtendedEmailPublisherTest {
             assertEquals("mail@test1.com", publisher.from);
             ExtendedEmailPublisherContext context =
                     new ExtendedEmailPublisherContext(publisher, null, null, null, TaskListener.NULL);
-            Session session = descriptor.createSession(publisher.getMailAccount(context));
+            Session session = descriptor.createSession(publisher.getMailAccount(context), context);
             assertEquals("smtp.test0.com", session.getProperty("mail.smtp.host"));
             assertEquals("587", session.getProperty("mail.smtp.port"));
             assertEquals("test0.com", session.getProperty("mail.smtp.ssl.trust"));
@@ -1185,7 +1185,7 @@ public class ExtendedEmailPublisherTest {
 
             publisher = (ExtendedEmailPublisher) descriptor.newInstance(Stapler.getCurrentRequest(), form);
             assertEquals("mail@test1.com", publisher.from);
-            session = descriptor.createSession(publisher.getMailAccount(context));
+            session = descriptor.createSession(publisher.getMailAccount(context), context);
             assertEquals("smtp.test1.com", session.getProperty("mail.smtp.host"));
             assertEquals("25", session.getProperty("mail.smtp.port"));
             assertEquals("test1.com", session.getProperty("mail.smtp.ssl.trust"));
@@ -1193,7 +1193,7 @@ public class ExtendedEmailPublisherTest {
             form.put("project_from", "mail@test2.com");
             publisher = (ExtendedEmailPublisher) descriptor.newInstance(Stapler.getCurrentRequest(), form);
             assertEquals("mail@test2.com", publisher.from);
-            session = descriptor.createSession(publisher.getMailAccount(context));
+            session = descriptor.createSession(publisher.getMailAccount(context), context);
             assertEquals("smtp.test2.com", session.getProperty("mail.smtp.host"));
             assertEquals("465", session.getProperty("mail.smtp.port"));
             assertEquals("test2.com", session.getProperty("mail.smtp.ssl.trust"));

--- a/src/test/java/hudson/plugins/emailext/MailAccountTest.java
+++ b/src/test/java/hudson/plugins/emailext/MailAccountTest.java
@@ -1,13 +1,22 @@
 package hudson.plugins.emailext;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+import hudson.util.Secret;
 import net.sf.json.JSONObject;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
+
+import java.util.List;
 
 public class MailAccountTest {
     @Rule
@@ -39,19 +48,6 @@ public class MailAccountTest {
         assertTrue(account.isValid());
     }
 
-    @Test @WithoutJenkins
-    public void testIsValidAuthConfigMissingPassword() {
-        JSONObject obj = new JSONObject();
-        obj.put("address", "foo@bar.com");
-        obj.put("smtpHost", "mail.bar.com");
-        obj.put("smtpPort", 25);
-        obj.put("auth", true);
-        obj.put("smtpUsername", "foo");
-
-        MailAccount account = new MailAccount(obj);
-        assertFalse(account.isValid());
-    }
-
     @Test
     public void testIsValidAuthConfig() {
         JSONObject obj = new JSONObject();
@@ -59,10 +55,24 @@ public class MailAccountTest {
         obj.put("smtpHost", "mail.bar.com");
         obj.put("smtpPort", 25);
         obj.put("auth", true);
-        obj.put("smtpUsername", "foo");
-        obj.put("smtpPassword", "bar");
+        obj.put("credentialsId", "foo");
 
         MailAccount account = new MailAccount(obj);
         assertTrue(account.isValid());
+    }
+
+    @Test
+    public void testUpgradeDuringCredentialsGetter() {
+        MailAccount account = new MailAccount();
+        account.setSmtpUsername("foo");
+        account.setSmtpPassword(Secret.fromString("bar"));
+
+        assertNotNull(account.getCredentialsId());
+
+        List<StandardUsernamePasswordCredentials> creds = CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class);
+        assertEquals(1, creds.size());
+        StandardUsernamePasswordCredentials c = creds.get(0);
+        assertEquals("foo", c.getUsername());
+        assertEquals("bar", c.getPassword().getPlainText());
     }
 }

--- a/src/test/resources/configuration-as-code-upgrade.yml
+++ b/src/test/resources/configuration-as-code-upgrade.yml
@@ -5,7 +5,8 @@ unclassified:
       - address: "foo.bar"
         smtpHost: "smtp-host"
         smtpPort: "1234"
-        credentialsId: "credentials-id"
+        smtpUsername: "smtp-username"
+        smtpPassword: "smtp-password"
         useSsl: true
         useTls: true
         advProperties: "avd-properties"
@@ -18,7 +19,8 @@ unclassified:
     mailAccount:
       smtpHost: "smtp-host-xyz"
       smtpPort: "9876"
-      credentialsId: "smtp-credentials-xyz"
+      smtpUsername: "smtp-username-xyz"
+      smtpPassword: "smtp-password-xyz"
       advProperties: "adv-properties-xyz"
       useSsl: true
       useTls: true

--- a/src/test/resources/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest/persistedConfigurationBeforeDefaultAddress/hudson.plugins.emailext.ExtendedEmailPublisher.xml
+++ b/src/test/resources/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest/persistedConfigurationBeforeDefaultAddress/hudson.plugins.emailext.ExtendedEmailPublisher.xml
@@ -5,8 +5,7 @@
     <address>address not configured yet &lt;nobody@nowhere&gt;</address>
     <smtpHost>smtp.example.com</smtpHost>
     <smtpPort>2525</smtpPort>
-    <smtpUsername>admin</smtpUsername>
-    <smtpPassword>honeycomb</smtpPassword>
+    <credentialsId>email-ext-credentials-honeycomb</credentialsId>
     <useSsl>true</useSsl>
     <advProperties>mail.smtp.ssl.trust=example.com</advProperties>
     <defaultAccount>true</defaultAccount>
@@ -16,8 +15,7 @@
       <address>admin@example2.com</address>
       <smtpHost>smtp.example2.com</smtpHost>
       <smtpPort>2626</smtpPort>
-      <smtpUsername>admin2</smtpUsername>
-      <smtpPassword>honeycomb2</smtpPassword>
+      <credentialsId>email-ext-credentials-honeycomb2</credentialsId>
       <useSsl>true</useSsl>
       <advProperties>mail.smtp.ssl.trust=example2.com</advProperties>
       <defaultAccount>false</defaultAccount>

--- a/src/test/resources/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest/persistedConfigurationBeforeJCasC/hudson.plugins.emailext.ExtendedEmailPublisher.xml
+++ b/src/test/resources/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest/persistedConfigurationBeforeJCasC/hudson.plugins.emailext.ExtendedEmailPublisher.xml
@@ -4,8 +4,7 @@
   <mailAccount>
     <smtpHost>smtp.example.com</smtpHost>
     <smtpPort>2525</smtpPort>
-    <smtpUsername>admin</smtpUsername>
-    <smtpPassword>honeycomb</smtpPassword>
+    <credentialsId>email-ext-credentials-honeycomb</credentialsId>
     <useSsl>true</useSsl>
     <advProperties>mail.smtp.ssl.trust=example.com</advProperties>
   </mailAccount>
@@ -14,8 +13,7 @@
       <address>admin@example2.com</address>
       <smtpHost>smtp.example2.com</smtpHost>
       <smtpPort>2626</smtpPort>
-      <smtpUsername>admin2</smtpUsername>
-      <smtpPassword>honeycomb2</smtpPassword>
+      <credentialsId>email-ext-credentials-honeycomb2</credentialsId>
       <useSsl>true</useSsl>
       <advProperties>mail.smtp.ssl.trust=example2.com</advProperties>
     </hudson.plugins.emailext.MailAccount>

--- a/src/test/resources/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest/persistedConfigurationBeforeJCasC/hudson.plugins.emailext.ExtendedEmailPublisher.xml
+++ b/src/test/resources/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest/persistedConfigurationBeforeJCasC/hudson.plugins.emailext.ExtendedEmailPublisher.xml
@@ -4,7 +4,8 @@
   <mailAccount>
     <smtpHost>smtp.example.com</smtpHost>
     <smtpPort>2525</smtpPort>
-    <credentialsId>email-ext-credentials-honeycomb</credentialsId>
+    <smtpUsername>admin</smtpUsername>
+    <smtpPassword>honeycomb</smtpPassword>
     <useSsl>true</useSsl>
     <advProperties>mail.smtp.ssl.trust=example.com</advProperties>
   </mailAccount>
@@ -13,7 +14,8 @@
       <address>admin@example2.com</address>
       <smtpHost>smtp.example2.com</smtpHost>
       <smtpPort>2626</smtpPort>
-      <credentialsId>email-ext-credentials-honeycomb2</credentialsId>
+      <smtpUsername>admin2</smtpUsername>
+      <smtpPassword>honeycomb2</smtpPassword>
       <useSsl>true</useSsl>
       <advProperties>mail.smtp.ssl.trust=example2.com</advProperties>
     </hudson.plugins.emailext.MailAccount>

--- a/src/test/resources/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest/persistedConfigurationWithCredentialId/hudson.plugins.emailext.ExtendedEmailPublisher.xml
+++ b/src/test/resources/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest/persistedConfigurationWithCredentialId/hudson.plugins.emailext.ExtendedEmailPublisher.xml
@@ -2,12 +2,11 @@
 <hudson.plugins.emailext.ExtendedEmailPublisherDescriptor>
   <defaultSuffix>@example.com</defaultSuffix>
   <mailAccount>
-    <address>address not configured yet &lt;nobody@nowhere&gt;</address>
     <smtpHost>smtp.example.com</smtpHost>
     <smtpPort>2525</smtpPort>
-    <smtpUsername>admin</smtpUsername>
-    <smtpPassword>honeycomb</smtpPassword>
+    <credentialsId>email-ext-admin</credentialsId>
     <useSsl>true</useSsl>
+    <useTls>false</useTls>
     <advProperties>mail.smtp.ssl.trust=example.com</advProperties>
     <defaultAccount>true</defaultAccount>
   </mailAccount>
@@ -16,9 +15,9 @@
       <address>admin@example2.com</address>
       <smtpHost>smtp.example2.com</smtpHost>
       <smtpPort>2626</smtpPort>
-      <smtpUsername>admin2</smtpUsername>
-      <smtpPassword>honeycomb2</smtpPassword>
+      <credentialsId>email-ext-admin2</credentialsId>
       <useSsl>true</useSsl>
+      <useTls>false</useTls>
       <advProperties>mail.smtp.ssl.trust=example2.com</advProperties>
       <defaultAccount>false</defaultAccount>
     </hudson.plugins.emailext.MailAccount>
@@ -62,7 +61,6 @@
   <defaultReplyTo>noreply@example.com</defaultReplyTo>
   <allowedDomains>@example.com</allowedDomains>
   <excludedCommitters>excluded@example.com</excludedCommitters>
-  <overrideGlobalSettings>false</overrideGlobalSettings>
   <listId>&lt;list.example.com&gt;</listId>
   <precedenceBulk>true</precedenceBulk>
   <debugMode>true</debugMode>

--- a/src/test/resources/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest/persistedConfigurationWithCredentialId/jenkins.model.JenkinsLocationConfiguration.xml
+++ b/src/test/resources/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest/persistedConfigurationWithCredentialId/jenkins.model.JenkinsLocationConfiguration.xml
@@ -1,0 +1,5 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<jenkins.model.JenkinsLocationConfiguration>
+  <adminAddress>admin@example.com</adminAddress>
+  <jenkinsUrl>http://localhost:56053/jenkins/</jenkinsUrl>
+</jenkins.model.JenkinsLocationConfiguration>


### PR DESCRIPTION
This switches the MailAccount class to use credentials instead of directly storing the username/password. There is an upgrade path from the old settings to using credentials.

https://issues.jenkins.io/browse/JENKINS-66849

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Hacktoberfest submission