### PR TITLE
fix: JENKINS-69414 - Add OAuth 2.0 support

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -358,6 +358,10 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
             props.put("mail.smtp.auth", "true");
         }
 
+        if(acc.isUseOAuth2()) {
+            props.put("mail.smtp.auth.mechanisms", "XOAUTH2");
+        }
+
         // avoid hang by setting some timeout.
         props.put("mail.smtp.timeout", "60000");
         props.put("mail.smtp.connectiontimeout", "60000");

--- a/src/main/java/hudson/plugins/emailext/MailAccount.java
+++ b/src/main/java/hudson/plugins/emailext/MailAccount.java
@@ -44,6 +44,8 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount>{
     private String advProperties;
     private boolean defaultAccount;
 
+    private boolean useOAuth2;
+
     @Deprecated
     public MailAccount(JSONObject jo){
         address = Util.nullify(jo.optString("address", null));
@@ -239,6 +241,15 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount>{
     @DataBoundSetter
     public void setUseTls(boolean useTls){
         this.useTls = useTls;
+    }
+
+    public boolean isUseOAuth2() {
+        return useOAuth2;
+    }
+
+    @DataBoundSetter
+    public void setUseOAuth2(boolean useOAuth2) {
+        this.useOAuth2 = useOAuth2;
     }
 
     public String getAdvProperties(){

--- a/src/main/resources/hudson/plugins/emailext/MailAccount/config.groovy
+++ b/src/main/resources/hudson/plugins/emailext/MailAccount/config.groovy
@@ -23,11 +23,13 @@ f.advanced {
     f.entry(field: "credentialsId", title: _("Credentials")) {
         c.select()
     }
-
     f.entry(field: "useSsl", title: _("Use SSL")) {
         f.checkbox()
     }
     f.entry(field: "useTls", title: _("Use TLS")) {
+        f.checkbox()
+    }
+    f.entry(field: "useOAuth2", title: _("Use OAuth 2.0")) {
         f.checkbox()
     }
     f.entry(field: "advProperties", title: _("Advanced Email Properties")) {


### PR DESCRIPTION
This adds a checkbox to the mail account configuration to allow users to enable OAuth 2.0 (see https://javaee.github.io/javamail/OAuth2).

The token needs to be put as the password in the credentials.

See https://issues.jenkins.io/browse/JENKINS-69414

I tested with Gmail using my email address and the OAuth 2.0 token as the password in the credential for the MailAccount.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
