### PR TITLE
fix: Update delimiter fix-up for personal parts

### DIFF
--- a/src/main/java/hudson/plugins/emailext/EmailRecipientUtils.java
+++ b/src/main/java/hudson/plugins/emailext/EmailRecipientUtils.java
@@ -141,7 +141,7 @@ public class EmailRecipientUtils {
 
         // we only need to do more fixup if there are spaces in the string
         if (input.contains(" ")) {
-            if(!input.contains("<") && !input.contains(("("))) {
+            if (!input.contains("<") && !input.contains(("("))) {
                 input = input.replace(" ", ", ");
             } else {
                 StringBuilder builder = new StringBuilder(input);

--- a/src/test/java/hudson/plugins/emailext/EmailRecipientUtilsTest.java
+++ b/src/test/java/hudson/plugins/emailext/EmailRecipientUtilsTest.java
@@ -1,10 +1,10 @@
 package hudson.plugins.emailext;
 
-import jakarta.mail.internet.InternetAddress;
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+
+import jakarta.mail.internet.InternetAddress;
+import org.junit.Test;
 
 public class EmailRecipientUtilsTest {
     @Test
@@ -17,7 +17,8 @@ public class EmailRecipientUtilsTest {
         assertEquals("Name Surname", addresses[0].getPersonal());
         assertEquals("n.Surname@mymail.com", addresses[0].getAddress());
 
-        output = EmailRecipientUtils.fixupDelimiters("user0, user1@email.com User Two    <user2@email.com> user3@email.com   ");
+        output = EmailRecipientUtils.fixupDelimiters(
+                "user0, user1@email.com User Two    <user2@email.com> user3@email.com   ");
         assertEquals("user0, user1@email.com, User Two <user2@email.com>, user3@email.com", output);
         addresses = InternetAddress.parse(output);
         assertEquals(4, addresses.length);

--- a/src/test/java/hudson/plugins/emailext/EmailRecipientUtilsTest.java
+++ b/src/test/java/hudson/plugins/emailext/EmailRecipientUtilsTest.java
@@ -1,0 +1,37 @@
+package hudson.plugins.emailext;
+
+import jakarta.mail.internet.InternetAddress;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class EmailRecipientUtilsTest {
+    @Test
+    public void testFixupDelimiters() throws Exception {
+        String output;
+        output = EmailRecipientUtils.fixupDelimiters("  Name   Surname   <n.Surname@mymail.com>   ");
+        assertEquals("Name Surname <n.Surname@mymail.com>", output);
+        InternetAddress[] addresses = InternetAddress.parse(output);
+        assertEquals(1, addresses.length);
+        assertEquals("Name Surname", addresses[0].getPersonal());
+        assertEquals("n.Surname@mymail.com", addresses[0].getAddress());
+
+        output = EmailRecipientUtils.fixupDelimiters("user0, user1@email.com User Two    <user2@email.com> user3@email.com   ");
+        assertEquals("user0, user1@email.com, User Two <user2@email.com>, user3@email.com", output);
+        addresses = InternetAddress.parse(output);
+        assertEquals(4, addresses.length);
+
+        assertNull(addresses[0].getPersonal());
+        assertEquals("user0", addresses[0].getAddress());
+
+        assertNull(addresses[1].getPersonal());
+        assertEquals("user1@email.com", addresses[1].getAddress());
+
+        assertEquals("User Two", addresses[2].getPersonal());
+        assertEquals("user2@email.com", addresses[2].getAddress());
+
+        assertNull(addresses[3].getPersonal());
+        assertEquals("user3@email.com", addresses[3].getAddress());
+    }
+}


### PR DESCRIPTION
Updated the delimiter fix-up to take into account personal names in email addresses (e.g., `Slide O Mix <someone@email.com>`).

See [JENKINS-69681](https://issues.jenkins.io/browse/JENKINS-69681)

Supersedes #395 

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
