### PR TITLE
Use detached JavaMail plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,13 +3,9 @@
  * https://github.com/jenkins-infra/pipeline-library/
  */
 buildPlugin(useContainerAgent: true, configurations: [
-  // Test the long-term support end of the compatibility spectrum (i.e., the minimum required
-  // Jenkins version).
-  [ platform: 'linux', jdk: '8', jenkins: null ],
-
   // Test the common case (i.e., a recent LTS release).
-  [ platform: 'linux', jdk: '8', jenkins: '2.303.2' ],
+  [ platform: 'linux', jdk: '8' ],
 
   // Test the bleeding edge of the compatibility spectrum (i.e., the latest supported Java runtime).
-  [ platform: 'linux', jdk: '11', jenkins: '2.303.2' ],
+  [ platform: 'linux', jdk: '11' ],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/email-ext-plugin</gitHubRepo>
         <java.level>8</java.level>
-        <jenkins.version>2.277.1</jenkins.version>
+        <jenkins.version>2.331</jenkins.version>
         <hpi.compatibleSinceVersion>2.57.2</hpi.compatibleSinceVersion>
         <concurrency>1</concurrency>
         <argLine>-Dfile.encoding=UTF-8</argLine>
@@ -106,8 +106,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.277.x</artifactId>
-                <version>984.vb5eaac999a7e</version>
+                <artifactId>bom-weekly</artifactId>
+                <version>1117.v62a_f6a_01de98</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <revision>2.90</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/email-ext-plugin</gitHubRepo>
-        <jenkins.version>2.332.1</jenkins.version>
+        <jenkins.version>2.346.1</jenkins.version>
         <hpi.compatibleSinceVersion>2.57.2</hpi.compatibleSinceVersion>
         <concurrency>1</concurrency>
         <!-- To be removed once Jenkins.MANAGE gets out of beta -->
@@ -104,7 +104,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.332.x</artifactId>
+                <artifactId>bom-2.346.x</artifactId>
                 <version>1478.v81d3dc4f9a_43</version>
                 <scope>import</scope>
                 <type>pom</type>


### PR DESCRIPTION
Downstream of #335 and jenkinsci/jenkins#6165. Bumps the baseline to one containing jenkinsci/jenkins#6165, thus using the detached JavaMail plugin, but does not upgrade to Jakarta Mail.