### PR TITLE
remove inline js from checkUrl

### DIFF
--- a/src/main/resources/hudson/plugins/emailext/EmailExtTemplateAction/index.groovy
+++ b/src/main/resources/hudson/plugins/emailext/EmailExtTemplateAction/index.groovy
@@ -35,7 +35,7 @@ l.layout {
             form(action: "", method: "post", name: "templateTest", onSubmit: "return onSubmit();") {
                 table {
                     f.entry(title: _("Jelly/Groovy Template File Name")) {
-                        f.textbox(name: "template_file_name", id: "template_file_name", clazz: "required", checkUrl:"'templateFileCheck?value='+this.value")
+                        f.textbox(name: "template_file_name", id: "template_file_name", clazz: "required", checkUrl:"templateFileCheck", checkDependsOn: "")
                     }
                     f.entry(title: _("Build To Test")) {
                         select(name: "template_build", id: "template_build") {

--- a/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/config.groovy
+++ b/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/config.groovy
@@ -18,10 +18,10 @@ f.entry(title: _("Project From")) {
   f.textbox(name: "project_from", value: configured ? instance.from : "")
 }
 f.entry(title: _("Project Recipient List"), help: "/plugin/email-ext/help/projectConfig/globalRecipientList.html", description: _("Comma-separated list of email address that should receive notifications for this project.")) {
-  f.textarea(name: "project_recipient_list", value: configured ? instance.recipientList : "\$DEFAULT_RECIPIENTS", checkUrl: "'${rootURL}/publisher/ExtendedEmailPublisher/recipientListRecipientsCheck?value='+encodeURIComponent(this.value)")
+  f.textarea(name: "project_recipient_list", value: configured ? instance.recipientList : "\$DEFAULT_RECIPIENTS", checkUrl: "${rootURL}/publisher/ExtendedEmailPublisher/recipientListRecipientsCheck", checkDependsOn: "")
 }
 f.entry(title: _("Project Reply-To List"), help: "/plugin/email-ext/help/projectConfig/replyToList.html", description: _("Comma-separated list of email address that should be in the Reply-To header for this project.")) {
-  f.textarea(name: "project_replyto", value: configured ? instance.replyTo : "\$DEFAULT_REPLYTO", checkUrl: "'${rootURL}/publisher/ExtendedEmailPublisher/recipientListRecipientsCheck?value='+encodeURIComponent(this.value)")
+  f.textarea(name: "project_replyto", value: configured ? instance.replyTo : "\$DEFAULT_REPLYTO", checkUrl: "${rootURL}/publisher/ExtendedEmailPublisher/recipientListRecipientsCheck", checkDependsOn: "")
 }
 f.entry(title: _("Content Type"), help: "/plugin/email-ext/help/projectConfig/contentType.html") {
   select(name: "project_content_type", class: "setting-input") {

--- a/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/global.groovy
+++ b/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/global.groovy
@@ -57,7 +57,7 @@ f.section(title: _("Extended E-mail Notification")) {
     f.textbox()
   }
   f.entry(field: "maxAttachmentSizeMb", help: "/plugin/email-ext/help/globalConfig/maxAttachmentSize.html", title: _("Maximum Attachment Size")) {
-    f.number(checkUrl: "'${rootURL}/publisher/ExtendedEmailPublisher/maxAttachmentSizeCheck?value='+encodeURIComponent(this.value)")
+    f.number(checkUrl: "${rootURL}/publisher/ExtendedEmailPublisher/maxAttachmentSizeCheck", checkDependsOn: "")
   }
   f.entry(field: "defaultBody", help: "/plugin/email-ext/help/globalConfig/defaultBody.html", title: _("Default Content")) {
     f.textarea()


### PR DESCRIPTION
remove fetching the field value via javascript and set the checkDependsOn attribute. This avoids that core interprets the code as javascript and calls eval on the url which is a violation of CSP rules.

<!-- Please describe your pull request here. -->

### Testing done
Manual testing by visiting the corresponding pages and entering invalid data. Validation error is still shown.
With CSP plugin installed there is nothing reported anymore.


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
