### PR TITLE
Replace unicode left single quotation by Ascii single quote

### DIFF
--- a/src/main/java/hudson/plugins/emailext/plugins/recipients/RecipientProviderUtilities.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/recipients/RecipientProviderUtilities.java
@@ -216,7 +216,7 @@ public final class RecipientProviderUtilities {
                                 listener.getLogger()
                                         .printf(
                                                 "Not sending mail to unregistered user (id: %s, email: %s) because "
-                                                        + "your SCM claimed this was associated with a user ID ‘",
+                                                        + "your SCM claimed this was associated with a user ID '",
                                                 user.getId(), userAddress);
                                 try {
                                     listener.hyperlink('/' + user.getUrl(), user.getDisplayName());


### PR DESCRIPTION
Use Ascii single quotes on both sides of the user name. Jenkins core uses the unicode character in several places, but this plugin generally doesn't.
See line 226 for the finishing quote character.

### Testing done

None

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
