### PR TITLE
fix: prevent watching from applying to all jobs

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -368,7 +368,11 @@ public class ExtendedEmailPublisher extends Notifier implements MatrixAggregatab
     @NonNull
     @Override
     public Collection<? extends Action> getProjectActions(AbstractProject<?, ?> project) {
-        return Collections.singletonList(new EmailExtWatchAction(project));
+        EmailExtWatchAction action = project.getAction(EmailExtWatchAction.class);
+        if (action == null) {
+            action = new EmailExtWatchAction(project);
+        }
+        return Collections.singletonList(action);
     }
 
     public void debug(PrintStream p, String format, Object... args) {

--- a/src/main/java/hudson/plugins/emailext/watching/EmailExtWatchJobProperty.java
+++ b/src/main/java/hudson/plugins/emailext/watching/EmailExtWatchJobProperty.java
@@ -33,36 +33,42 @@ public class EmailExtWatchJobProperty extends JobProperty<Job<?, ?>> {
 
     public void addWatcher(User user) {
         String existing = null;
-        for (String u : watchers) {
-            if (u.compareTo(user.getId()) == 0) {
-                existing = u;
-                break;
+        synchronized (watchers) {
+            for (String u : watchers) {
+                if (u.compareTo(user.getId()) == 0) {
+                    existing = u;
+                    break;
+                }
             }
-        }
 
-        if (existing == null) {
-            watchers.add(user.getId());
+            if (existing == null) {
+                watchers.add(user.getId());
+            }
         }
     }
 
     public void removeWatcher(User user) {
         String remove = null;
-        for (String u : watchers) {
-            if (u.compareTo(user.getId()) == 0) {
-                remove = u;
-                break;
+        synchronized (watchers) {
+            for (String u : watchers) {
+                if (u.compareTo(user.getId()) == 0) {
+                    remove = u;
+                    break;
+                }
             }
-        }
 
-        if (remove != null) {
-            watchers.remove(user.getId());
+            if (remove != null) {
+                watchers.remove(user.getId());
+            }
         }
     }
 
     public boolean isWatching(User user) {
-        for (String u : watchers) {
-            if (u.compareTo(user.getId()) == 0) {
-                return true;
+        synchronized (watchers) {
+            for (String u : watchers) {
+                if (u.compareTo(user.getId()) == 0) {
+                    return true;
+                }
             }
         }
         return false;

--- a/src/main/resources/hudson/plugins/emailext/watching/EmailExtWatchAction/index.groovy
+++ b/src/main/resources/hudson/plugins/emailext/watching/EmailExtWatchAction/index.groovy
@@ -45,7 +45,7 @@ l.layout(norefresh: true) {
 
                     f.entry(title: _("Content Token Reference"), help: descriptor.getHelpFile('tokens'))
                     def triggers = hudson.plugins.emailext.plugins.EmailTrigger.all().findAll { t -> t.isWatchable() }
-                    def configuredTriggers = (my != null && my.triggers.size() > 0) ? my.triggers : []
+                    def configuredTriggers = (my != null && my?.triggers?.size() > 0) ? my.triggers : []
                     // do we want to filter the triggers somehow so that only some show up?
 
                     showSendTo = false


### PR DESCRIPTION
Fixes the watching feature so that when a user watches a given job, it only applies to that job. Previously, when a job was watched, the project was not stored in the user property, so it would end up watching all jobs.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
