### PR TITLE
fix: JENKINS-62079 - Add contributor() recipient provider which pulls information from ContributorMetadataAction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,10 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+        </dependency>
 
         <!-- workflow stuff -->
         <dependency>
@@ -186,11 +190,6 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
             <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>scm-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency> <!-- StepConfigTester -->

--- a/src/main/java/hudson/plugins/emailext/plugins/recipients/ContributorMetadataRecipientProvider.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/recipients/ContributorMetadataRecipientProvider.java
@@ -1,0 +1,82 @@
+package hudson.plugins.emailext.plugins.recipients;
+
+import java.io.PrintStream;
+import java.util.Collections;
+import java.util.Set;
+
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.User;
+import hudson.plugins.emailext.ExtendedEmailPublisherContext;
+import hudson.plugins.emailext.ExtendedEmailPublisherDescriptor;
+import hudson.plugins.emailext.Messages;
+import hudson.plugins.emailext.plugins.RecipientProvider;
+import hudson.plugins.emailext.plugins.RecipientProviderDescriptor;
+import jenkins.model.Jenkins;
+import jenkins.scm.api.metadata.ContributorMetadataAction;
+
+public class ContributorMetadataRecipientProvider extends RecipientProvider {
+
+    @DataBoundConstructor
+    public ContributorMetadataRecipientProvider() {
+
+    }
+
+    @Override
+    public void addRecipients(ExtendedEmailPublisherContext context, EnvVars env, Set<InternetAddress> to,
+            Set<InternetAddress> cc, Set<InternetAddress> bcc) {
+
+        final class Debug implements RecipientProviderUtilities.IDebug {
+            private final ExtendedEmailPublisherDescriptor descriptor
+                    = Jenkins.get().getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
+
+            private final PrintStream logger = context.getListener().getLogger();
+
+            public void send(final String format, final Object... args) {
+                descriptor.debug(logger, format, args);
+            }
+        }
+
+        final Debug debug = new Debug();
+
+        ContributorMetadataAction contributor = context.getRun().getAction(ContributorMetadataAction.class);
+        if(contributor != null) {
+            User user = User.getById(contributor.getContributor(), false);
+            if(user == null) {
+                // just add the email address if set
+                if(!StringUtils.isBlank(contributor.getContributorEmail())) {
+                    try {
+                        to.add(new InternetAddress(contributor.getContributorEmail()));
+                    } catch(AddressException e) {
+                        context.getListener().error(Messages.ErrorAddingContributorAddress(e.getMessage()));
+                        debug.send(Messages.ErrorAddingContributorAddress(e.toString()));
+                    }
+                }
+            } else {
+                RecipientProviderUtilities.addUsers(Collections.singleton(user), context, env, to, cc, bcc, debug);
+            }
+        } else {
+            context.getListener().getLogger().print(Messages.NoContributorInformationAvailable());
+        }    
+    }
+
+    @Extension
+    @Symbol("contributor")
+    public static final class DescriptorImpl extends RecipientProviderDescriptor {
+
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return Messages.ContributorMetadataRecipientProvider_DisplayName();
+        }
+    }
+    
+}

--- a/src/main/resources/hudson/plugins/emailext/Messages.properties
+++ b/src/main/resources/hudson/plugins/emailext/Messages.properties
@@ -30,8 +30,8 @@ BuildUserRecipientProvider.DisplayName=Build User
 UpstreamComitterRecipientProvider.DisplayName=Upstream Committers
 ContributorMetadataRecipientProvider.DisplayName=Contributor
 
-ErrorAddingContributorAddress=Error adding contributor email address: {0}
-NoContributorInformationAvailable=No contributor information available
+ContributorMetadataRecipientProvider.ErrorAddingContributorAddress=Error adding contributor email address: {0}
+ContributorMetadataRecipientProvider.NoContributorInformationAvailable=No contributor information available
 
 contentType.plainText=Plain Text (text/plain)
 contentType.html=HTML (text/html)

--- a/src/main/resources/hudson/plugins/emailext/Messages.properties
+++ b/src/main/resources/hudson/plugins/emailext/Messages.properties
@@ -28,6 +28,10 @@ ListRecipientProvider.DisplayName=Recipient List
 RequesterRecipientProvider.DisplayName=Requestor
 BuildUserRecipientProvider.DisplayName=Build User
 UpstreamComitterRecipientProvider.DisplayName=Upstream Committers
+ContributorMetadataRecipientProvider.DisplayName=Contributor
+
+ErrorAddingContributorAddress=Error adding contributor email address: {0}
+NoContributorInformationAvailable=No contributor information available
 
 contentType.plainText=Plain Text (text/plain)
 contentType.html=HTML (text/html)

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/ContributorMetadataRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/ContributorMetadataRecipientProviderTest.java
@@ -1,0 +1,57 @@
+package hudson.plugins.emailext.plugins.recipients;
+
+import hudson.model.Result;
+import hudson.plugins.emailext.ExtendedEmailPublisherDescriptor;
+import hudson.tasks.Mailer;
+import jenkins.model.Jenkins;
+import jenkins.scm.api.metadata.ContributorMetadataAction;
+
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+public class ContributorMetadataRecipientProviderTest {
+
+    private MockedStatic<Jenkins> mockedJenkins;
+    private MockedStatic<Mailer> mockedMailer;
+
+    @Before
+    public void before() {
+        final Jenkins jenkins = Mockito.mock(Jenkins.class);
+        Mockito.when(jenkins.isUseSecurity()).thenReturn(false);
+        final ExtendedEmailPublisherDescriptor extendedEmailPublisherDescriptor = Mockito.mock(ExtendedEmailPublisherDescriptor.class);
+        extendedEmailPublisherDescriptor.setDebugMode(true);
+        Mockito.when(extendedEmailPublisherDescriptor.getExcludedCommitters()).thenReturn("");
+
+        Mockito.when(jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class)).thenReturn(extendedEmailPublisherDescriptor);
+        mockedJenkins = Mockito.mockStatic(Jenkins.class);
+        mockedJenkins.when(Jenkins::get).thenReturn(jenkins);
+
+        final Mailer.DescriptorImpl descriptor = Mockito.mock(Mailer.DescriptorImpl.class);
+        Mockito.when(descriptor.getDefaultSuffix()).thenReturn("DOMAIN");
+        mockedMailer = Mockito.mockStatic(Mailer.class);
+        mockedMailer.when(Mailer::descriptor).thenReturn(descriptor);
+    }
+
+    @After
+    public void after() {
+        mockedMailer.close();
+        mockedJenkins.close();
+    }
+
+    @Test
+    public void testAddRecipients() throws Exception {
+        final WorkflowJob j = Mockito.mock(WorkflowJob.class);
+        final WorkflowRun build = Mockito.spy(new WorkflowRun(j));
+        Mockito.when(build.getResult()).thenReturn(Result.UNSTABLE);
+        final ContributorMetadataAction action = Mockito.mock(ContributorMetadataAction.class);
+        Mockito.when(action.getContributorEmail()).thenReturn("mickey@disney.com");
+        Mockito.when(build.getAction(ContributorMetadataAction.class)).thenReturn(action);
+
+        TestUtilities.checkRecipients(build, new ContributorMetadataRecipientProvider(), "mickey@disney.com");
+    }    
+}


### PR DESCRIPTION
This adds a recipient provider which pulls information from the ContributorMetadataAction which is applied to the Run from multiple SCM providers.

https://issues.jenkins.io/browse/JENKINS-62079

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
