### PR TITLE
[JENKINS-72912] Warn when using authentication without encryption

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <revision>2.106</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/email-ext-plugin</gitHubRepo>
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.version>2.440.1</jenkins.version>
     <hpi.compatibleSinceVersion>2.57.2</hpi.compatibleSinceVersion>
     <concurrency>1</concurrency>
     <!-- To be removed once Jenkins.MANAGE gets out of beta -->
@@ -113,22 +113,10 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.387.x</artifactId>
-        <version>2543.vfb_1a_5fb_9496d</version>
+        <artifactId>bom-2.440.x</artifactId>
+        <version>2884.vc36b_64ce114a_</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <!-- TODO Remove once in BOM -->
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>jakarta-activation-api</artifactId>
-        <version>2.1.3-1</version>
-      </dependency>
-      <!-- TODO Remove once in BOM -->
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>jakarta-mail-api</artifactId>
-        <version>2.1.3-1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -514,6 +514,15 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
                                 context.getListener().getLogger(),
                                 "Additional account " + mailAccount.getAddress() + " has invalid SMTP server");
                     }
+                } else if (!mailAccount.isSecureAuthWhenFIPS()) {
+                    context.getListener().getLogger().println("Mail account uses insecure authentication");
+                    if (mailAccount.isDefaultAccount()) {
+                        debug(context.getListener().getLogger(), "Default account uses insecure authentication");
+                    } else {
+                        debug(
+                                context.getListener().getLogger(),
+                                "Additional account " + mailAccount.getAddress() + " uses insecure authentication");
+                    }
                 }
                 return false;
             }
@@ -879,6 +888,10 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
                     debug(
                             context.getListener().getLogger(),
                             "Ignoring additional account " + addAccount.getAddress() + " with invalid SMTP server");
+                } else if (!addAccount.isSecureAuthWhenFIPS()) {
+                    debug(
+                            context.getListener().getLogger(),
+                            "Ignoring additional account " + addAccount.getAddress() + " with insecure authentication");
                 }
                 continue;
             }

--- a/src/test/java/hudson/plugins/emailext/FormValidationMessageMatcher.java
+++ b/src/test/java/hudson/plugins/emailext/FormValidationMessageMatcher.java
@@ -1,0 +1,53 @@
+package hudson.plugins.emailext;
+
+import hudson.util.FormValidation;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Simple Matcher that checks a FormValidations message.
+ */
+public class FormValidationMessageMatcher extends TypeSafeMatcher<FormValidation> {
+
+    private final Matcher<String> messageMatcher;
+
+    private FormValidationMessageMatcher(Matcher<String> messageMatcher) {
+        this.messageMatcher = messageMatcher;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("message ");
+        messageMatcher.describeTo(description);
+    }
+
+    @Override
+    protected void describeMismatchSafely(FormValidation item, Description mismatchDescription) {
+        mismatchDescription.appendText("message ");
+        messageMatcher.describeMismatch(item.renderHtml(), mismatchDescription);
+    }
+
+    @Override
+    protected boolean matchesSafely(FormValidation item) {
+        return messageMatcher.matches(item.renderHtml());
+    }
+
+    /**
+     * Creates a matcher of {@link FormValidation} that matches when the examined validations message is exactly the given String.
+     * This should only be used where there is a single validation otherwise if the format produced by {@link FormValidation#aggregate(java.util.Collection)}changes then this will break.
+     * @param message the exact message expected.
+     */
+    public static FormValidationMessageMatcher hasMessage(String message) {
+        return new FormValidationMessageMatcher(Matchers.is(message));
+    }
+
+    /**
+     * Creates a matcher of {@link FormValidation} that matches when the examined validations message is matches the given {@code matcher}.
+     * @param matcher the matcher to be used to check the message.
+     */
+    public static FormValidationMessageMatcher hasMessage(Matcher<String> matcher) {
+        return new FormValidationMessageMatcher(matcher);
+    }
+}

--- a/src/test/java/hudson/plugins/emailext/MailAccountFIPSTest.java
+++ b/src/test/java/hudson/plugins/emailext/MailAccountFIPSTest.java
@@ -2,83 +2,49 @@ package hudson.plugins.emailext;
 
 import static hudson.plugins.emailext.FormValidationMessageMatcher.hasMessage;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.jvnet.hudson.test.JenkinsMatchers.hasKind;
 
-import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.plugins.emailext.MailAccount.MailAccountDescriptor;
 import hudson.util.FormValidation.Kind;
-import hudson.util.Secret;
-import java.util.List;
 import jenkins.model.Jenkins;
-import net.sf.json.JSONObject;
-import org.hamcrest.Matchers;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.FlagRule;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
 
