### PR TITLE
[JENKINS-71925] Deprecation of jobs modifying the 'from' email field

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -310,6 +310,18 @@ Class groovyClass = new GroovyClassLoader(getClass().getClassLoader()).parseClas
 GroovyObject jiveFormatter = (GroovyObject) groovyClass.newInstance();
 ----
 
+=== JENKINS-71925: Deprecation of jobs modifying the 'from' email field
+
+In plugin version `2.100` and older, users could configure jobs on a controller to modify the 'from' attribute at a job level (using Pipeline `from:` , or freestyle `Project From`).
+
+Some companies have internal policies which do not allow this, and it can be unexpected when an email 'from' can be controlled by any user who has the `Job/Configure` permission or the ability to commit to a repo which contains a Jenkinsfile.
+
+The 'from' field of emails now always uses the `from` address defined at `Manage Jenkins` -> `System` -> `System Admin e-mail address`, and is not configurable at a job-level.
+
+Users that would like to go back to the previous behaviour can add the system property as a startup argument: `-Dhudson.plugins.emailext.enable-job-from=true`.
+
+A message is emitted to the controller logs when the 'from'/'project from' field is used by a job, at a `WARNING` level if the 'from' address was ignored, and 'INFO' level if the system property is set (to remind about the deprecation).
+
 == Related plugins
 
 * https://plugins.jenkins.io/email-ext-recipients-column/[Email Ext Recipients Column plugin]

--- a/README.adoc
+++ b/README.adoc
@@ -318,7 +318,7 @@ Some companies have internal policies which do not allow this, and it can be une
 
 The 'from' field of emails now always uses the `from` address defined at `Manage Jenkins` -> `System` -> `System Admin e-mail address`, and is not configurable at a job-level.
 
-Users that would like to go back to the previous behaviour can add the system property as a startup argument: `-Dhudson.plugins.emailext.enable-job-from=true`.
+Users that would like to go back to the previous behaviour can add the system property as a startup argument: `-Dhudson.plugins.emailext.ExtendedEmailPublisher.enableFrom=true`.
 
 A message is emitted to the controller logs when the 'from'/'project from' field is used by a job, at a `WARNING` level if the 'from' address was ignored, and 'INFO' level if the system property is set (to remind about the deprecation).
 

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -105,11 +105,17 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
 
     private static final String CONTENT_TRANSFER_ENCODING =
             System.getProperty(ExtendedEmailPublisher.class.getName() + ".Content-Transfer-Encoding");
-    protected static final String ENABLE_FROM_PROPERTY =
-            ExtendedEmailPublisher.class.getPackage().getName() + ".enable-job-from";
-    protected static final boolean ENABLE_FROM =
-            System.getProperty(ENABLE_FROM_PROPERTY, "false").equals("true");
 
+    private static final String ENABLE_FROM_PROPERTY =
+            ExtendedEmailPublisher.class.getPackage().getName() + ".enable-job-from";
+
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "for script console")
+    public static boolean ENABLE_FROM = Boolean.getBoolean(ENABLE_FROM_PROPERTY);
+
+    /*
+     * for Stapler
+     */
+    @Restricted(NoExternalUse.class)
     public static boolean getEnableFrom() {
         return ENABLE_FROM;
     }

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -106,8 +106,7 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
     private static final String CONTENT_TRANSFER_ENCODING =
             System.getProperty(ExtendedEmailPublisher.class.getName() + ".Content-Transfer-Encoding");
 
-    private static final String ENABLE_FROM_PROPERTY =
-            ExtendedEmailPublisher.class.getPackage().getName() + ".enable-job-from";
+    private static final String ENABLE_FROM_PROPERTY = ExtendedEmailPublisher.class.getName() + ".enableFrom";
 
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "for script console")
     public static boolean ENABLE_FROM = Boolean.getBoolean(ENABLE_FROM_PROPERTY);

--- a/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/config.groovy
+++ b/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/config.groovy
@@ -13,6 +13,7 @@ def configured = instance != null
 f.entry(title: _("Disable Extended Email Publisher"), help: "/plugin/email-ext/help/projectConfig/disable.html", description: _("Allows the user to disable the publisher, while maintaining the settings")) {
     f.checkbox(name: "project_disabled", checked: instance?.disabled)
 }
