### PR TITLE
HTML formatted email not showing up at all in Gmail 

### DIFF
--- a/src/main/resources/hudson/plugins/emailext/templates/groovy-html-larry.template
+++ b/src/main/resources/hudson/plugins/emailext/templates/groovy-html-larry.template
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<style type="text/css">
+<style type="text/css" data-inline="true">
 /*base css*/
 a{color:#4a72af}
 body{background-color:#e4e4e4}

--- a/src/main/resources/hudson/plugins/emailext/templates/groovy-html.template
+++ b/src/main/resources/hudson/plugins/emailext/templates/groovy-html.template
@@ -1,4 +1,4 @@
-<STYLE>
+<STYLE type="text/css" data-inline="true">
   BODY, TABLE, TD, TH, P {
     font-family: Calibri, Verdana, Helvetica, sans serif;
     font-size: 12px;


### PR DESCRIPTION
The email was not coming in the default expected template format as Gmail no longer supports the Style tag.

### Testing done

Done

<!-- Comment:
Provide a clear description of how this change was tested.
Tested in Yahoo, gmail mail after this working as expected
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