-public class MailAccountTest {
+public class MailAccountFIPSTest {
+
+    @ClassRule
+    public static FlagRule<String> fipsSystemPropertyRule =
+            FlagRule.systemProperty("jenkins.security.FIPS140.COMPLIANCE", "true");
+
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
     @Test
     @WithoutJenkins
-    public void testIsValidEmptyConfig() {
-        JSONObject obj = new JSONObject();
-        MailAccount account = new MailAccount(obj);
-        assertFalse(account.isValid());
-    }
-
-    @Test
-    @WithoutJenkins
-    public void testIsValidMissingAddress() {
-        JSONObject obj = new JSONObject();
-        obj.put("smtpHost", "mail.bar.com");
-        obj.put("smtpPort", 25);
-        MailAccount account = new MailAccount(obj);
-        assertFalse(account.isValid());
-    }
-
-    @Test
-    @WithoutJenkins
     public void testIsValidNonAuthConfig() {
-        JSONObject obj = new JSONObject();
-        obj.put("address", "foo@bar.com");
-        obj.put("smtpHost", "mail.bar.com");
-        obj.put("smtpPort", 25);
-        MailAccount account = new MailAccount(obj);
-        assertTrue(account.isValid());
-    }
-
-    @Test
-    public void testIsValidAuthConfig() {
-        JSONObject obj = new JSONObject();
-        obj.put("address", "foo@bar.com");
-        obj.put("smtpHost", "mail.bar.com");
-        obj.put("smtpPort", 25);
-        obj.put("auth", true);
-        obj.put("credentialsId", "foo");
-
-        MailAccount account = new MailAccount(obj);
+        MailAccount account = new MailAccount();
+        account.setAddress("joe@example.com");
         assertTrue(account.isValid());
     }
 
     @Test
     @WithoutJenkins
-    public void testIsValidAuthConfigWithoutEncryption() {
+    public void testIsNotValidAuthConfigWithoutEncryption() {
         MailAccount account = new MailAccount();
         account.setAddress("joe@example.com");
         account.setCredentialsId("foo");
-        assertTrue(account.isValid());
+        assertFalse(account.isValid());
     }
 
     @Test
@@ -99,22 +65,6 @@ public class MailAccountTest {
         account.setCredentialsId("foo");
         account.setUseTls(true);
         assertTrue(account.isValid());
-    }
-
-    @Test
-    public void testUpgradeDuringCredentialsGetter() {
-        MailAccount account = new MailAccount();
-        account.setSmtpUsername("foo");
-        account.setSmtpPassword(Secret.fromString("bar"));
-
-        assertNotNull(account.getCredentialsId());
-
-        List<StandardUsernamePasswordCredentials> creds =
-                CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class);
-        assertEquals(1, creds.size());
-        StandardUsernamePasswordCredentials c = creds.get(0);
-        assertEquals("foo", c.getUsername());
-        assertEquals("bar", c.getPassword().getPlainText());
     }
 
     @Test
@@ -140,31 +90,26 @@ public class MailAccountTest {
         assertThat(mad.doCheckCredentialsId(null, validCredentialId, false, true), hasKind(Kind.OK));
         assertThat(mad.doCheckCredentialsId(null, validCredentialId, true, true), hasKind(Kind.OK));
 
-        // valid credentials without TLS produce a warning (error in FIPS, but requires system property)
+        // valid credentials without TLS produce a error
         assertThat(
                 mad.doCheckCredentialsId(null, validCredentialId, false, false),
-                Matchers.allOf(
-                        hasKind(Kind.WARNING),
-                        hasMessage(
-                                "For security when using authentication it is recommended to enable either TLS or SSL")));
+                allOf(hasKind(Kind.ERROR), hasMessage("Authentication requires either TLS or SSL to be enabled")));
 
         // non-valid creds show the error regardless of SSL/TLS
         assertThat(
                 mad.doCheckCredentialsId(null, "bogus", false, false),
-                Matchers.allOf(
+                allOf(
                         hasKind(Kind.ERROR),
-                        hasMessage(
-                                containsString(
-                                        "For security when using authentication it is recommended to enable either TLS or SSL")),
+                        hasMessage(containsString("Authentication requires either TLS or SSL to be enabled")),
                         hasMessage(containsString("Cannot find currently selected credentials"))));
         assertThat(
                 mad.doCheckCredentialsId(null, "bogus", true, false),
-                Matchers.allOf(hasKind(Kind.ERROR), hasMessage("Cannot find currently selected credentials")));
+                allOf(hasKind(Kind.ERROR), hasMessage("Cannot find currently selected credentials")));
         assertThat(
                 mad.doCheckCredentialsId(null, "bogus", false, true),
-                Matchers.allOf(hasKind(Kind.ERROR), hasMessage("Cannot find currently selected credentials")));
+                allOf(hasKind(Kind.ERROR), hasMessage("Cannot find currently selected credentials")));
         assertThat(
                 mad.doCheckCredentialsId(null, "bogus", true, true),
-                Matchers.allOf(hasKind(Kind.ERROR), hasMessage("Cannot find currently selected credentials")));
+                allOf(hasKind(Kind.ERROR), hasMessage("Cannot find currently selected credentials")));
     }
 }


### PR DESCRIPTION
As SMTP is plain text, any credential used can be leaked on the network. Due to this issue a warning when using a credential without using TLS or SSL.

Additionally when in FIPS mode this becomes a hard requirement, so the warning becomes and error and the `MailAccount` will be treated as invalid

analogous to https://github.com/jenkinsci/mailer-plugin/pull/275
<!-- Please describe your pull request here. -->

### Testing done

see new unit tests

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
