### PR TITLE
Fix tests with Jenkins 2.395

### DIFF
--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
@@ -58,6 +58,7 @@ import hudson.plugins.emailext.plugins.trigger.UnstableTrigger;
 import hudson.plugins.emailext.plugins.trigger.XNthFailureTrigger;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
+import hudson.util.VersionNumber;
 import jakarta.mail.Authenticator;
 import java.util.Collection;
 import java.util.Collections;
@@ -79,12 +80,21 @@ public class ExtendedEmailPublisherDescriptorTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
+    private void assertTitlePage(HtmlPage page) {
+        VersionNumber jenkinsVersion = j.jenkins.getVersion();
+        VersionNumber newManageJenkinsVersion = new VersionNumber("2.395");
+        String expectedTitle = "System [Jenkins]";
+        if (jenkinsVersion.isOlderThan(newManageJenkinsVersion)) {
+            expectedTitle = "Configure System [Jenkins]";
+        }
+        assertEquals("Should be at the Configure System page", expectedTitle, page.getTitleText());
+    }
+
     @Test
     public void testGlobalConfigDefaultState() throws Exception {
         HtmlPage page = j.createWebClient().goTo("configure");
 
-        assertEquals("Should be at the Configure System page",
-                "Configure System [Jenkins]", page.getTitleText());
+        assertTitlePage(page);
 
         HtmlTextInput smtpHost = page.getElementByName("_.smtpHost");
         assertNotNull("SMTP Server should be present", smtpHost);
@@ -250,8 +260,7 @@ public class ExtendedEmailPublisherDescriptorTest {
         ExtendedEmailPublisherDescriptor descriptor = j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
         HtmlPage page = j.createWebClient().goTo("configure");
 
-        assertEquals("Should be at the Configure System page",
-                "Configure System [Jenkins]", page.getTitleText());
+        assertTitlePage(page);
 
         List<DomNode> nodes = page.getByXPath(".//button[contains(text(),'Default Triggers')]");
         assertEquals(1, nodes.size());
@@ -287,8 +296,7 @@ public class ExtendedEmailPublisherDescriptorTest {
         ExtendedEmailPublisherDescriptor descriptor = j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
         HtmlPage page = j.createWebClient().goTo("configure");
 
-        assertEquals("Should be at the Configure System page",
-                "Configure System [Jenkins]", page.getTitleText());
+        assertTitlePage(page);
 
         List<DomElement> nodes = page.getByXPath(".//div[contains(@class, 'setting-name') and ./text()='Additional groovy classpath'] | .//div[contains(@class, 'jenkins-form-label') and ./text()='Additional groovy classpath']");
         assertEquals(1, nodes.size());


### PR DESCRIPTION
## Fix assertions for configure system page on 2.395

Jenkins 2.395 includes https://github.com/jenkinsci/jenkins/pull/7661 that simplifies the names of the settings on the "Configure System" page.

That simplification breaks email-ext tests in the Jenkins plugin bill of materials and any time they are run with Jenkins 2.395 or later.  We can temporarily exclude the tests from the plugin bill of materials, but it is much better to have the tests pass.

This pull request adapts the tests to the change so that they pass with the current weekly and past LTS releases.

https://github.com/jenkinsci/bom/pull/1857 shows the failing tests with Jenkins 2.395.

The failures can also be seen with the command:

```
$ mvn clean -Djenkins.verison=2.395 -Dtest=ExtendedEmailPublisherDescriptorTest verify
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
