### PR TITLE
Include warnings-ng reports in templates

### DIFF
--- a/src/main/resources/hudson/plugins/emailext/templates/groovy-html.template
+++ b/src/main/resources/hudson/plugins/emailext/templates/groovy-html.template
@@ -51,6 +51,10 @@
   .test-failed {
     color: #E74C3C;
   }
+  .td-title-issues {
+    font-weight: bold;
+    font-size: 120%;
+  }
 </STYLE>
 <BODY>
   <!-- BUILD RESULT -->
@@ -235,6 +239,40 @@
   </table>
   <br/>
   <% } %>
+
+<!-- WARNINGS-NG REPORT -->
+  <%
+  try {
+    def aggregationAction = it.getAction("io.jenkins.plugins.analysis.core.model.AggregationAction")
+    if ( aggregationAction != null ) { %>
+  <table class="section">
+    <tr class="tr-title">
+      <td class="td-title" colspan="5">${hudson.Util.xmlEscape(aggregationAction.getDisplayName())}</td>
+    </tr>
+    <tr>
+      <td class="td-title-issues">Tool</td>
+      <td class="td-title-issues">Low</td>
+      <td class="td-title-issues">Normal</td>
+      <td class="td-title-issues">High</td>
+      <td class="td-title-issues">Error</td>
+    </tr>
+      <% aggregationAction.getTools().each {
+        tool -> %>
+    <tr>
+      <td><a href="${tool.getLatestUrl()}">${hudson.Util.xmlEscape(tool.getName())}</a></td>
+      <td>${tool.getLowSize()}</td>
+      <td>${tool.getNormalSize()}</td>
+      <td>${tool.getHighSize()}</td>
+      <td>${tool.getErrorSize()}</td>
+    </tr>
+    <% } %>
+    </table>
+  <br/>
+  <%
+    }
+  } catch(e) {
+    // we don't do anything
+  } %>
 
 <!-- CONSOLE OUTPUT -->
   <%

--- a/src/main/resources/hudson/plugins/emailext/templates/groovy-text.template
+++ b/src/main/resources/hudson/plugins/emailext/templates/groovy-text.template
@@ -26,6 +26,21 @@ CHANGE SET
 <% }
 } %>
 
+<%
+try {
+   def aggregationAction = it.getAction("io.jenkins.plugins.analysis.core.model.AggregationAction")
+   if ( aggregationAction != null ) { %>
+${aggregationAction.getDisplayName().toUpperCase()}
+      <% aggregationAction.getTools().each {
+        tool -> %>
+Tool: ${tool.getName()}
+Report: ${tool.getLatestUrl()}
+Low: ${tool.getLowSize()}, Normal: ${tool.getNormalSize()}, High: ${tool.getHighSize()}, Error: ${tool.getErrorSize()}
+<% 	}
+   }
+  } catch(e) {
+    // we don't do anything
+  } %>
 
 <% if(build.result==hudson.model.Result.FAILURE) { %>
 CONSOLE OUTPUT

--- a/src/main/resources/hudson/plugins/emailext/templates/html.jelly
+++ b/src/main/resources/hudson/plugins/emailext/templates/html.jelly
@@ -237,6 +237,31 @@ TD.console { font-family:Courier New; }
 <BR/>
 </j:if>
 
+<!-- WARNINGS-NG REPORT -->
+
+<j:set var="aggregationAction" value="${it.getAction('io.jenkins.plugins.analysis.core.model.AggregationAction')}" />
+<j:if test="${aggregationAction!=null}">
+    <table width="100%">
+        <tr><td class="bg1" colspan="5"><b>${aggregationAction.getDisplayName()}</b></td></tr>
+        <tr>
+            <td class="bg2">Tool</td>
+            <td class="bg2">Low</td>
+            <td class="bg2">Normal</td>
+            <td class="bg2">High</td>
+            <td class="bg2">Error</td>
+        </tr>
+        <j:forEach var="tool" items="${aggregationAction.getTools()}">
+            <tr>
+                <td><a href="${tool.getLatestUrl()}">${tool.getName()}</a></td>
+                <td>${tool.getLowSize()}</td>
+                <td>${tool.getNormalSize()}</td>
+                <td>${tool.getHighSize()}</td>
+                <td>${tool.getErrorSize()}</td>
+            </tr>
+        </j:forEach>
+    </table>
+    <br/>
+</j:if>
 
 <!-- CONSOLE OUTPUT -->
 

--- a/src/main/resources/hudson/plugins/emailext/templates/text.jelly
+++ b/src/main/resources/hudson/plugins/emailext/templates/text.jelly
@@ -84,4 +84,15 @@ By packages
   </j:if>
 </j:if>
 
+<!-- WARNINGS-NG REPORT -->
+<j:set var="aggregationAction" value="${it.getAction('io.jenkins.plugins.analysis.core.model.AggregationAction')}" />
+    <j:if test="${aggregationAction!=null}">
+        <j:whitespace>${aggregationAction.getDisplayName().toUpperCase()}&#10;</j:whitespace>
+        <j:forEach var="tool" items="${aggregationAction.getTools()}">
+            <j:whitespace>Tool: ${tool.getName()}&#10;</j:whitespace>
+            <j:whitespace>Report: ${tool.getLatestUrl()}&#10;</j:whitespace>
+            <j:whitespace>Low: ${tool.getLowSize()}, Normal: ${tool.getNormalSize()}, High: ${tool.getHighSize()}, Error: ${tool.getErrorSize()}&#10;</j:whitespace>
+            <j:whitespace>&#10;</j:whitespace>
+         </j:forEach>
+    </j:if>
 </j:jelly>


### PR DESCRIPTION
From personal experience I think it makes sense to include the reports from [warnings-ng](https://github.com/jenkinsci/warnings-ng-plugin) in the emails send by Jenkins. I know that one can customize the templates as desired but I'd love to see this added as a _recommendation_.

I added the reports only to the currently documented templates and left the other untouched.
Regarding the code-formatting: It is a mess already and I did not bother - let me know if you want me to change it.

See the screenshots below that demonstrate the feature:

**groovy-html.template**
![groovy-html.template](https://github.com/jenkinsci/email-ext-plugin/assets/49242855/4a08a3b3-e031-46b4-aee0-67e606699817)

**groovy-text.template**
![groovy-text.template](https://github.com/jenkinsci/email-ext-plugin/assets/49242855/b3105bd5-aa4f-4f88-84da-2f76d0979999)

**html.jelly**
![html.jelly](https://github.com/jenkinsci/email-ext-plugin/assets/49242855/88ef0d25-43ea-4782-b8de-78badd8a3ea4)

**text.jelly**
![text.jelly](https://github.com/jenkinsci/email-ext-plugin/assets/49242855/d2ba840b-6cf7-4751-b92d-4419b698834b)

### Testing done

Existing tests run fine. Manually tested visual changes are as intended - see screenshots for details.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```