### PR TITLE
Do not submit an empty pre/post-send script for approval

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -4,6 +4,7 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.domains.HostnamePortRequirement;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
@@ -100,12 +101,12 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
     /**
      * This is the global default pre-send script.
      */
-    private String defaultPresendScript = "";
+    private String defaultPresendScript;
 
     /**
      * This is the global default post-send script.
      */
-    private String defaultPostsendScript = "";
+    private String defaultPostsendScript;
 
     private List<GroovyScriptPath> defaultClasspath = new ArrayList<>();
 
@@ -702,34 +703,38 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
         return true;
     }
 
-    public String getDefaultPresendScript() {
+    public @CheckForNull String getDefaultPresendScript() {
         return defaultPresendScript;
     }
 
     @SuppressWarnings("unused")
     @DataBoundSetter
-    public void setDefaultPresendScript(String script) {
-        script = StringUtils.trim(script);
-        this.defaultPresendScript = ScriptApproval.get()
-                .configuring(
-                        script == null ? "" : script,
-                        GroovyLanguage.get(),
-                        ApprovalContext.create().withCurrentUser());
+    public void setDefaultPresendScript(@CheckForNull String script) {
+        script = StringUtils.trimToNull(script);
+        this.defaultPresendScript = script == null
+                ? null
+                : ScriptApproval.get()
+                        .configuring(
+                                script,
+                                GroovyLanguage.get(),
+                                ApprovalContext.create().withCurrentUser());
     }
 
-    public String getDefaultPostsendScript() {
+    public @CheckForNull String getDefaultPostsendScript() {
         return defaultPostsendScript;
     }
 
     @SuppressWarnings("unused")
     @DataBoundSetter
-    public void setDefaultPostsendScript(String script) {
-        script = StringUtils.trim(script);
-        this.defaultPostsendScript = ScriptApproval.get()
-                .configuring(
-                        script == null ? "" : script,
-                        GroovyLanguage.get(),
-                        ApprovalContext.create().withCurrentUser());
+    public void setDefaultPostsendScript(@CheckForNull String script) {
+        script = StringUtils.trimToNull(script);
+        this.defaultPostsendScript = script == null
+                ? null
+                : ScriptApproval.get()
+                        .configuring(
+                                script,
+                                GroovyLanguage.get(),
+                                ApprovalContext.create().withCurrentUser());
     }
 
     public List<GroovyScriptPath> getDefaultClasspath() {

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
@@ -2,6 +2,7 @@ package hudson.plugins.emailext;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.oneOf;
 import static org.junit.Assert.assertArrayEquals;
@@ -66,6 +67,7 @@ import org.htmlunit.html.HtmlPage;
 import org.htmlunit.html.HtmlSelect;
 import org.htmlunit.html.HtmlTextArea;
 import org.htmlunit.html.HtmlTextInput;
+import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -1197,5 +1199,16 @@ public class ExtendedEmailPublisherDescriptorTest {
                         SuccessTrigger.class.getName(),
                         UnstableTrigger.class.getName(),
                         XNthFailureTrigger.class.getName()));
+    }
+
+    @Test
+    public void emptyScriptApproval() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.ADMINISTER)
+                .everywhere()
+                .to("admin"));
+        j.submit(j.createWebClient().login("admin").goTo("configure").getFormByName("config"));
+        assertThat(ScriptApproval.get().getPendingScripts(), is(empty()));
     }
 }

--- a/src/test/java/hudson/plugins/emailext/plugins/ContentBuilderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/ContentBuilderTest.java
@@ -19,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import org.junit.Rule;
 import org.junit.Test;
@@ -115,20 +116,24 @@ public class ContentBuilderTest {
     public void testTransformText_shouldExpand_$DEFAULT_PRESEND_SCRIPT() {
         assertEquals(
                 publisher.getDescriptor().getDefaultPresendScript(),
-                ContentBuilder.transformText("$DEFAULT_PRESEND_SCRIPT", publisher, build, listener));
+                StringUtils.trimToNull(
+                        ContentBuilder.transformText("$DEFAULT_PRESEND_SCRIPT", publisher, build, listener)));
         assertEquals(
                 publisher.getDescriptor().getDefaultPresendScript(),
-                ContentBuilder.transformText("${DEFAULT_PRESEND_SCRIPT}", publisher, build, listener));
+                StringUtils.trimToNull(
+                        ContentBuilder.transformText("${DEFAULT_PRESEND_SCRIPT}", publisher, build, listener)));
     }
 
     @Test
     public void testTransformText_shouldExpand_$DEFAULT_POSTSEND_SCRIPT() {
         assertEquals(
                 publisher.getDescriptor().getDefaultPostsendScript(),
-                ContentBuilder.transformText("$DEFAULT_POSTSEND_SCRIPT", publisher, build, listener));
+                StringUtils.trimToNull(
+                        ContentBuilder.transformText("$DEFAULT_POSTSEND_SCRIPT", publisher, build, listener)));
         assertEquals(
                 publisher.getDescriptor().getDefaultPostsendScript(),
-                ContentBuilder.transformText("${DEFAULT_POSTSEND_SCRIPT}", publisher, build, listener));
+                StringUtils.trimToNull(
+                        ContentBuilder.transformText("${DEFAULT_POSTSEND_SCRIPT}", publisher, build, listener)));
     }
 
     @Test


### PR DESCRIPTION
Addresses what seems to have been a regression from 04efc23: every time you save the global config page, a warning pops up in **Manage** that you have a script to approve…but it is empty. Note that the method call here is deprecated as of https://github.com/jenkinsci/script-security-plugin/commit/f4c0bb9b58e105b4fc6b62be0f7f2daa46178190 but I am not touching that.