### PR TITLE
[JENKINS-71881] Allow administrators to disable modification of the 'from' email field

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -99,6 +99,28 @@ step([$class: 'Mailer',
   recipients: emailextrecipients([culprits(), requestor()])])
 ----
 
+=== Allow administrators to disable modification of the 'from' email field
+
+If you would like to disable the ability to use `from:` with the `emailext` Pipeline step, as well as disable `Project From` for freestyle jobs, start your controller with the system property: `-Dhudson.plugins.emailext.disable-job-from=true`.
+When this system property is enabled, emails will always use the `from` address defined at `Manage Jenkins` -> `System` -> `System Admin e-mail address`.
+If a Pipeline uses `from:` when this property is true, the value from the `from:` field will be ignored (email will still be sent), and the following message will be emitted in the controller logs::
+
+----
+INFO    h.plugins.emailext.EmailExtStep#setFrom: Pipeline step used 'from', from value was ignored because it is disabled via system property hudson.plugins.emailext.disable-job-from
+----
+
+If a freestyle job is configured with the `Project From` field, when saving the job configuration that field is ignored, and the following message will be emitted in the controller logs:
+
+----
+INFO    h.p.e.ExtendedEmailPublisher#<init>: Freestyle job was configured with `Project From`, from value was ignored because it is disabled via system property hudson.plugins.emailext.disable-job-from
+----
+
+If a freestyle job was already configured and using the `Project From` field, then subsequently this system property is enabled, the 'from' will be ignored (but the job will not be reconfigured), and a message will be emitted in the controller logs:
+
+----
+INFO    h.p.e.ExtendedEmailPublisher#getFromAddress: Pre-existing freestyle job had configuration with `Project From`, from value was ignored because it is disabled via system property hudson.plugins.emailext.disable-job-from
+----
+
 == Usage
 
 To see the advanced configuration for this plugin, click on the *Advanced* button.

--- a/src/main/java/hudson/plugins/emailext/EmailExtStep.java
+++ b/src/main/java/hudson/plugins/emailext/EmailExtStep.java
@@ -19,6 +19,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -34,6 +36,7 @@ import org.kohsuke.stapler.DataBoundSetter;
  * Created by acearl on 9/14/2015.
  */
 public class EmailExtStep extends Step {
+    private static final Logger LOGGER = Logger.getLogger(EmailExtStep.class.getName());
 
     public final String subject;
 
@@ -98,7 +101,15 @@ public class EmailExtStep extends Step {
 
     @DataBoundSetter
     public void setFrom(@CheckForNull String from) {
-        this.from = Util.fixNull(from);
+        if (ExtendedEmailPublisher.DISABLE_FROM) {
+            LOGGER.log(
+                    Level.INFO,
+                    "Pipeline step used 'from', from value was ignored because it is disabled via system property "
+                            + ExtendedEmailPublisher.DISABLE_FROM_PROPERTY);
+            this.from = "";
+        } else {
+            this.from = Util.fixNull(from);
+        }
     }
 
     public @CheckForNull String getReplyTo() {


### PR DESCRIPTION
[JENKINS-71881](https://issues.jenkins.io/browse/JENKINS-71881)

The email-ext plugin currently allows users configuring jobs on a controller to modify the 'from' attribute at a job level (using Pipeline `from:` , or freestyle `Project From`). When using gmail, this field will be in the email as `X-Google-Original-From:`.

Some companies have internal policies which do not allow this.

With this new feature, the 'from' field of emails sent by the email-ext plugin should always use the `from` address defined at `Manage Jenkins` -> `System` -> `System Admin e-mail address`, and not be configurable at a job-level.

Not all users will want to enable this restriction, so an optional system property to enable this feature has been added, the feature is disabled by default and must be enabled by adding the system property set to true: `-Dhudson.plugins.emailext.disable-job-from=true`.

When enabled, an informational message will be printed to the controller logs when the 'from' field is used by a job (indicating the 'from' has been ignored).

### Testing done

Manual tests performed by running:

```
mvn hpi:run -Dhudson.plugins.emailext.disable-job-from=true
```

* Configuring the email-ext plugin with my email provider
* Setting my email address at `Manage Jenkins` -> `System` -> `System Admin e-mail address`
* Creating a Pipeline job which uses the `from` field (my actual email address was used):

```
emailext body: 'test', subject: 'test-using-from', to: 'user@example.com', from: 'user2@example.com'
```

* When this job is run, the controller logs emit:

```
INFO    h.plugins.emailext.EmailExtStep#setFrom: Pipeline step used 'from', from value was ignored because it is disabled via system property hudson.plugins.emailext.disable-job-from
```

* The email I receive does not contain the `X-Google-Original-From:` field (which is the email field I saw before this change was implemented)

* Creating a Freestyle job, adding a `Post-build Actions` of type `Editable Email Notification`, and filling in the `Project From` field, then saving the job. Upon saving the following log is emitted in the controller logs, and when the job is configured again, the `Project From` field is blank (the value was not saved):

```
INFO    h.p.e.ExtendedEmailPublisher#<init>: Freestyle job was configured with `Project From`, from value was ignored because it is disabled via system property hudson.plugins.emailext.disable-job-from
```

* Stop the instance, and start it without the system property:

```
mvn hpi:run
```

* Create a Freestyle job, adding a `Post-build Actions` of type `Editable Email Notification`, and filling in the `Project From` field, then saving the job. 
* Stop the instance, and start it with the system property:

```
mvn hpi:run -Dhudson.plugins.emailext.disable-job-from=true
```

* Run the freestyle job and the email I receive does not contain the `X-Google-Original-From:` field, and the controller logs will contain:

```
INFO    h.p.e.ExtendedEmailPublisher#getFromAddress: Pre-existing freestyle job had configuration with `Project From`, from value was ignored because it is disabled via system property hudson.plugins.emailext.disable-job-from
```

* I also tested Pipeline and freestyle jobs which do not set the `from` field work correctly, and do not emit any messages in the controller logs
* When the system property is set, all emails come from the email address at `Manage Jenkins` -> `System` -> `System Admin e-mail address`, and the  `X-Google-Original-From:` field is not included in the emails.

I'm currently evaluating what automated tests can be written for this feature.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] ~Link to relevant pull requests, esp. upstream and downstream changes~
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
