### PR TITLE
Fix page title test for new title format

### DIFF
--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
@@ -83,13 +83,15 @@ public class ExtendedEmailPublisherDescriptorTest {
     public JenkinsRule j = new JenkinsRule();
 
     private void assertTitlePage(HtmlPage page) {
-        VersionNumber jenkinsVersion = Jenkins.getVersion();
-        VersionNumber newManageJenkinsVersion = new VersionNumber("2.395");
-        String expectedTitle = "System [Jenkins]";
-        if (jenkinsVersion.isOlderThan(newManageJenkinsVersion)) {
-            expectedTitle = "Configure System [Jenkins]";
-        }
-        assertEquals("Should be at the Configure System page", expectedTitle, page.getTitleText());
+        // oldTitleFormat can be removed once our baseline is high enough
+        String oldTitleFormat = "System [Jenkins]";
+        String newTitleFormat = "System - Jenkins";
+        String actualTitle = page.getTitleText();
+
+        assertTrue(
+                "Should be at the Configure System page",
+                actualTitle.equals(oldTitleFormat) || actualTitle.equals(newTitleFormat)
+        );
     }
 
     @Test

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
@@ -83,14 +83,9 @@ public class ExtendedEmailPublisherDescriptorTest {
     public JenkinsRule j = new JenkinsRule();
 
     private void assertTitlePage(HtmlPage page) {
-        // oldTitleFormat can be removed once our baseline is high enough
-        String oldTitleFormat = "System [Jenkins]";
-        String newTitleFormat = "System - Jenkins";
         String actualTitle = page.getTitleText();
 
-        assertTrue(
-                "Should be at the Configure System page",
-                actualTitle.equals(oldTitleFormat) || actualTitle.equals(newTitleFormat));
+        assertTrue("Should be at the Configure System page", actualTitle.startsWith("System"));
     }
 
     @Test

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
@@ -90,8 +90,7 @@ public class ExtendedEmailPublisherDescriptorTest {
 
         assertTrue(
                 "Should be at the Configure System page",
-                actualTitle.equals(oldTitleFormat) || actualTitle.equals(newTitleFormat)
-        );
+                actualTitle.equals(oldTitleFormat) || actualTitle.equals(newTitleFormat));
     }
 
     @Test


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/10178 changes the format of the page title, going from `x [Jenkins]` to `x - Jenkins`. As a result it's broken one of the tests in this plugin, this PR resolves that whilst maintaining backwards compatibility with older versions of Jenkins.

### Testing done

* Tests pass

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
