### PR TITLE
[JENKINS-71709] Improve logger message to identify users by ID

### DIFF
--- a/src/main/java/hudson/plugins/emailext/plugins/recipients/RecipientProviderUtilities.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/recipients/RecipientProviderUtilities.java
@@ -192,13 +192,15 @@ public final class RecipientProviderUtilities {
                                 if (SEND_TO_USERS_WITHOUT_READ) {
                                     listener.getLogger()
                                             .printf(
-                                                    "Warning: user %s has no permission to view %s, but sending mail anyway%n",
-                                                    userAddress, run.getFullDisplayName());
+                                                    "Warning: user (id: %s, email: %s) has no permission to view %s, " +
+                                                        "but sending mail anyway%n",
+                                                    user.getId(), userAddress, run.getFullDisplayName());
                                 } else {
                                     listener.getLogger()
                                             .printf(
-                                                    "Not sending mail to user %s with no permission to view %s",
-                                                    userAddress, run.getFullDisplayName());
+                                                    "Not sending mail to user (id: %s, email: %s) with no permission " +
+                                                        "to view %s",
+                                                    user.getId(), userAddress, run.getFullDisplayName());
                                     continue;
                                 }
                             }
@@ -208,14 +210,14 @@ public final class RecipientProviderUtilities {
                                     || ExtendedEmailPublisher.descriptor().isAllowUnregisteredEnabled()) {
                                 listener.getLogger()
                                         .printf(
-                                                "Warning: %s is not a recognized user, but sending mail anyway%n",
-                                                userAddress);
+                                                "Warning: user (id: %s, email: %s) is not a recognized user, but sending mail anyway%n",
+                                                user.getId(), userAddress);
                             } else {
                                 listener.getLogger()
                                         .printf(
-                                                "Not sending mail to unregistered user %s because your SCM"
-                                                        + " claimed this was associated with a user ID ‘",
-                                                userAddress);
+                                                "Not sending mail to unregistered user (id: %s, email: %s) because " +
+                                                    "your SCM claimed this was associated with a user ID ‘",
+                                                user.getId(), userAddress);
                                 try {
                                     listener.hyperlink('/' + user.getUrl(), user.getDisplayName());
                                 } catch (IOException ignored) {

--- a/src/main/java/hudson/plugins/emailext/plugins/recipients/RecipientProviderUtilities.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/recipients/RecipientProviderUtilities.java
@@ -192,14 +192,14 @@ public final class RecipientProviderUtilities {
                                 if (SEND_TO_USERS_WITHOUT_READ) {
                                     listener.getLogger()
                                             .printf(
-                                                    "Warning: user (id: %s, email: %s) has no permission to view %s, " +
-                                                        "but sending mail anyway%n",
+                                                    "Warning: user (id: %s, email: %s) has no permission to view %s, "
+                                                            + "but sending mail anyway%n",
                                                     user.getId(), userAddress, run.getFullDisplayName());
                                 } else {
                                     listener.getLogger()
                                             .printf(
-                                                    "Not sending mail to user (id: %s, email: %s) with no permission " +
-                                                        "to view %s",
+                                                    "Not sending mail to user (id: %s, email: %s) with no permission "
+                                                            + "to view %s",
                                                     user.getId(), userAddress, run.getFullDisplayName());
                                     continue;
                                 }
@@ -215,8 +215,8 @@ public final class RecipientProviderUtilities {
                             } else {
                                 listener.getLogger()
                                         .printf(
-                                                "Not sending mail to unregistered user (id: %s, email: %s) because " +
-                                                    "your SCM claimed this was associated with a user ID ‘",
+                                                "Not sending mail to unregistered user (id: %s, email: %s) because "
+                                                        + "your SCM claimed this was associated with a user ID ‘",
                                                 user.getId(), userAddress);
                                 try {
                                     listener.hyperlink('/' + user.getUrl(), user.getDisplayName());


### PR DESCRIPTION
[JENKINS-71709](https://issues.jenkins.io/browse/JENKINS-71709): log not just the user email address but also user ID to help identify why a user might be subjected to a specific warning (such as missing permission).

### Testing done

Let me know if a test is needed for this.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```