+
 if (hudson.plugins.emailext.ExtendedEmailPublisher.getEnableFrom()) {
   f.entry(title: _("Project From")) {
     f.textbox(name: "project_from", value: configured ? instance.from : "")

--- a/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/config.groovy
+++ b/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/config.groovy
@@ -13,7 +13,7 @@ def configured = instance != null
 f.entry(title: _("Disable Extended Email Publisher"), help: "/plugin/email-ext/help/projectConfig/disable.html", description: _("Allows the user to disable the publisher, while maintaining the settings")) {
     f.checkbox(name: "project_disabled", checked: instance?.disabled)
 }
-if (hudson.plugins.emailext.ExtendedEmailPublisher.getEnableFrom() ) {
+if (hudson.plugins.emailext.ExtendedEmailPublisher.getEnableFrom()) {
   f.entry(title: _("Project From")) {
     f.textbox(name: "project_from", value: configured ? instance.from : "")
   }

--- a/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/config.groovy
+++ b/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/config.groovy
@@ -13,9 +13,10 @@ def configured = instance != null
 f.entry(title: _("Disable Extended Email Publisher"), help: "/plugin/email-ext/help/projectConfig/disable.html", description: _("Allows the user to disable the publisher, while maintaining the settings")) {
     f.checkbox(name: "project_disabled", checked: instance?.disabled)
 }
-
-f.entry(title: _("Project From")) {
-  f.textbox(name: "project_from", value: configured ? instance.from : "")
+if (hudson.plugins.emailext.ExtendedEmailPublisher.getEnableFrom() ) {
+  f.entry(title: _("Project From")) {
+    f.textbox(name: "project_from", value: configured ? instance.from : "")
+  }
 }
 f.entry(title: _("Project Recipient List"), help: "/plugin/email-ext/help/projectConfig/globalRecipientList.html", description: _("Comma-separated list of email address that should receive notifications for this project.")) {
   f.textarea(name: "project_recipient_list", value: configured ? instance.recipientList : "\$DEFAULT_RECIPIENTS", checkUrl: "'${rootURL}/publisher/ExtendedEmailPublisher/recipientListRecipientsCheck?value='+encodeURIComponent(this.value)")

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
@@ -1641,6 +1641,7 @@ public class ExtendedEmailPublisherTest {
         Message msg = mailbox.get(0);
         Address[] from = msg.getFrom();
         assertEquals(1, from.length);
+
         // JENKINS-71925 from email should be ignored
         assertEquals(JenkinsLocationConfiguration.get().getAdminAddress(), from[0].toString());
     }


### PR DESCRIPTION
[JENKINS-71925](https://issues.jenkins.io/browse/JENKINS-71925)

Re-implementing this feature after discussion with @basil in https://github.com/jenkinsci/email-ext-plugin/pull/479

The email-ext plugin previously allowed users configuring jobs on a controller to modify the 'from' attribute at a job level (using Pipeline `from:` , or freestyle `Project From`).

Some companies have internal policies which do not allow this, and it can be unexpected when an email 'from' can be controlled by any user who has the `Job/Configure` permission or the ability to commit to a repo which contains a Jenkinsfile.

After this change, the 'from' field of emails sent by the email-ext plugin should always use the `from` address defined at `Manage Jenkins` -> `System` -> `System Admin e-mail address`, and not be configurable at a job-level.

Users that would like to go back to the previous behaviour can add the system property as a startup argument: `-Dhudson.plugins.emailext.enable-job-from=true`.

A message is emitted to the controller logs when the 'from'/'project from' field is used by a job, at a `WARNING` level if the 'from' address was ignored, and 'INFO' level if the system property is set (to remind about the deprecation).

### Testing done

1 . Start the instance with the system property to continue to allow 'from' feature to be available:

```
mvn hpi:run -Dhudson.plugins.emailext.enable-job-from=true
```

2 . Configure the email-ext plugin with my email provider
3 . Set my email address at `Manage Jenkins` -> `System` -> `System Admin e-mail address`
4 . Create a Pipeline job which uses the `from` field with a fake address (sent to myself)

```
emailext body: 'test', subject: 'test-using-from', to: 'me@example.com', from: 'user2@example.com'
```

5 . When this job is run, I see `X-Google-Original-From:` in the email content, and the following message is logged (this message is not emitted if `from:` is not used):

```
INFO    h.p.e.ExtendedEmailPublisher#getFromAddress: JENKINS-71925: Job has `Project From` configured, which is deprecated
```

6 . Create a Freestyle job, adding a `Post-build Actions` of type `Editable Email Notification`, and filling in the `Project From` field, then saving the job. When the job is saved, and the `Project From` field is is not blank, the following message is logged:

```
INFO    h.p.e.ExtendedEmailPublisher#<init>: JENKINS-71925: Freestyle job was configured with `Project From` which is deprecated
```

7 . When this freestyle job runs, I see `X-Google-Original-From:` in the email, and the following message is logged:

```
INFO    h.p.e.ExtendedEmailPublisher#getFromAddress: JENKINS-71925: Job has `Project From` configured, which is deprecated
```

8 . Stop the controller and start it without the new system property (so the feature is disabled by default):

```
mvn hpi:run
```

9 . Run the Pipeline job from step 4, the email will not contain `X-Google-Original-From:`, and the following warning is logged:

```
WARNING h.p.e.ExtendedEmailPublisher#getFromAddress: JENKINS-71925: Job has `Project From` configured, from value was ignored because it is disabled by default. Enable by setting system property 'hudson.plugins.emailext.enable-job-from' to true
```

10 . Run the freestyle job from step 6, the email will not contain `X-Google-Original-From:`, and the following warning is logged:


```
WARNING h.p.e.ExtendedEmailPublisher#getFromAddress: JENKINS-71925: Job has `Project From` configured, from value was ignored because it is disabled by default. Enable by setting system property 'hudson.plugins.emailext.enable-job-from' to true
```

11 . I also tested Pipeline and freestyle jobs which do not set the `from` field, they work correctly, and do not emit any messages in the controller logs (the email comes from the `System Admin e-mail address`)

12 . Configure the freestyle job from step 6, notice the `Project From` field no longer shows up in the UI, and when the job is saved, the config is saved without `Project From`.

13 . Stop the instance again, and add the system property:

```
mvn hpi:run -Dhudson.plugins.emailext.enable-job-from=true
```

14 . Ensure the 'from' feature still works for freestyle and Pipeline jobs, but the job which was saved in step 12 has the `Project From` field empty



### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue