### PR TITLE
[JENKINS-74891] Extract inline JavaScript from `EmailExtTemplateAction/index.groovy`

### DIFF
--- a/src/main/resources/hudson/plugins/emailext/EmailExtTemplateAction/index.groovy
+++ b/src/main/resources/hudson/plugins/emailext/EmailExtTemplateAction/index.groovy
@@ -14,25 +14,11 @@ l.layout {
     st.include(it: my.project, page: "sidepanel")
     l.main_panel {
         st.bind(var: "templateTester", value: my)
-        script """function onSubmit() {
-                var templateFile = document.getElementById('template_file_name').value;
-                var buildId = document.getElementById('template_build').value;
-                templateTester.renderTemplate(templateFile,buildId, function(t) {
-                    document.getElementById('rendered_template').src = "data:text/html;charset=utf-8," + escape(t.responseObject()[0]);
-                    var consoleOutput = t.responseObject()[1];
-                    if(consoleOutput.length == 0) {
-                        document.getElementById('output').style.display = 'none';                        
-                    } else {
-                        document.getElementById('output').style.display = 'block';
-                        document.getElementById('console_output').innerHTML = consoleOutput;
-                    }
-                });
-                return false;
-            }"""
+        st.adjunct(includes: "hudson.plugins.emailext.EmailExtTemplateAction.template-test")
         h1(my.displayName)        
         if(hasPermission) {
             h3(_("description"))
-            form(action: "", method: "post", name: "templateTest", onSubmit: "return onSubmit();") {
+            form(action: "", method: "post", name: "templateTest", class: "test-template-form") {
                 table {
                     f.entry(title: _("Jelly/Groovy Template File Name")) {
                         f.textbox(name: "template_file_name", id: "template_file_name", clazz: "required", checkUrl:"templateFileCheck", checkDependsOn: "")

--- a/src/main/resources/hudson/plugins/emailext/EmailExtTemplateAction/template-test.js
+++ b/src/main/resources/hudson/plugins/emailext/EmailExtTemplateAction/template-test.js
@@ -1,0 +1,22 @@
+function onSubmit() {
+    var templateFile = document.getElementById('template_file_name').value;
+    var buildId = document.getElementById('template_build').value;
+    templateTester.renderTemplate(templateFile,buildId, function(t) {
+        document.getElementById('rendered_template').src = "data:text/html;charset=utf-8," + escape(t.responseObject()[0]);
+        var consoleOutput = t.responseObject()[1];
+        if(consoleOutput.length == 0) {
+            document.getElementById('output').style.display = 'none';
+        } else {
+            document.getElementById('output').style.display = 'block';
+            document.getElementById('console_output').innerHTML = consoleOutput;
+        }
+    });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    document.querySelector(".test-template-form").addEventListener("submit", (event) => {
+        event.preventDefault();
+        
+        onSubmit();
+    });
+});


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-74891

There's still a problem with the mechanism that renders the template. It's rendered inside an `iframe` element. Default CSP header that's set by [Content Security Policy](https://plugins.jenkins.io/csp/) does not define `frame-src`, hence `default-src` is used, which only allows `'self'`. This means that `data:` src for `iframe` is not allowed, which prohibits templates from being rendered in restrictive mode. This is also be demonstrated on "After the change" video below.

Depending on how wanted this feature is it can either be fixed or deprecated with a notice that it doesn't work in CSP restrictive mode. 
Alternatively CSP plugin could define `frame-src` policy that we'd consider safe (probably a question to @jenkinsci/core-security-review what sources would be safe). I have doubts that `data:` will make it into the list of safe sources.

### Testing done

[Before the change](https://www.youtube.com/watch?v=TI5BiUTMsyY)
[After the change](https://www.youtube.com/watch?v=MUt2rLCHQ6I)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
