### PR TITLE
Remove `useBeta` property from `pom.xml`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.6</version>
+    <version>5.7</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.7</version>
+    <version>5.9</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.9</version>
+    <version>5.12</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.5</version>
+    <version>5.6</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,12 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jsoup</artifactId>
+      <!-- To remove when on bom -->
+      <version>1.18.3-30.v952e9442d416</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
@@ -168,11 +174,6 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
       <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.jsoup</groupId>
-      <artifactId>jsoup</artifactId>
-      <version>1.18.3</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>1405.vb_cda_74a_f8974</version>
+      <version>1408.va_622a_b_f5b_1b_1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.479.x</artifactId>
-        <version>4023.va_eeb_b_4e45f07</version>
+        <version>4051.v78dce3ce8b_d6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.baseline>2.479</jenkins.baseline>
-    <!-- REMOVE -->
-    <jenkins.version>2.495</jenkins.version>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <hpi.compatibleSinceVersion>2.57.2</hpi.compatibleSinceVersion>
     <concurrency>1</concurrency>
     <spotless.check.skip>false</spotless.check.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -89,11 +89,10 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <!-- REMOVE -->
+    <jenkins.version>2.494-rc35897.1f8edd4c1651</jenkins.version>
     <hpi.compatibleSinceVersion>2.57.2</hpi.compatibleSinceVersion>
     <concurrency>1</concurrency>
-    <!-- To be removed once Jenkins.MANAGE gets out of beta -->
-    <useBeta>true</useBeta>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jsoup</artifactId>
       <!-- To remove when on bom -->
-      <version>1.18.3-30.v952e9442d416</version>
+      <version>1.19.1-36.v63b_c859911d0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.479.x</artifactId>
-        <version>4051.v78dce3ce8b_d6</version>
+        <version>4136.vca_c3202a_7fd1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>1408.va_622a_b_f5b_1b_1</version>
+      <version>1413.va_51c53703df1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.baseline>2.479</jenkins.baseline>
     <!-- REMOVE -->
-    <jenkins.version>2.494-rc35897.1f8edd4c1651</jenkins.version>
+    <jenkins.version>2.495</jenkins.version>
     <hpi.compatibleSinceVersion>2.57.2</hpi.compatibleSinceVersion>
     <concurrency>1</concurrency>
     <spotless.check.skip>false</spotless.check.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <hpi.compatibleSinceVersion>2.57.2</hpi.compatibleSinceVersion>
     <concurrency>1</concurrency>
     <spotless.check.skip>false</spotless.check.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>1413.va_51c53703df1</version>
+      <version>1415.v831096eb_5534</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.479.x</artifactId>
-        <version>4136.vca_c3202a_7fd1</version>
+        <version>4669.v0e99c712a_30e</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jsoup</artifactId>
       <!-- To remove when on bom -->
-      <version>1.19.1-36.v63b_c859911d0</version>
+      <version>1.19.1-38.v216a_f3721b_3c</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/emailext/EmailRecipientUtils.java
+++ b/src/main/java/hudson/plugins/emailext/EmailRecipientUtils.java
@@ -62,8 +62,8 @@ public class EmailRecipientUtils {
                         cc.add(address);
                         break;
                     case RecipientListStringAnalyser.NOT_FOUND:
-                        // Fallback: Treat NOT_FOUND like TO in case RecipientListStringAnalyser fails due to whatever
-                        // reason (maybe encoding of personal?)
+                    // Fallback: Treat NOT_FOUND like TO in case RecipientListStringAnalyser fails due to whatever
+                    // reason (maybe encoding of personal?)
                     case TO:
                         to.add(address);
                         break;

--- a/src/test/java/hudson/plugins/emailext/ConfigFileMigrationTest.java
+++ b/src/test/java/hudson/plugins/emailext/ConfigFileMigrationTest.java
@@ -1,41 +1,39 @@
 package hudson.plugins.emailext;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.jenkinsci.lib.configprovider.AbstractConfigProviderImpl;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.plugins.configfiles.GlobalConfigFiles;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
 
-public class ConfigFileMigrationTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class ConfigFileMigrationTest {
 
     @Test
     @LocalData
-    public void testMigrateOldData() {
+    void testMigrateOldData(JenkinsRule j) {
 
         for (ConfigProvider cp : ConfigProvider.all()) {
             // as all the config files have been moved to global config,
-            // all providers must not hold any files any more
+            // all providers must not hold any files anymore
             AbstractConfigProviderImpl acp = (AbstractConfigProviderImpl) cp;
-            Assert.assertTrue(
-                    "configs for " + acp.getProviderId() + " should be empty",
-                    acp.getConfigs().isEmpty());
+            assertTrue(acp.getConfigs().isEmpty(), "configs for " + acp.getProviderId() + " should be empty");
         }
 
-        Assert.assertEquals(
+        assertEquals(
                 1,
-                getProvider(JellyTemplateConfig.JellyTemplateConfigProvider.class)
+                getProvider(j, JellyTemplateConfig.JellyTemplateConfigProvider.class)
                         .getAllConfigs()
                         .size());
-        Assert.assertEquals(1, GlobalConfigFiles.get().getConfigs().size());
+        assertEquals(1, GlobalConfigFiles.get().getConfigs().size());
     }
 
-    private <T> T getProvider(Class<T> providerClass) {
+    private static <T> T getProvider(JenkinsRule j, Class<T> providerClass) {
         return j.getInstance().getExtensionList(providerClass).get(providerClass);
     }
 }

--- a/src/test/java/hudson/plugins/emailext/EmailRecipientUtilsTest.java
+++ b/src/test/java/hudson/plugins/emailext/EmailRecipientUtilsTest.java
@@ -1,14 +1,15 @@
 package hudson.plugins.emailext;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import jakarta.mail.internet.InternetAddress;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class EmailRecipientUtilsTest {
+class EmailRecipientUtilsTest {
+
     @Test
-    public void testFixupDelimiters() throws Exception {
+    void testFixupDelimiters() throws Exception {
         String output;
         output = EmailRecipientUtils.fixupDelimiters("  Name   Surname   <n.Surname@mymail.com>   ");
         assertEquals("Name Surname <n.Surname@mymail.com>", output);

--- a/src/test/java/hudson/plugins/emailext/EmailTypeTest.java
+++ b/src/test/java/hudson/plugins/emailext/EmailTypeTest.java
@@ -1,9 +1,6 @@
 package hudson.plugins.emailext;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import hudson.model.FreeStyleProject;
 import hudson.plugins.emailext.plugins.recipients.DevelopersRecipientProvider;
@@ -14,25 +11,31 @@ import java.io.IOException;
 import java.net.URL;
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class EmailTypeTest {
+@WithJenkins
+class EmailTypeTest {
 
-    @Rule
-    public final JenkinsRule j = new JenkinsRule();
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule j) {
+        this.j = j;
+    }
 
     @Test
-    public void testHasNoRecipients() {
+    void testHasNoRecipients() {
         EmailType t = new EmailType();
 
         assertFalse(t.getHasRecipients());
     }
 
     @Test
-    public void testHasDeveloperRecipients() {
+    void testHasDeveloperRecipients() {
         EmailType t = new EmailType();
 
         t.addRecipientProvider(new DevelopersRecipientProvider());
@@ -41,7 +44,7 @@ public class EmailTypeTest {
     }
 
     @Test
-    public void testHasRecipientList() {
+    void testHasRecipientList() {
         EmailType t = new EmailType();
 
         t.addRecipientProvider(new ListRecipientProvider());
@@ -50,7 +53,7 @@ public class EmailTypeTest {
     }
 
     @Test
-    public void testHasDeveloperAndRecipientList() {
+    void testHasDeveloperAndRecipientList() {
         EmailType t = new EmailType();
 
         t.addRecipientProvider(new ListRecipientProvider());
@@ -60,7 +63,7 @@ public class EmailTypeTest {
     }
 
     @Test
-    public void testCompressBuildAttachment() {
+    void testCompressBuildAttachment() {
         EmailType t = new EmailType();
         t.setCompressBuildLog(true);
 
@@ -68,14 +71,14 @@ public class EmailTypeTest {
     }
 
     @Test
-    public void testDefaultCompressBuildAttachment() {
+    void testDefaultCompressBuildAttachment() {
         EmailType t = new EmailType();
 
         assertFalse(t.getCompressBuildLog());
     }
 
     @Test
-    public void testUpgradeToRecipientProvider() throws IOException {
+    void testUpgradeToRecipientProvider() throws IOException {
         URL url = this.getClass().getResource("/recipient-provider-upgrade.xml");
         File jobConfig = new File(url.getFile());
 
@@ -100,7 +103,7 @@ public class EmailTypeTest {
 
     @Test
     @Issue("JENKINS-24506")
-    public void testUpgradeTriggerWithNoRecipients() throws IOException {
+    void testUpgradeTriggerWithNoRecipients() throws IOException {
         URL url = this.getClass().getResource("/recipient-provider-upgrade2.xml");
         File jobConfig = new File(url.getFile());
 

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorJCasCTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorJCasCTest.java
@@ -1,10 +1,7 @@
 package hudson.plugins.emailext;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
@@ -16,30 +13,23 @@ import hudson.plugins.emailext.plugins.trigger.FixedTrigger;
 import hudson.plugins.emailext.plugins.trigger.RegressionTrigger;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import jakarta.mail.Authenticator;
 import jakarta.mail.PasswordAuthentication;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class ExtendedEmailPublisherDescriptorJCasCTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule r = new JenkinsConfiguredWithCodeRule();
-
-    @Rule
-    public TestName testName = new TestName();
+@WithJenkinsConfiguredWithCode
+class ExtendedEmailPublisherDescriptorJCasCTest {
 
     @Test
     @ConfiguredWithCode("configuration-as-code.yml")
-    public void shouldValidatedJCasCConfiguration() {
+    void shouldValidatedJCasCConfiguration(JenkinsConfiguredWithCodeRule r) {
         final ExtendedEmailPublisherDescriptor descriptor =
                 ExtensionList.lookupSingleton(ExtendedEmailPublisherDescriptor.class);
         assertNotNull(descriptor);
@@ -96,7 +86,7 @@ public class ExtendedEmailPublisherDescriptorJCasCTest {
 
     @Test
     @ConfiguredWithCode("configuration-as-code-with-triggers.yml")
-    public void shouldBeAbleToConfigureTriggers() {
+    void shouldBeAbleToConfigureTriggers(JenkinsConfiguredWithCodeRule r) {
         final ExtendedEmailPublisherDescriptor descriptor =
                 ExtensionList.lookupSingleton(ExtendedEmailPublisherDescriptor.class);
         assertNotNull(descriptor);
@@ -104,7 +94,7 @@ public class ExtendedEmailPublisherDescriptorJCasCTest {
         final List<String> expectedTriggers = Arrays.asList(
                 RegressionTrigger.class.getName(), AbortedTrigger.class.getName(), FixedTrigger.class.getName());
 
-        MatcherAssert.assertThat(
+        assertThat(
                 descriptor.getDefaultTriggerIds(),
                 Matchers.contains(
                         expectedTriggers.stream().map(Matchers::equalTo).collect(Collectors.toList())));
@@ -112,7 +102,7 @@ public class ExtendedEmailPublisherDescriptorJCasCTest {
 
     @Test
     @ConfiguredWithCode("configuration-as-code-upgrade.yml")
-    public void shouldValidatedJCasCConfigurationWithUpgrade() {
+    void shouldValidatedJCasCConfigurationWithUpgrade(JenkinsConfiguredWithCodeRule r) {
         final ExtendedEmailPublisherDescriptor descriptor =
                 ExtensionList.lookupSingleton(ExtendedEmailPublisherDescriptor.class);
         assertNotNull(descriptor);
@@ -181,7 +171,7 @@ public class ExtendedEmailPublisherDescriptorJCasCTest {
 
     @Test
     @ConfiguredWithCode("configuration-as-code-upgrade-creds-check.yml")
-    public void shouldUseCorrectCredentialsAfterUpgrade() throws Exception {
+    void shouldUseCorrectCredentialsAfterUpgrade(JenkinsConfiguredWithCodeRule r) throws Exception {
         final ExtendedEmailPublisherDescriptor descriptor =
                 ExtensionList.lookupSingleton(ExtendedEmailPublisherDescriptor.class);
 

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
@@ -5,13 +5,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.oneOf;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
@@ -68,132 +62,138 @@ import org.htmlunit.html.HtmlSelect;
 import org.htmlunit.html.HtmlTextArea;
 import org.htmlunit.html.HtmlTextInput;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-public class ExtendedEmailPublisherDescriptorTest {
+@WithJenkins
+class ExtendedEmailPublisherDescriptorTest {
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+    private JenkinsRule j;
 
-    private void assertTitlePage(HtmlPage page) {
+    @BeforeEach
+    void setUp(JenkinsRule j) {
+        this.j = j;
+    }
+
+    private static void assertTitlePage(HtmlPage page) {
         String actualTitle = page.getTitleText();
 
-        assertTrue("Should be at the Configure System page", actualTitle.startsWith("System"));
+        assertTrue(actualTitle.startsWith("System"), "Should be at the Configure System page");
     }
 
     @Test
-    public void testGlobalConfigDefaultState() throws Exception {
+    void testGlobalConfigDefaultState() throws Exception {
         HtmlPage page = j.createWebClient().goTo("configure");
 
         assertTitlePage(page);
 
         HtmlTextInput smtpHost = page.getElementByName("_.smtpHost");
-        assertNotNull("SMTP Server should be present", smtpHost);
-        assertEquals("SMTP Server should be blank by default", "", smtpHost.getText());
+        assertNotNull(smtpHost, "SMTP Server should be present");
+        assertEquals("", smtpHost.getText(), "SMTP Server should be blank by default");
 
         HtmlNumberInput smtpPort = page.getElementByName("_.smtpPort");
-        assertNotNull("SMTP Port should be present", smtpPort);
-        assertEquals("SMTP Port should be 25 by default", "25", smtpPort.getText());
+        assertNotNull(smtpPort, "SMTP Port should be present");
+        assertEquals("25", smtpPort.getText(), "SMTP Port should be 25 by default");
 
         HtmlTextInput defaultSuffix = page.getElementByName("_.defaultSuffix");
-        assertNotNull("Default suffix should be present", defaultSuffix);
-        assertEquals("Default suffix should be blank by default", "", defaultSuffix.getText());
+        assertNotNull(defaultSuffix, "Default suffix should be present");
+        assertEquals("", defaultSuffix.getText(), "Default suffix should be blank by default");
 
         // default content type select control
         HtmlSelect contentType = page.getElementByName("_.defaultContentType");
-        assertNotNull("Content type selection should be present", contentType);
+        assertNotNull(contentType, "Content type selection should be present");
         assertEquals(
-                "Plain text should be selected by default",
                 "text/plain",
-                contentType.getSelectedOptions().get(0).getValueAttribute());
+                contentType.getSelectedOptions().get(0).getValueAttribute(),
+                "Plain text should be selected by default");
 
         HtmlCheckBoxInput precedenceBulk = page.getElementByName("_.precedenceBulk");
-        assertNotNull("Precedence Bulk should be present", precedenceBulk);
-        assertFalse("Add precedence bulk should not be checked by default", precedenceBulk.isChecked());
+        assertNotNull(precedenceBulk, "Precedence Bulk should be present");
+        assertFalse(precedenceBulk.isChecked(), "Add precedence bulk should not be checked by default");
 
         HtmlTextInput defaultRecipients = page.getElementByName("_.defaultRecipients");
-        assertNotNull("Default Recipients should be present", defaultRecipients);
-        assertEquals("Default recipients should be blank by default", "", defaultRecipients.getText());
+        assertNotNull(defaultRecipients, "Default Recipients should be present");
+        assertEquals("", defaultRecipients.getText(), "Default recipients should be blank by default");
 
         HtmlTextInput defaultReplyTo = page.getElementByName("_.defaultReplyTo");
-        assertNotNull("Default Reply-to should be present", defaultReplyTo);
-        assertEquals("Default Reply-To should be blank by default", "", defaultReplyTo.getText());
+        assertNotNull(defaultReplyTo, "Default Reply-to should be present");
+        assertEquals("", defaultReplyTo.getText(), "Default Reply-To should be blank by default");
 
         HtmlTextInput emergencyReroute = page.getElementByName("_.emergencyReroute");
-        assertNotNull("Emergency Reroute should be present", emergencyReroute);
-        assertEquals("Emergency Reroute should be blank by default", "", emergencyReroute.getText());
+        assertNotNull(emergencyReroute, "Emergency Reroute should be present");
+        assertEquals("", emergencyReroute.getText(), "Emergency Reroute should be blank by default");
 
         HtmlTextInput allowedDomains = page.getElementByName("_.allowedDomains");
-        assertNotNull("Allowed Domains should be present", allowedDomains);
-        assertEquals("Allowed Domains should be blank by default", "", allowedDomains.getText());
+        assertNotNull(allowedDomains, "Allowed Domains should be present");
+        assertEquals("", allowedDomains.getText(), "Allowed Domains should be blank by default");
 
         HtmlTextInput excludedRecipients = page.getElementByName("_.excludedCommitters");
-        assertNotNull("Excluded Recipients should be present", excludedRecipients);
-        assertEquals("Excluded Recipients should be blank by default", "", excludedRecipients.getText());
+        assertNotNull(excludedRecipients, "Excluded Recipients should be present");
+        assertEquals("", excludedRecipients.getText(), "Excluded Recipients should be blank by default");
 
         HtmlTextInput defaultSubject = page.getElementByName("_.defaultSubject");
-        assertNotNull("Default Subject should be present", defaultSubject);
+        assertNotNull(defaultSubject, "Default Subject should be present");
         assertEquals(
-                "Default Subject should be set",
                 "$PROJECT_NAME - Build # $BUILD_NUMBER - $BUILD_STATUS!",
-                defaultSubject.getText());
+                defaultSubject.getText(),
+                "Default Subject should be set");
 
         HtmlNumberInput maxAttachmentSize = page.getElementByName("_.maxAttachmentSizeMb");
-        assertNotNull("Max attachment size should be present", maxAttachmentSize);
+        assertNotNull(maxAttachmentSize, "Max attachment size should be present");
         assertThat(
                 "Max attachment size should be blank or -1 by default",
                 maxAttachmentSize.getText(),
                 is(oneOf("", "-1")));
 
         HtmlTextArea defaultContent = page.getElementByName("_.defaultBody");
-        assertNotNull("Default content should be present", defaultContent);
+        assertNotNull(defaultContent, "Default content should be present");
         assertEquals(
-                "Default content should be set by default",
                 "$PROJECT_NAME - Build # $BUILD_NUMBER - $BUILD_STATUS:\n\nCheck console output at $BUILD_URL to view the results.",
-                defaultContent.getText());
+                defaultContent.getText(),
+                "Default content should be set by default");
 
         HtmlTextArea defaultPresendScript = page.getElementByName("_.defaultPresendScript");
-        assertNotNull("Default presend script should be present", defaultPresendScript);
-        assertEquals("Default presend script should be blank by default", "", defaultPresendScript.getText());
+        assertNotNull(defaultPresendScript, "Default presend script should be present");
+        assertEquals("", defaultPresendScript.getText(), "Default presend script should be blank by default");
 
         HtmlTextArea defaultPostsendScript = page.getElementByName("_.defaultPostsendScript");
-        assertNotNull("Default postsend script should be present", defaultPostsendScript);
-        assertEquals("Default postsend script should be blank by default", "", defaultPostsendScript.getText());
+        assertNotNull(defaultPostsendScript, "Default postsend script should be present");
+        assertEquals("", defaultPostsendScript.getText(), "Default postsend script should be blank by default");
 
         HtmlCheckBoxInput debugMode = page.getElementByName("_.debugMode");
-        assertNotNull("Debug mode should be present", debugMode);
-        assertFalse("Debug mode should not be checked by default", debugMode.isChecked());
+        assertNotNull(debugMode, "Debug mode should be present");
+        assertFalse(debugMode.isChecked(), "Debug mode should not be checked by default");
 
         HtmlCheckBoxInput adminRequiredForTemplateTesting = page.getElementByName("_.adminRequiredForTemplateTesting");
-        assertNotNull("Admin required for template testing should be present", adminRequiredForTemplateTesting);
+        assertNotNull(adminRequiredForTemplateTesting, "Admin required for template testing should be present");
         assertFalse(
-                "Admin required for template testing should be unchecked by default",
-                adminRequiredForTemplateTesting.isChecked());
+                adminRequiredForTemplateTesting.isChecked(),
+                "Admin required for template testing should be unchecked by default");
 
         HtmlCheckBoxInput watchingEnabled = page.getElementByName("_.watchingEnabled");
-        assertNotNull("Watching enable should be present", watchingEnabled);
-        assertFalse("Watching enable should be unchecked by default", watchingEnabled.isChecked());
+        assertNotNull(watchingEnabled, "Watching enable should be present");
+        assertFalse(watchingEnabled.isChecked(), "Watching enable should be unchecked by default");
 
         HtmlCheckBoxInput allowUnregisteredEnabled = page.getElementByName("_.allowUnregisteredEnabled");
-        assertNotNull("Allow unregistered should be present", allowUnregisteredEnabled);
-        assertFalse("Allow unregistered should be unchecked by default", allowUnregisteredEnabled.isChecked());
+        assertNotNull(allowUnregisteredEnabled, "Allow unregistered should be present");
+        assertFalse(allowUnregisteredEnabled.isChecked(), "Allow unregistered should be unchecked by default");
 
         assertThrows(
-                "defaultClasspath section should not be present",
                 ElementNotFoundException.class,
-                () -> page.getElementByName("defaultClasspath"));
+                () -> page.getElementByName("defaultClasspath"),
+                "defaultClasspath section should not be present");
     }
 
     @Test
     @Issue("JENKINS-20030")
-    public void testGlobalConfigSimpleRoundTrip() throws Exception {
+    void testGlobalConfigSimpleRoundTrip() throws Exception {
         ExtendedEmailPublisherDescriptor descriptor =
                 j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -206,7 +206,7 @@ public class ExtendedEmailPublisherDescriptorTest {
 
     @Test
     @Issue("JENKINS-63367")
-    public void testSmtpPortRetainsSetValue() throws Exception {
+    void testSmtpPortRetainsSetValue() throws Exception {
         ExtendedEmailPublisherDescriptor descriptor =
                 j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
         JenkinsRule.WebClient client = j.createWebClient();
@@ -224,7 +224,7 @@ public class ExtendedEmailPublisherDescriptorTest {
 
     @Test
     @Issue("JENKINS-20133")
-    public void testPrecedenceBulkSettingRoundTrip() throws Exception {
+    void testPrecedenceBulkSettingRoundTrip() throws Exception {
         ExtendedEmailPublisherDescriptor descriptor =
                 j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -237,7 +237,7 @@ public class ExtendedEmailPublisherDescriptorTest {
 
     @Test
     @Issue("JENKINS-20133")
-    public void testListIDRoundTrip() throws Exception {
+    void testListIDRoundTrip() throws Exception {
         ExtendedEmailPublisherDescriptor descriptor =
                 j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -250,7 +250,7 @@ public class ExtendedEmailPublisherDescriptorTest {
     }
 
     @Test
-    public void testAdvancedProperties() throws Exception {
+    void testAdvancedProperties() throws Exception {
         ExtendedEmailPublisherDescriptor descriptor =
                 j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -263,7 +263,7 @@ public class ExtendedEmailPublisherDescriptorTest {
     }
 
     @Test
-    public void defaultTriggers() throws Exception {
+    void defaultTriggers() throws Exception {
         ExtendedEmailPublisherDescriptor descriptor =
                 j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -302,7 +302,7 @@ public class ExtendedEmailPublisherDescriptorTest {
     }
 
     @Test
-    public void groovyClassPath() throws Exception {
+    void groovyClassPath() throws Exception {
         ExtendedEmailPublisherDescriptor descriptor =
                 j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -316,7 +316,7 @@ public class ExtendedEmailPublisherDescriptorTest {
 
         nodes = settingName.getByXPath(
                 "../div[contains(@class, 'setting-name')]/div[@class='repeated-container']/div[@name='defaultClasspath']");
-        assertEquals("Should not have any class path setup by default", 0, nodes.size());
+        assertEquals(0, nodes.size(), "Should not have any class path setup by default");
 
         HtmlDivision div;
         HtmlButton addButton;
@@ -377,7 +377,7 @@ public class ExtendedEmailPublisherDescriptorTest {
     }
 
     @Test
-    public void managePermissionShouldAccess() {
+    void managePermissionShouldAccess() {
         final String USER = "user";
         final String MANAGER = "manager";
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
@@ -396,19 +396,19 @@ public class ExtendedEmailPublisherDescriptorTest {
                 .to(MANAGER));
         try (ACLContext c = ACL.as(User.getById(USER, true))) {
             Collection<Descriptor> descriptors = Functions.getSortedDescriptorsForGlobalConfigUnclassified();
-            assertEquals("Global configuration should not be accessible to READ users", 0, descriptors.size());
+            assertEquals(0, descriptors.size(), "Global configuration should not be accessible to READ users");
         }
         try (ACLContext c = ACL.as(User.getById(MANAGER, true))) {
             Collection<Descriptor> descriptors = Functions.getSortedDescriptorsForGlobalConfigUnclassified();
             Optional<Descriptor> found = descriptors.stream()
                     .filter(descriptor -> descriptor instanceof ExtendedEmailPublisherDescriptor)
                     .findFirst();
-            assertTrue("Global configuration should be accessible to MANAGE users", found.isPresent());
+            assertTrue(found.isPresent(), "Global configuration should be accessible to MANAGE users");
         }
     }
 
     @Test
-    public void noAuthenticatorIsCreatedWhenCredentialsIsBlank() {
+    void noAuthenticatorIsCreatedWhenCredentialsIsBlank() {
         ExtendedEmailPublisherDescriptor descriptor =
                 j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
 
@@ -438,7 +438,7 @@ public class ExtendedEmailPublisherDescriptorTest {
     }
 
     @Test
-    public void authenticatorIsCreatedWhenCredentialsIdProvided() throws Exception {
+    void authenticatorIsCreatedWhenCredentialsIdProvided() throws Exception {
         UsernamePasswordCredentials c = new UsernamePasswordCredentialsImpl(
                 CredentialsScope.GLOBAL, "email-ext-admin", "Username/password for SMTP", "admin", "honeycomb");
         CredentialsProvider.lookupStores(j.jenkins).iterator().next().addCredentials(Domain.global(), c);
@@ -471,7 +471,7 @@ public class ExtendedEmailPublisherDescriptorTest {
     }
 
     @Test
-    public void testFixEmptyAndTrimNormal() throws Exception {
+    void testFixEmptyAndTrimNormal() throws Exception {
         ExtendedEmailPublisherDescriptor descriptor =
                 j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
         // add a credential to the GLOBAL scope
@@ -501,7 +501,7 @@ public class ExtendedEmailPublisherDescriptorTest {
     }
 
     @Test
-    public void testFixEmptyAndTrimExtraSpaces() throws Exception {
+    void testFixEmptyAndTrimExtraSpaces() throws Exception {
         ExtendedEmailPublisherDescriptor descriptor =
                 j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
         // add a credential to the GLOBAL scope
@@ -531,7 +531,7 @@ public class ExtendedEmailPublisherDescriptorTest {
     }
 
     @Test
-    public void testFixEmptyAndTrimEmptyString() throws Exception {
+    void testFixEmptyAndTrimEmptyString() throws Exception {
         ExtendedEmailPublisherDescriptor descriptor =
                 j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
         MailAccount ma = new MailAccount();
@@ -556,7 +556,7 @@ public class ExtendedEmailPublisherDescriptorTest {
     }
 
     @Test
-    public void testFixEmptyAndTrimNull() throws Exception {
+    void testFixEmptyAndTrimNull() throws Exception {
         ExtendedEmailPublisherDescriptor descriptor =
                 j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
         MailAccount ma = new MailAccount();
@@ -582,7 +582,7 @@ public class ExtendedEmailPublisherDescriptorTest {
 
     @LocalData
     @Test
-    public void persistedConfigurationBeforeJCasC() {
+    void persistedConfigurationBeforeJCasC() {
         // Local data created using Email Extension 2.71 with the following code:
         /*
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -771,7 +771,7 @@ public class ExtendedEmailPublisherDescriptorTest {
     @Issue("JENKINS-63846")
     @LocalData
     @Test
-    public void persistedConfigurationBeforeDefaultAddress() {
+    void persistedConfigurationBeforeDefaultAddress() {
         // Local data created using Email Extension 2.72 with the following code:
         /*
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -985,7 +985,7 @@ public class ExtendedEmailPublisherDescriptorTest {
 
     @Test
     @LocalData
-    public void persistedConfigurationWithCredentialId() {
+    void persistedConfigurationWithCredentialId() {
         // Local data created using Email Extension 2.72 with the following code:
         /*
         // add two credentials to the GLOBAL scope
@@ -1198,7 +1198,7 @@ public class ExtendedEmailPublisherDescriptorTest {
     }
 
     @Test
-    public void emptyScriptApproval() throws Exception {
+    void emptyScriptApproval() throws Exception {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
                 .grant(Jenkins.ADMINISTER)

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherMatrixTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherMatrixTest.java
@@ -2,8 +2,9 @@ package hudson.plugins.emailext;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.matrix.Axis;
 import hudson.matrix.AxisList;
@@ -25,54 +26,52 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.mock_javamail.Mailbox;
 
-public class ExtendedEmailPublisherMatrixTest {
+@WithJenkins
+class ExtendedEmailPublisherMatrixTest {
 
     private ExtendedEmailPublisher publisher;
     private MatrixProject project;
     private static List<DumbSlave> agents;
 
-    @ClassRule
-    public static JenkinsRule j = new JenkinsRule();
+    private static JenkinsRule j;
 
-    @Rule
-    public TestName testName = new TestName();
-
-    @BeforeClass
-    public static void beforeClass() throws Exception {
+    @BeforeAll
+    static void beforeClass(JenkinsRule rule) throws Exception {
+        j = rule;
         agents = new ArrayList<>();
         agents.add(j.createOnlineSlave(new LabelAtom("success-agent1")));
         agents.add(j.createOnlineSlave(new LabelAtom("success-agent2")));
         agents.add(j.createOnlineSlave(new LabelAtom("success-agent3")));
     }
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp(TestInfo info) throws Exception {
         publisher = new ExtendedEmailPublisher();
         publisher.defaultSubject = "%DEFAULT_SUBJECT";
         publisher.defaultContent = "%DEFAULT_CONTENT";
         publisher.attachBuildLog = false;
 
-        project = j.createProject(MatrixProject.class, testName.getMethodName());
+        project = j.createProject(
+                MatrixProject.class, info.getTestMethod().orElseThrow().getName());
         project.getPublishersList().add(publisher);
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         Mailbox.clearAll();
     }
 
     @Test
-    public void testPreBuildMatrixBuildSendParentOnly() throws Exception {
+    void testPreBuildMatrixBuildSendParentOnly() throws Exception {
         publisher.setMatrixTriggerMode(MatrixTriggerMode.ONLY_PARENT);
         List<RecipientProvider> recProviders = Collections.emptyList();
         PreBuildTrigger trigger = new PreBuildTrigger(
@@ -97,7 +96,7 @@ public class ExtendedEmailPublisherMatrixTest {
     }
 
     @Test
-    public void testPreBuildMatrixBuildSendAgentsOnly() throws Exception {
+    void testPreBuildMatrixBuildSendAgentsOnly() throws Exception {
         addAgentToProject(0, 1, 2);
         List<RecipientProvider> recProviders = Collections.emptyList();
         publisher.setMatrixTriggerMode(MatrixTriggerMode.ONLY_CONFIGURATIONS);
@@ -119,7 +118,7 @@ public class ExtendedEmailPublisherMatrixTest {
     }
 
     @Test
-    public void testPreBuildMatrixBuildSendAgentsAndParent() throws Exception {
+    void testPreBuildMatrixBuildSendAgentsAndParent() throws Exception {
         addAgentToProject(0, 1);
         List<RecipientProvider> recProviders = Collections.emptyList();
         publisher.setMatrixTriggerMode(MatrixTriggerMode.BOTH);
@@ -141,7 +140,7 @@ public class ExtendedEmailPublisherMatrixTest {
     }
 
     @Test
-    public void testAttachBuildLogForAllAxes() throws Exception {
+    void testAttachBuildLogForAllAxes() throws Exception {
         publisher.setMatrixTriggerMode(MatrixTriggerMode.ONLY_PARENT);
         publisher.attachBuildLog = true;
         addAgentToProject(0, 1, 2);
@@ -169,25 +168,25 @@ public class ExtendedEmailPublisherMatrixTest {
 
         Message msg = Mailbox.get("solganik@gmail.com").get(0);
 
-        assertTrue("Message should be multipart", msg instanceof MimeMessage);
-        assertTrue("Content should be a MimeMultipart", msg.getContent() instanceof MimeMultipart);
+        assertInstanceOf(MimeMessage.class, msg, "Message should be multipart");
+        assertInstanceOf(MimeMultipart.class, msg.getContent(), "Content should be a MimeMultipart");
 
         MimeMultipart part = (MimeMultipart) msg.getContent();
 
-        assertEquals("Should have four body items (message + attachment)", 4, part.getCount());
+        assertEquals(4, part.getCount(), "Should have four body items (message + attachment)");
 
         int i = 1;
         for (MatrixRun r : build.getExactRuns()) {
             String fileName = "build" + "-" + r.getParent().getCombination().toString('-', '-') + ".log";
             BodyPart attach = part.getBodyPart(i);
             assertTrue(
-                    "There should be a log named \"" + fileName + "\" attached",
-                    fileName.equalsIgnoreCase(attach.getFileName()));
+                    fileName.equalsIgnoreCase(attach.getFileName()),
+                    "There should be a log named \"" + fileName + "\" attached");
             i++;
         }
     }
 
-    private void addEmailType(EmailTrigger trigger) {
+    private static void addEmailType(EmailTrigger trigger) {
         trigger.setEmail(new EmailType() {
             {
                 setRecipientList("solganik@gmail.com");

--- a/src/test/java/hudson/plugins/emailext/MailAccountFIPSTest.java
+++ b/src/test/java/hudson/plugins/emailext/MailAccountFIPSTest.java
@@ -4,8 +4,8 @@ import static hudson.plugins.emailext.FormValidationMessageMatcher.hasMessage;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.jvnet.hudson.test.JenkinsMatchers.hasKind;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
@@ -14,25 +14,33 @@ import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.plugins.emailext.MailAccount.MailAccountDescriptor;
 import hudson.util.FormValidation.Kind;
 import jenkins.model.Jenkins;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.FlagRule;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class MailAccountFIPSTest {
+@WithJenkins
+class MailAccountFIPSTest {
 
-    @ClassRule
-    public static FlagRule<String> fipsSystemPropertyRule =
-            FlagRule.systemProperty("jenkins.security.FIPS140.COMPLIANCE", "true");
+    private static String fipsSystemProperty;
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+    @BeforeAll
+    static void beforeClass() {
+        fipsSystemProperty = System.setProperty("jenkins.security.FIPS140.COMPLIANCE", "true");
+    }
+
+    @AfterAll
+    static void afterClass() {
+        if (fipsSystemProperty != null) {
+            System.clearProperty("jenkins.security.FIPS140.COMPLIANCE");
+        }
+    }
 
     @Test
     @WithoutJenkins
-    public void testIsValidNonAuthConfig() {
+    void testIsValidNonAuthConfig() {
         MailAccount account = new MailAccount();
         account.setAddress("joe@example.com");
         assertTrue(account.isValid());
@@ -40,7 +48,7 @@ public class MailAccountFIPSTest {
 
     @Test
     @WithoutJenkins
-    public void testIsNotValidAuthConfigWithoutEncryption() {
+    void testIsNotValidAuthConfigWithoutEncryption() {
         MailAccount account = new MailAccount();
         account.setAddress("joe@example.com");
         account.setCredentialsId("foo");
@@ -49,7 +57,7 @@ public class MailAccountFIPSTest {
 
     @Test
     @WithoutJenkins
-    public void testIsValidAuthConfigAndSSL() {
+    void testIsValidAuthConfigAndSSL() {
         MailAccount account = new MailAccount();
         account.setAddress("joe@example.com");
         account.setCredentialsId("foo");
@@ -59,7 +67,7 @@ public class MailAccountFIPSTest {
 
     @Test
     @WithoutJenkins
-    public void testIsValidAuthConfigAndTLS() {
+    void testIsValidAuthConfigAndTLS() {
         MailAccount account = new MailAccount();
         account.setAddress("joe@example.com");
         account.setCredentialsId("foo");
@@ -68,7 +76,7 @@ public class MailAccountFIPSTest {
     }
 
     @Test
-    public void testFormValidationForInsecureAuth() throws Exception {
+    void testFormValidationForInsecureAuth(JenkinsRule j) throws Exception {
         final String validCredentialId = "valid-id";
         SystemCredentialsProvider.getInstance()
                 .getCredentials()

--- a/src/test/java/hudson/plugins/emailext/MailAccountTest.java
+++ b/src/test/java/hudson/plugins/emailext/MailAccountTest.java
@@ -3,10 +3,7 @@ package hudson.plugins.emailext;
 import static hudson.plugins.emailext.FormValidationMessageMatcher.hasMessage;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.jvnet.hudson.test.JenkinsMatchers.hasKind;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
@@ -21,18 +18,17 @@ import java.util.List;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.hamcrest.Matchers;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class MailAccountTest {
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class MailAccountTest {
 
     @Test
     @WithoutJenkins
-    public void testIsValidEmptyConfig() {
+    void testIsValidEmptyConfig() {
         JSONObject obj = new JSONObject();
         MailAccount account = new MailAccount(obj);
         assertFalse(account.isValid());
@@ -40,7 +36,7 @@ public class MailAccountTest {
 
     @Test
     @WithoutJenkins
-    public void testIsValidMissingAddress() {
+    void testIsValidMissingAddress() {
         JSONObject obj = new JSONObject();
         obj.put("smtpHost", "mail.bar.com");
         obj.put("smtpPort", 25);
@@ -50,7 +46,7 @@ public class MailAccountTest {
 
     @Test
     @WithoutJenkins
-    public void testIsValidNonAuthConfig() {
+    void testIsValidNonAuthConfig() {
         JSONObject obj = new JSONObject();
         obj.put("address", "foo@bar.com");
         obj.put("smtpHost", "mail.bar.com");
@@ -60,7 +56,7 @@ public class MailAccountTest {
     }
 
     @Test
-    public void testIsValidAuthConfig() {
+    void testIsValidAuthConfig(JenkinsRule j) {
         JSONObject obj = new JSONObject();
         obj.put("address", "foo@bar.com");
         obj.put("smtpHost", "mail.bar.com");
@@ -74,7 +70,7 @@ public class MailAccountTest {
 
     @Test
     @WithoutJenkins
-    public void testIsValidAuthConfigWithoutEncryption() {
+    void testIsValidAuthConfigWithoutEncryption() {
         MailAccount account = new MailAccount();
         account.setAddress("joe@example.com");
         account.setCredentialsId("foo");
@@ -83,7 +79,7 @@ public class MailAccountTest {
 
     @Test
     @WithoutJenkins
-    public void testIsValidAuthConfigAndSSL() {
+    void testIsValidAuthConfigAndSSL() {
         MailAccount account = new MailAccount();
         account.setAddress("joe@example.com");
         account.setCredentialsId("foo");
@@ -93,7 +89,7 @@ public class MailAccountTest {
 
     @Test
     @WithoutJenkins
-    public void testIsValidAuthConfigAndTLS() {
+    void testIsValidAuthConfigAndTLS() {
         MailAccount account = new MailAccount();
         account.setAddress("joe@example.com");
         account.setCredentialsId("foo");
@@ -102,7 +98,7 @@ public class MailAccountTest {
     }
 
     @Test
-    public void testUpgradeDuringCredentialsGetter() {
+    void testUpgradeDuringCredentialsGetter(JenkinsRule j) {
         MailAccount account = new MailAccount();
         account.setSmtpUsername("foo");
         account.setSmtpPassword(Secret.fromString("bar"));
@@ -118,7 +114,7 @@ public class MailAccountTest {
     }
 
     @Test
-    public void testFormValidationForInsecureAuth() throws Exception {
+    void testFormValidationForInsecureAuth(JenkinsRule j) throws Exception {
         final String validCredentialId = "valid-id";
         SystemCredentialsProvider.getInstance()
                 .getCredentials()

--- a/src/test/java/hudson/plugins/emailext/RecipientListStringAnalyserTest.java
+++ b/src/test/java/hudson/plugins/emailext/RecipientListStringAnalyserTest.java
@@ -1,45 +1,45 @@
 package hudson.plugins.emailext;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import jakarta.mail.internet.InternetAddress;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class RecipientListStringAnalyserTest {
+class RecipientListStringAnalyserTest {
 
     @Test
-    public void getTypeForNotContainedEmailAddressReturnsMinus1() throws Exception {
+    void getTypeForNotContainedEmailAddressReturnsMinus1() throws Exception {
         RecipientListStringAnalyser analyser = new RecipientListStringAnalyser("mickey@disney.com");
         assertEquals(
                 RecipientListStringAnalyser.NOT_FOUND, analyser.getType(new InternetAddress("mickey2@disney.com")));
     }
 
     @Test
-    public void getTypeForEmailAddressReturnsTO() throws Exception {
+    void getTypeForEmailAddressReturnsTO() throws Exception {
         RecipientListStringAnalyser analyser = new RecipientListStringAnalyser("mickey@disney.com");
         assertEquals(EmailRecipientUtils.TO, analyser.getType(new InternetAddress("mickey@disney.com")));
     }
 
     @Test
-    public void getTypeForCcPrefixedEmailAddressReturnsCC() throws Exception {
+    void getTypeForCcPrefixedEmailAddressReturnsCC() throws Exception {
         RecipientListStringAnalyser analyser = new RecipientListStringAnalyser("cc:mickey@disney.com");
         assertEquals(EmailRecipientUtils.CC, analyser.getType(new InternetAddress("mickey@disney.com")));
     }
 
     @Test
-    public void getTypeForEmailAddressStartingWithCCReturnsTo() throws Exception {
+    void getTypeForEmailAddressStartingWithCCReturnsTo() throws Exception {
         RecipientListStringAnalyser analyser = new RecipientListStringAnalyser("ccmickey@disney.com");
         assertEquals(EmailRecipientUtils.TO, analyser.getType(new InternetAddress("ccmickey@disney.com")));
     }
 
     @Test
-    public void getTypeForBccPrefixedEmailAddressReturnsBCC() throws Exception {
+    void getTypeForBccPrefixedEmailAddressReturnsBCC() throws Exception {
         RecipientListStringAnalyser analyser = new RecipientListStringAnalyser("bcc:mickey@disney.com");
         assertEquals(EmailRecipientUtils.BCC, analyser.getType(new InternetAddress("mickey@disney.com")));
     }
 
     @Test
-    public void getTypeForSeveralEmailAddressesWithDifferentSeparatorsReturnsTO() throws Exception {
+    void getTypeForSeveralEmailAddressesWithDifferentSeparatorsReturnsTO() throws Exception {
         String[] testStrings = {
             "mickey@disney.com;donald@disney.com",
             "mickey@disney.com donald@disney.com",
@@ -54,13 +54,13 @@ public class RecipientListStringAnalyserTest {
     }
 
     @Test
-    public void getTypeForEmailAddressWithWhitespaceBeforeAndAfterReturnsTO() throws Exception {
+    void getTypeForEmailAddressWithWhitespaceBeforeAndAfterReturnsTO() throws Exception {
         RecipientListStringAnalyser analyser = new RecipientListStringAnalyser(" mickey@disney.com ");
         assertEquals(EmailRecipientUtils.TO, analyser.getType(new InternetAddress("mickey@disney.com")));
     }
 
     @Test
-    public void getTypeForPartiallyCcPrefixed2ndEmailAddresses() throws Exception {
+    void getTypeForPartiallyCcPrefixed2ndEmailAddresses() throws Exception {
         RecipientListStringAnalyser analyser =
                 new RecipientListStringAnalyser("mickey@disney.com, cc:donald@disney.com");
         assertEquals(EmailRecipientUtils.TO, analyser.getType(new InternetAddress("mickey@disney.com")));
@@ -68,7 +68,7 @@ public class RecipientListStringAnalyserTest {
     }
 
     @Test
-    public void getTypeForPartiallyCcPrefixed1stEmailAddresses() throws Exception {
+    void getTypeForPartiallyCcPrefixed1stEmailAddresses() throws Exception {
         RecipientListStringAnalyser analyser =
                 new RecipientListStringAnalyser("cc:donald@disney.com, mickey@disney.com");
         assertEquals(EmailRecipientUtils.CC, analyser.getType(new InternetAddress("donald@disney.com")));
@@ -76,7 +76,7 @@ public class RecipientListStringAnalyserTest {
     }
 
     @Test
-    public void getTypeForPartiallyBccPrefixed2ndEmailAddresses() throws Exception {
+    void getTypeForPartiallyBccPrefixed2ndEmailAddresses() throws Exception {
         RecipientListStringAnalyser analyser =
                 new RecipientListStringAnalyser("mickey@disney.com, bcc:donald@disney.com");
         assertEquals(EmailRecipientUtils.TO, analyser.getType(new InternetAddress("mickey@disney.com")));
@@ -84,7 +84,7 @@ public class RecipientListStringAnalyserTest {
     }
 
     @Test
-    public void getTypeForPartiallyBccPrefixed1stEmailAddresses() throws Exception {
+    void getTypeForPartiallyBccPrefixed1stEmailAddresses() throws Exception {
         RecipientListStringAnalyser analyser =
                 new RecipientListStringAnalyser("bcc:donald@disney.com, mickey@disney.com");
         assertEquals(EmailRecipientUtils.BCC, analyser.getType(new InternetAddress("donald@disney.com")));
@@ -92,7 +92,7 @@ public class RecipientListStringAnalyserTest {
     }
 
     @Test
-    public void getTypeForCcAndBccPrefixedEmailAddresses() throws Exception {
+    void getTypeForCcAndBccPrefixedEmailAddresses() throws Exception {
         RecipientListStringAnalyser analyser =
                 new RecipientListStringAnalyser("cc:mickey@disney.com, bcc:donald@disney.com");
         assertEquals(EmailRecipientUtils.CC, analyser.getType(new InternetAddress("mickey@disney.com")));
@@ -100,7 +100,7 @@ public class RecipientListStringAnalyserTest {
     }
 
     @Test
-    public void getTypeForBccAndCcPrefixedEmailAddresses() throws Exception {
+    void getTypeForBccAndCcPrefixedEmailAddresses() throws Exception {
         RecipientListStringAnalyser analyser =
                 new RecipientListStringAnalyser("bcc:donald@disney.com, cc:mickey@disney.com");
         assertEquals(EmailRecipientUtils.BCC, analyser.getType(new InternetAddress("donald@disney.com")));
@@ -112,7 +112,7 @@ public class RecipientListStringAnalyserTest {
      * bugs in test case logic each permutation is implemented (again) in its own test case below.
      */
     @Test
-    public void getTypeForPartiallyCcAndBccPrefixedEmailAddresses1() throws Exception {
+    void getTypeForPartiallyCcAndBccPrefixedEmailAddresses1() throws Exception {
         RecipientListStringAnalyser analyser =
                 new RecipientListStringAnalyser("mickey@disney.com, cc:donald@disney.com, bcc:goofy@disney.com");
         assertEquals(EmailRecipientUtils.TO, analyser.getType(new InternetAddress("mickey@disney.com")));
@@ -121,7 +121,7 @@ public class RecipientListStringAnalyserTest {
     }
 
     @Test
-    public void getTypeForPartiallyCcAndBccPrefixedEmailAddresses2() throws Exception {
+    void getTypeForPartiallyCcAndBccPrefixedEmailAddresses2() throws Exception {
         RecipientListStringAnalyser analyser =
                 new RecipientListStringAnalyser("mickey@disney.com, bcc:goofy@disney.com, cc:donald@disney.com");
         assertEquals(EmailRecipientUtils.TO, analyser.getType(new InternetAddress("mickey@disney.com")));
@@ -130,7 +130,7 @@ public class RecipientListStringAnalyserTest {
     }
 
     @Test
-    public void getTypeForPartiallyCcAndBccPrefixedEmailAddresses3() throws Exception {
+    void getTypeForPartiallyCcAndBccPrefixedEmailAddresses3() throws Exception {
         RecipientListStringAnalyser analyser =
                 new RecipientListStringAnalyser("cc:donald@disney.com, mickey@disney.com, bcc:goofy@disney.com");
         assertEquals(EmailRecipientUtils.CC, analyser.getType(new InternetAddress("donald@disney.com")));
@@ -139,7 +139,7 @@ public class RecipientListStringAnalyserTest {
     }
 
     @Test
-    public void getTypeForPartiallyCcAndBccPrefixedEmailAddresses4() throws Exception {
+    void getTypeForPartiallyCcAndBccPrefixedEmailAddresses4() throws Exception {
         RecipientListStringAnalyser analyser =
                 new RecipientListStringAnalyser("cc:donald@disney.com, bcc:goofy@disney.com, mickey@disney.com");
         assertEquals(EmailRecipientUtils.CC, analyser.getType(new InternetAddress("donald@disney.com")));
@@ -148,7 +148,7 @@ public class RecipientListStringAnalyserTest {
     }
 
     @Test
-    public void getTypeForPartiallyCcAndBccPrefixedEmailAddresses5() throws Exception {
+    void getTypeForPartiallyCcAndBccPrefixedEmailAddresses5() throws Exception {
         RecipientListStringAnalyser analyser =
                 new RecipientListStringAnalyser("bcc:goofy@disney.com, mickey@disney.com, cc:donald@disney.com");
         assertEquals(EmailRecipientUtils.BCC, analyser.getType(new InternetAddress("goofy@disney.com")));
@@ -157,7 +157,7 @@ public class RecipientListStringAnalyserTest {
     }
 
     @Test
-    public void getTypeForPartiallyCcAndBccPrefixedEmailAddresses6() throws Exception {
+    void getTypeForPartiallyCcAndBccPrefixedEmailAddresses6() throws Exception {
         RecipientListStringAnalyser analyser =
                 new RecipientListStringAnalyser("bcc:goofy@disney.com, cc:donald@disney.com, mickey@disney.com");
         assertEquals(EmailRecipientUtils.BCC, analyser.getType(new InternetAddress("goofy@disney.com")));
@@ -166,7 +166,7 @@ public class RecipientListStringAnalyserTest {
     }
 
     @Test
-    public void testUTF8() throws Exception {
+    void testUTF8() throws Exception {
         RecipientListStringAnalyser analyser =
                 new RecipientListStringAnalyser("ashlux@gmail.com, cc:slide.o.mix@gmail.com, 愛嬋 <another@gmail.com>");
         assertEquals(EmailRecipientUtils.TO, analyser.getType(new InternetAddress("ashlux@gmail.com")));
@@ -175,7 +175,7 @@ public class RecipientListStringAnalyserTest {
     }
 
     @Test
-    public void testBackwardsNames() throws Exception {
+    void testBackwardsNames() throws Exception {
         RecipientListStringAnalyser analyser =
                 new RecipientListStringAnalyser("\"Mouse, Mickey\" <mickey@disney.com>, minnie@disney.com");
         InternetAddress addressWithPersonal = new InternetAddress("mickey@disney.com");

--- a/src/test/java/hudson/plugins/emailext/groovy/sandbox/ObjectInstanceWhitelistTest.java
+++ b/src/test/java/hudson/plugins/emailext/groovy/sandbox/ObjectInstanceWhitelistTest.java
@@ -1,27 +1,28 @@
 package hudson.plugins.emailext.groovy.sandbox;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.mail.Part;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
 import java.lang.reflect.Method;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link ObjectInstanceWhitelist}
  */
-public class ObjectInstanceWhitelistTest {
+class ObjectInstanceWhitelistTest {
+
     @Test
-    public void permitsInstance() {
+    void permitsInstance() {
         String i = "instance";
         ObjectInstanceWhitelist<String> str = new ObjectInstanceWhitelist<>(i) {};
         assertTrue(str.permitsInstance(i));
     }
 
     @Test
-    public void methodInSubInterface() throws Exception {
+    void methodInSubInterface() throws Exception {
         MimeMessage message = new MimeMessage((Session) null);
         MimeMessageInstanceWhitelist whitelist = new MimeMessageInstanceWhitelist(message);
 
@@ -31,7 +32,7 @@ public class ObjectInstanceWhitelistTest {
     }
 
     @Test
-    public void isClass() {
+    void isClass() {
         MimeMessage message = new MimeMessage((Session) null);
         ObjectInstanceWhitelist<MimeMessage> str = new ObjectInstanceWhitelist<>(message) {};
         assertTrue(str.isClass(Part.class));

--- a/src/test/java/hudson/plugins/emailext/plugins/ContentBuilderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/ContentBuilderTest.java
@@ -1,6 +1,6 @@
 package hudson.plugins.emailext.plugins;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -21,47 +21,48 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class ContentBuilderTest {
+@WithJenkins
+class ContentBuilderTest {
 
     private ExtendedEmailPublisher publisher;
     private BuildListener listener;
     private AbstractBuild<?, ?> build;
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule() {
-        @Override
-        public void before() throws Throwable {
-            super.before();
+    private JenkinsRule j;
 
-            listener = new StreamBuildListener(System.out, StandardCharsets.UTF_8);
+    @BeforeEach
+    void setUp(JenkinsRule j) throws Exception {
+        this.j = j;
 
-            publisher = new ExtendedEmailPublisher();
-            publisher.defaultContent = "For only 10 easy payment of $69.99 , AWESOME-O 4000 can be yours!";
-            publisher.defaultSubject = "How would you like your very own AWESOME-O 4000?";
-            publisher.recipientList = "ashlux@gmail.com";
+        listener = new StreamBuildListener(System.out, StandardCharsets.UTF_8);
 
-            Field f = ExtendedEmailPublisherDescriptor.class.getDeclaredField("defaultBody");
-            f.setAccessible(true);
-            f.set(publisher.getDescriptor(), "Give me $4000 and I'll mail you a check for $40,000!");
-            f = ExtendedEmailPublisherDescriptor.class.getDeclaredField("defaultSubject");
-            f.setAccessible(true);
-            f.set(publisher.getDescriptor(), "Nigerian needs your help!");
+        publisher = new ExtendedEmailPublisher();
+        publisher.defaultContent = "For only 10 easy payment of $69.99 , AWESOME-O 4000 can be yours!";
+        publisher.defaultSubject = "How would you like your very own AWESOME-O 4000?";
+        publisher.recipientList = "ashlux@gmail.com";
 
-            f = ExtendedEmailPublisherDescriptor.class.getDeclaredField("recipientList");
-            f.setAccessible(true);
-            f.set(publisher.getDescriptor(), "ashlux@gmail.com");
+        Field f = ExtendedEmailPublisherDescriptor.class.getDeclaredField("defaultBody");
+        f.setAccessible(true);
+        f.set(publisher.getDescriptor(), "Give me $4000 and I'll mail you a check for $40,000!");
+        f = ExtendedEmailPublisherDescriptor.class.getDeclaredField("defaultSubject");
+        f.setAccessible(true);
+        f.set(publisher.getDescriptor(), "Nigerian needs your help!");
 
-            build = mock(AbstractBuild.class);
-            when(build.getEnvironment(listener)).thenReturn(new EnvVars());
-        }
-    };
+        f = ExtendedEmailPublisherDescriptor.class.getDeclaredField("recipientList");
+        f.setAccessible(true);
+        f.set(publisher.getDescriptor(), "ashlux@gmail.com");
+
+        build = mock(AbstractBuild.class);
+        when(build.getEnvironment(listener)).thenReturn(new EnvVars());
+    }
 
     @Test
-    public void testTransformText_shouldExpand_$PROJECT_DEFAULT_CONTENT() {
+    void testTransformText_shouldExpand_$PROJECT_DEFAULT_CONTENT() {
         assertEquals(
                 publisher.defaultContent,
                 ContentBuilder.transformText(
@@ -73,7 +74,7 @@ public class ContentBuilderTest {
     }
 
     @Test
-    public void testTransformText_shouldExpand_$PROJECT_DEFAULT_SUBJECT() {
+    void testTransformText_shouldExpand_$PROJECT_DEFAULT_SUBJECT() {
         assertEquals(
                 publisher.defaultSubject,
                 ContentBuilder.transformText("$PROJECT_DEFAULT_SUBJECT", publisher, build, listener));
@@ -83,7 +84,7 @@ public class ContentBuilderTest {
     }
 
     @Test
-    public void testTransformText_shouldExpand_$DEFAULT_CONTENT() {
+    void testTransformText_shouldExpand_$DEFAULT_CONTENT() {
         assertEquals(
                 publisher.getDescriptor().getDefaultBody(),
                 ContentBuilder.transformText("$DEFAULT_CONTENT", publisher, build, listener));
@@ -93,7 +94,7 @@ public class ContentBuilderTest {
     }
 
     @Test
-    public void testTransformText_shouldExpand_$DEFAULT_SUBJECT() {
+    void testTransformText_shouldExpand_$DEFAULT_SUBJECT() {
         assertEquals(
                 publisher.getDescriptor().getDefaultSubject(),
                 ContentBuilder.transformText("$DEFAULT_SUBJECT", publisher, build, listener));
@@ -103,7 +104,7 @@ public class ContentBuilderTest {
     }
 
     @Test
-    public void testTransformText_shouldExpand_$DEFAULT_RECIPIENT_LIST() {
+    void testTransformText_shouldExpand_$DEFAULT_RECIPIENT_LIST() {
         assertEquals(
                 publisher.getDescriptor().getDefaultRecipients(),
                 ContentBuilder.transformText("$DEFAULT_RECIPIENTS", publisher, build, listener));
@@ -113,7 +114,7 @@ public class ContentBuilderTest {
     }
 
     @Test
-    public void testTransformText_shouldExpand_$DEFAULT_PRESEND_SCRIPT() {
+    void testTransformText_shouldExpand_$DEFAULT_PRESEND_SCRIPT() {
         assertEquals(
                 publisher.getDescriptor().getDefaultPresendScript(),
                 StringUtils.trimToNull(
@@ -125,7 +126,7 @@ public class ContentBuilderTest {
     }
 
     @Test
-    public void testTransformText_shouldExpand_$DEFAULT_POSTSEND_SCRIPT() {
+    void testTransformText_shouldExpand_$DEFAULT_POSTSEND_SCRIPT() {
         assertEquals(
                 publisher.getDescriptor().getDefaultPostsendScript(),
                 StringUtils.trimToNull(
@@ -137,8 +138,7 @@ public class ContentBuilderTest {
     }
 
     @Test
-    public void testTransformText_noNPEWithNullDefaultSubjectBody()
-            throws NoSuchFieldException, IllegalAccessException {
+    void testTransformText_noNPEWithNullDefaultSubjectBody() throws NoSuchFieldException, IllegalAccessException {
         Field f = ExtendedEmailPublisherDescriptor.class.getDeclaredField("defaultBody");
         f.setAccessible(true);
         f.set(publisher.getDescriptor(), null);
@@ -150,7 +150,7 @@ public class ContentBuilderTest {
     }
 
     @Test
-    public void testEscapedToken() throws IOException, InterruptedException {
+    void testEscapedToken() throws IOException, InterruptedException {
         build = mock(AbstractBuild.class);
         EnvVars testVars = new EnvVars();
         testVars.put("FOO", "BAR");
@@ -160,7 +160,7 @@ public class ContentBuilderTest {
     }
 
     @Test
-    public void testRuntimeMacro() {
+    void testRuntimeMacro() {
         RuntimeContent content = new RuntimeContent("Hello, world");
         assertEquals(
                 "Hello, world",
@@ -171,7 +171,7 @@ public class ContentBuilderTest {
                         Collections.singletonList(content)));
     }
 
-    public static class RuntimeContent extends TokenMacro {
+    private static class RuntimeContent extends TokenMacro {
 
         public static final String MACRO_NAME = "RUNTIME";
         private final String replacement;

--- a/src/test/java/hudson/plugins/emailext/plugins/CssInlinerTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/CssInlinerTest.java
@@ -1,8 +1,8 @@
 package hudson.plugins.emailext.plugins;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 
 /**
@@ -10,10 +10,10 @@ import org.jvnet.hudson.test.Issue;
  *
  * @author <a href="https://github.com/rahulsom">Rahul Somasunderam</a>
  */
-public class CssInlinerTest {
+class CssInlinerTest {
 
     @Test
-    public void testEmailWithoutCss() {
+    void testEmailWithoutCss() {
         String input = "<html>"
                 + "  <head></head>"
                 + "  <body>"
@@ -26,7 +26,7 @@ public class CssInlinerTest {
 
     @Test
     @Issue("JENKINS-25719")
-    public void testEntities() {
+    void testEntities() {
         String input = "<html>"
                 + "  <head>"
                 + "    <style data-inline='true'>"
@@ -49,7 +49,7 @@ public class CssInlinerTest {
     }
 
     @Test
-    public void testEmailWithNormalCss() {
+    void testEmailWithNormalCss() {
         String input = "<html>"
                 + "  <head>"
                 + "    <style>"
@@ -65,7 +65,7 @@ public class CssInlinerTest {
     }
 
     @Test
-    public void testEmailWithInlinedCss() {
+    void testEmailWithInlinedCss() {
         String input = "<html>"
                 + "  <head>"
                 + "    <style data-inline='true'>"
@@ -85,7 +85,7 @@ public class CssInlinerTest {
     }
 
     @Test
-    public void testEmailWithMixedCss() {
+    void testEmailWithMixedCss() {
         String input = "<html>"
                 + "  <head>"
                 + "    <style data-inline='true'>"
@@ -108,7 +108,7 @@ public class CssInlinerTest {
     }
 
     @Test
-    public void testImageInliningOff() {
+    void testImageInliningOff() {
         String input = "<html>"
                 + "  <body>"
                 + "    <img src='"
@@ -122,7 +122,7 @@ public class CssInlinerTest {
     }
 
     @Test
-    public void testImageInliningOn() {
+    void testImageInliningOn() {
         String input = "<html>"
                 + "  <body>"
                 + "    <img src='"
@@ -144,7 +144,7 @@ public class CssInlinerTest {
     }
 
     @Test
-    public void testNoPrettify() {
+    void testNoPrettify() {
         String input =
                 """
                 <html><head></head>
@@ -164,11 +164,11 @@ public class CssInlinerTest {
         assertEquals(input, output);
     }
 
-    private String process(String input) {
+    private static String process(String input) {
         return clean(new CssInliner().process(input));
     }
 
-    private String clean(String input) {
+    private static String clean(String input) {
         return input.replaceAll(" +", " ").replaceAll("\n", "").replaceAll("> *<", "><");
     }
 }

--- a/src/test/java/hudson/plugins/emailext/plugins/OnlyRegressionsTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/OnlyRegressionsTest.java
@@ -1,7 +1,7 @@
 package hudson.plugins.emailext.plugins;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.FilePath;
 import hudson.Launcher;
@@ -14,18 +14,16 @@ import hudson.tasks.junit.JUnitResultArchiver;
 import hudson.util.StreamTaskListener;
 import java.io.IOException;
 import java.net.URL;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class OnlyRegressionsTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class OnlyRegressionsTest {
 
     @Test
-    public void testOnlyRegressionsAreShown() throws Exception {
+    void testOnlyRegressionsAreShown(JenkinsRule j) throws Exception {
         FreeStyleProject project = j.createFreeStyleProject("onlyRegressions");
         project.getPublishersList().add(new JUnitResultArchiver("target/testreports/*.xml", true, null));
 
@@ -52,16 +50,16 @@ public class OnlyRegressionsTest {
         failedTestsContent.onlyRegressions = true;
         String content = failedTestsContent.evaluate(project.getLastBuild(), listener, FailedTestsContent.MACRO_NAME);
         assertTrue(
-                "The failing test should be reported the first time it fails",
-                content.contains("hudson.plugins.emailext"));
+                content.contains("hudson.plugins.emailext"),
+                "The failing test should be reported the first time it fails");
 
         project.scheduleBuild2(0).get();
         content = failedTestsContent.evaluate(project.getLastBuild(), listener, FailedTestsContent.MACRO_NAME);
         assertFalse(
-                "The failing test should not be reported the second time it fails",
-                content.contains("hudson.plugins.emailext"));
+                content.contains("hudson.plugins.emailext"),
+                "The failing test should not be reported the second time it fails");
         assertTrue(
-                "The content should state that there are other failing tests still",
-                content.contains("and 1 other failed test"));
+                content.contains("and 1 other failed test"),
+                "The content should state that there are other failing tests still");
     }
 }

--- a/src/test/java/hudson/plugins/emailext/plugins/RecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/RecipientProviderTest.java
@@ -1,8 +1,8 @@
 package hudson.plugins.emailext.plugins;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import hudson.model.FreeStyleProject;
 import hudson.plugins.emailext.plugins.recipients.DevelopersRecipientProvider;
@@ -13,17 +13,15 @@ import java.util.Arrays;
 import java.util.List;
 import org.hamcrest.CoreMatchers;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class RecipientProviderTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class RecipientProviderTest {
 
     @Test
-    public void allSupporting() {
+    void allSupporting(JenkinsRule j) {
         List<RecipientProviderDescriptor> descriptors = RecipientProvider.allSupporting(WorkflowJob.class);
         assertThat(
                 descriptors, CoreMatchers.hasItem(CoreMatchers.isA(DevelopersRecipientProvider.DescriptorImpl.class)));
@@ -38,7 +36,7 @@ public class RecipientProviderTest {
     }
 
     @Test
-    public void checkAllSupport() {
+    void checkAllSupport(JenkinsRule j) {
         RecipientProvider.checkAllSupport(
                 Arrays.asList(new RequesterRecipientProvider(), new DevelopersRecipientProvider()), WorkflowJob.class);
         List<? extends RecipientProvider> providers =

--- a/src/test/java/hudson/plugins/emailext/plugins/ZipDataSourceTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/ZipDataSourceTest.java
@@ -1,22 +1,20 @@
 package hudson.plugins.emailext.plugins;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.ZipInputStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ZipDataSourceTest {
+class ZipDataSourceTest {
 
     private static final int BUFFER_SIZE = 1024;
 
     @Test
-    public void testGetName() throws IOException {
+    void testGetName() throws IOException {
         String name = "myFile";
 
         ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
@@ -26,7 +24,7 @@ public class ZipDataSourceTest {
     }
 
     @Test
-    public void testGetContentType() throws IOException {
+    void testGetContentType() throws IOException {
         String name = "myFile";
 
         ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
@@ -36,7 +34,7 @@ public class ZipDataSourceTest {
     }
 
     @Test
-    public void testGetInputStream() throws IOException {
+    void testGetInputStream() throws IOException {
         byte[] sample = "Hello World lllllllllllots of repeated charactersssssssssssss Hello World again".getBytes();
         ZipDataSource dataSource = new ZipDataSource("name", new ByteArrayInputStream(sample));
         InputStream in = dataSource.getInputStream();
@@ -55,15 +53,15 @@ public class ZipDataSourceTest {
     }
 
     @Test
-    public void testGetOutputStream() throws IOException {
+    void testGetOutputStream() throws IOException {
         String name = "myFile";
 
         ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
         ZipDataSource dataSource = new ZipDataSource(name, in);
 
         assertThrows(
-                "It is not possible to get an OutputStream from the ZipDataSource",
                 IOException.class,
-                dataSource::getOutputStream);
+                dataSource::getOutputStream,
+                "It is not possible to get an OutputStream from the ZipDataSource");
     }
 }

--- a/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/FailedTestsContentTest.java
@@ -1,8 +1,6 @@
 package hudson.plugins.emailext.plugins.content;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -15,26 +13,27 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.apache.commons.lang.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class FailedTestsContentTest {
+class FailedTestsContentTest {
+
     private FailedTestsContent failedTestContent;
 
     private AbstractBuild<?, ?> build;
 
     private TaskListener listener;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         failedTestContent = new FailedTestsContent();
         listener = StreamTaskListener.fromStdout();
         build = mock(AbstractBuild.class);
     }
 
     @Test
-    public void testGetContent_noTestsRanShouldGiveAMeaningfulMessage() throws Exception {
+    void testGetContent_noTestsRanShouldGiveAMeaningfulMessage() throws Exception {
         String content = failedTestContent.evaluate(build, listener, FailedTestsContent.MACRO_NAME);
 
         assertEquals("No tests ran.", content);
@@ -44,7 +43,7 @@ public class FailedTestsContentTest {
      * Verifies that token expansion works for pipeline builds (JENKINS-38519).
      */
     @Test
-    public void testGetContent_withWorkspaceAndNoTestsRanShouldGiveAMeaningfulMessage() throws Exception {
+    void testGetContent_withWorkspaceAndNoTestsRanShouldGiveAMeaningfulMessage() throws Exception {
         String content =
                 failedTestContent.evaluate(build, build.getWorkspace(), listener, FailedTestsContent.MACRO_NAME);
 
@@ -52,7 +51,7 @@ public class FailedTestsContentTest {
     }
 
     @Test
-    public void testGetContent_whenAllTestsPassedShouldGiveMeaningfulMessage() throws Exception {
+    void testGetContent_whenAllTestsPassedShouldGiveMeaningfulMessage() throws Exception {
         AbstractTestResultAction<?> testResults = mock(AbstractTestResultAction.class);
         when(testResults.getFailCount()).thenReturn(0);
 
@@ -64,7 +63,7 @@ public class FailedTestsContentTest {
     }
 
     @Test
-    public void testGetContent_whenSomeTestsFailedShouldGiveMeaningfulMessage() throws Exception {
+    void testGetContent_whenSomeTestsFailedShouldGiveMeaningfulMessage() throws Exception {
         AbstractTestResultAction<?> testResults = mock(AbstractTestResultAction.class);
         when(testResults.getFailCount()).thenReturn(123);
 
@@ -77,7 +76,7 @@ public class FailedTestsContentTest {
     }
 
     @Test
-    public void testGetContent_withMessage_withStack() throws Exception {
+    void testGetContent_withMessage_withStack() throws Exception {
         AbstractTestResultAction<?> testResults = mock(AbstractTestResultAction.class);
         when(testResults.getFailCount()).thenReturn(2);
 
@@ -108,7 +107,7 @@ public class FailedTestsContentTest {
     }
 
     @Test
-    public void testGetContent_noMessage_withStack() throws Exception {
+    void testGetContent_noMessage_withStack() throws Exception {
         AbstractTestResultAction<?> testResults = mock(AbstractTestResultAction.class);
         when(testResults.getFailCount()).thenReturn(2);
 
@@ -138,7 +137,7 @@ public class FailedTestsContentTest {
     }
 
     @Test
-    public void testGetContent_withMessage_noStack() throws Exception {
+    void testGetContent_withMessage_noStack() throws Exception {
         AbstractTestResultAction<?> testResults = mock(AbstractTestResultAction.class);
         when(testResults.getFailCount()).thenReturn(2);
 
@@ -168,7 +167,7 @@ public class FailedTestsContentTest {
     }
 
     @Test
-    public void testGetContent_noMessage_noStack() throws Exception {
+    void testGetContent_noMessage_noStack() throws Exception {
         AbstractTestResultAction<?> testResults = mock(AbstractTestResultAction.class);
         when(testResults.getFailCount()).thenReturn(2);
 
@@ -198,7 +197,7 @@ public class FailedTestsContentTest {
     }
 
     @Test
-    public void testGetContent_whenContentLargerThanMaxLengthShouldTruncate() throws Exception {
+    void testGetContent_whenContentLargerThanMaxLengthShouldTruncate() throws Exception {
         AbstractTestResultAction<?> testResults = mock(AbstractTestResultAction.class);
         when(testResults.getFailCount()).thenReturn(5);
 
@@ -227,7 +226,7 @@ public class FailedTestsContentTest {
     }
 
     @Test
-    public void testGetContent_withMessage_withStack_htmlEscaped() throws Exception {
+    void testGetContent_withMessage_withStack_htmlEscaped() throws Exception {
         AbstractTestResultAction<?> testResults = mock(AbstractTestResultAction.class);
         when(testResults.getFailCount()).thenReturn(1);
 
@@ -248,16 +247,16 @@ public class FailedTestsContentTest {
         String content = failedTestContent.evaluate(build, listener, FailedTestsContent.MACRO_NAME);
 
         assertEquals(
-                content,
                 "1 tests failed.<br/>" + "FAILED:  hudson.plugins.emailext.ExtendedEmailPublisherTest.Test<br/><br/>"
                         + "Error Message:<br/>"
                         + "expected:&lt;ABORTED&gt; but was:&lt;COMPLETED&gt; <br/><br/>"
                         + "Stack Trace:<br/>"
-                        + "at org.nexusformat.NexusFile.&lt;clinit&gt;(NexusFile.java:99)<br/><br/>");
+                        + "at org.nexusformat.NexusFile.&lt;clinit&gt;(NexusFile.java:99)<br/><br/>",
+                content);
     }
 
     @Test
-    public void testGetContent_withMessage_withStack_outputYaml() throws Exception {
+    void testGetContent_withMessage_withStack_outputYaml() throws Exception {
         AbstractTestResultAction<?> testResults = mock(AbstractTestResultAction.class);
         when(testResults.getFailCount()).thenReturn(1);
         String testStackTrace =
@@ -352,7 +351,7 @@ public class FailedTestsContentTest {
     }
 
     @Test
-    public void testGetContent_withMessage_withStack_specificTestSuite() throws Exception {
+    void testGetContent_withMessage_withStack_specificTestSuite() throws Exception {
         AbstractTestResultAction<?> testResults = mock(AbstractTestResultAction.class);
 
         List<TestResult> failedTests = new ArrayList<>();
@@ -398,7 +397,7 @@ public class FailedTestsContentTest {
     }
 
     @Test
-    public void testGetContent_withMessage_withStack_allTestSuites() throws Exception {
+    void testGetContent_withMessage_withStack_allTestSuites() throws Exception {
         AbstractTestResultAction<?> testResults = mock(AbstractTestResultAction.class);
 
         List<TestResult> failedTests = new ArrayList<>();

--- a/src/test/java/hudson/plugins/emailext/plugins/content/JellyScriptContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/JellyScriptContentTest.java
@@ -1,7 +1,7 @@
 package hudson.plugins.emailext.plugins.content;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -14,59 +14,58 @@ import hudson.util.DescribableList;
 import hudson.util.StreamTaskListener;
 import java.lang.reflect.Field;
 import java.util.GregorianCalendar;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class JellyScriptContentTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule() {
-        @Override
-        public void before() throws Throwable {
-            super.before();
-
-            content = new JellyScriptContent();
-            listener = StreamTaskListener.fromStdout();
-
-            publisher = new ExtendedEmailPublisher();
-            publisher.defaultContent = "For only 10 easy payment of $69.99 , AWESOME-O 4000 can be yours!";
-            publisher.defaultSubject = "How would you like your very own AWESOME-O 4000?";
-            publisher.recipientList = "ashlux@gmail.com";
-
-            Field f = ExtendedEmailPublisherDescriptor.class.getDeclaredField("defaultBody");
-            f.setAccessible(true);
-            f.set(publisher.getDescriptor(), "Give me $4000 and I'll mail you a check for $40,000!");
-            f = ExtendedEmailPublisherDescriptor.class.getDeclaredField("defaultSubject");
-            f.setAccessible(true);
-            f.set(publisher.getDescriptor(), "Nigerian needs your help!");
-
-            f = ExtendedEmailPublisherDescriptor.class.getDeclaredField("recipientList");
-            f.setAccessible(true);
-            f.set(publisher.getDescriptor(), "ashlux@gmail.com");
-
-            build = mock(AbstractBuild.class);
-            AbstractProject<?, ?> project = mock(AbstractProject.class);
-            DescribableList publishers = mock(DescribableList.class);
-            when(publishers.get(ExtendedEmailPublisher.class)).thenReturn(publisher);
-            when(project.getPublishersList()).thenReturn(publishers);
-            when(build.getProject()).thenReturn(project);
-        }
-    };
+@WithJenkins
+class JellyScriptContentTest {
 
     private JellyScriptContent content;
     private ExtendedEmailPublisher publisher;
     private TaskListener listener;
     private AbstractBuild build;
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule j) throws Exception {
+        this.j = j;
+        content = new JellyScriptContent();
+        listener = StreamTaskListener.fromStdout();
+
+        publisher = new ExtendedEmailPublisher();
+        publisher.defaultContent = "For only 10 easy payment of $69.99 , AWESOME-O 4000 can be yours!";
+        publisher.defaultSubject = "How would you like your very own AWESOME-O 4000?";
+        publisher.recipientList = "ashlux@gmail.com";
+
+        Field f = ExtendedEmailPublisherDescriptor.class.getDeclaredField("defaultBody");
+        f.setAccessible(true);
+        f.set(publisher.getDescriptor(), "Give me $4000 and I'll mail you a check for $40,000!");
+        f = ExtendedEmailPublisherDescriptor.class.getDeclaredField("defaultSubject");
+        f.setAccessible(true);
+        f.set(publisher.getDescriptor(), "Nigerian needs your help!");
+
+        f = ExtendedEmailPublisherDescriptor.class.getDeclaredField("recipientList");
+        f.setAccessible(true);
+        f.set(publisher.getDescriptor(), "ashlux@gmail.com");
+
+        build = mock(AbstractBuild.class);
+        AbstractProject<?, ?> project = mock(AbstractProject.class);
+        DescribableList publishers = mock(DescribableList.class);
+        when(publishers.get(ExtendedEmailPublisher.class)).thenReturn(publisher);
+        when(project.getPublishersList()).thenReturn(publishers);
+        when(build.getProject()).thenReturn(project);
+    }
 
     @Test
-    public void testShouldFindTemplateOnClassPath() throws Exception {
+    void testShouldFindTemplateOnClassPath() throws Exception {
         content.template = "empty-template-on-classpath";
         assertEquals("HELLO WORLD!", content.evaluate(build, listener, JellyScriptContent.MACRO_NAME));
     }
 
     @Test
-    public void testWhenTemplateNotFoundThrowFileNotFoundException() throws Exception {
+    void testWhenTemplateNotFoundThrowFileNotFoundException() throws Exception {
         content.template = "template-does-not-exist";
         String output = content.evaluate(build, listener, JellyScriptContent.MACRO_NAME);
 
@@ -78,7 +77,7 @@ public class JellyScriptContentTest {
      * any other SCM) specific methods.
      */
     @Test
-    public void testChangeLogDisplayShouldntOnlyRelyOnPortableMethods() throws Exception {
+    void testChangeLogDisplayShouldntOnlyRelyOnPortableMethods() throws Exception {
         content.template = "text";
 
         when(build.getTimestamp()).thenReturn(new GregorianCalendar());
@@ -101,7 +100,7 @@ public class JellyScriptContentTest {
      * any other SCM) specific methods.
      */
     @Test
-    public void testChangeLogDisplayShouldntOnlyRelyOnPortableMethods2() throws Exception {
+    void testChangeLogDisplayShouldntOnlyRelyOnPortableMethods2() throws Exception {
         content.template = "html";
 
         when(build.getTimestamp()).thenReturn(new GregorianCalendar());
@@ -117,7 +116,7 @@ public class JellyScriptContentTest {
         assertTrue(output.contains("add"));
     }
 
-    private void mockChangeSet(final AbstractBuild build) {
+    private static void mockChangeSet(final AbstractBuild build) {
         ScriptContentChangeLogSet changeLog = new ScriptContentChangeLogSet(build);
         when(build.getChangeSet()).thenReturn(changeLog);
     }

--- a/src/test/java/hudson/plugins/emailext/plugins/content/ScriptContentBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/ScriptContentBuildWrapperTest.java
@@ -1,9 +1,6 @@
 package hudson.plugins.emailext.plugins.content;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -17,23 +14,23 @@ import hudson.tasks.test.AggregatedTestResultAction.ChildReport;
 import java.util.Calendar;
 import java.util.LinkedList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class ScriptContentBuildWrapperTest {
+class ScriptContentBuildWrapperTest {
     private ScriptContentBuildWrapper buildWrapper;
 
     private AbstractBuild<?, ?> mockBuild;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         mockBuild = mock(AbstractBuild.class);
 
         buildWrapper = new ScriptContentBuildWrapper(mockBuild);
     }
 
     @Test
-    public void testGetTimestampString() {
+    void testGetTimestampString() {
         final Calendar calendar = Calendar.getInstance();
         when(mockBuild.getTimestamp()).thenReturn(calendar);
 
@@ -41,14 +38,14 @@ public class ScriptContentBuildWrapperTest {
     }
 
     @Test
-    public void testGetAction_whenActionNotFoundThenReturnNull() {
+    void testGetAction_whenActionNotFoundThenReturnNull() {
         when(mockBuild.getActions()).thenReturn(new LinkedList<>());
 
         assertNull(buildWrapper.getAction("class.not.found"));
     }
 
     @Test
-    public void testGetJUnitTestResult_whenMavenProjectUseMavenPluginsSurefireAggregatedReport() {
+    void testGetJUnitTestResult_whenMavenProjectUseMavenPluginsSurefireAggregatedReport() {
         final AggregatedTestResultAction surefireAggregatedReport = mock(AggregatedTestResultAction.class);
         final ChildReport childReport1 = mockChildReport();
         final ChildReport childReport2 = mockChildReport();
@@ -79,14 +76,14 @@ public class ScriptContentBuildWrapperTest {
     }
 
     @Test
-    public void testGetJUnitTestResult_listShouldBeEmptyWhenNoTestsFound() {
+    void testGetJUnitTestResult_listShouldBeEmptyWhenNoTestsFound() {
         final List<TestResult> testResults = buildWrapper.getJUnitTestResult();
 
         assertTrue(testResults.isEmpty());
     }
 
     @Test
-    public void testGetJUnitTestResult_whenFreestyleProjectShouldGetTest() {
+    void testGetJUnitTestResult_whenFreestyleProjectShouldGetTest() {
         final TestResult testResult = new TestResult();
         final TestResultAction testResultAction = mock(TestResultAction.class);
 

--- a/src/test/java/hudson/plugins/emailext/plugins/content/ScriptContentChangeLogSet.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/ScriptContentChangeLogSet.java
@@ -3,6 +3,7 @@ package hudson.plugins.emailext.plugins.content;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.AbstractBuild;
 import hudson.model.User;
 import hudson.scm.ChangeLogSet;
@@ -27,6 +28,7 @@ public class ScriptContentChangeLogSet extends ChangeLogSet<ChangeLogSet.Entry> 
     }
 
     @Override
+    @NonNull
     public Iterator iterator() {
         return Collections.singletonList(new Entry() {
                     @Override

--- a/src/test/java/hudson/plugins/emailext/plugins/content/ScriptContentSecureTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/ScriptContentSecureTest.java
@@ -28,10 +28,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.cloudbees.hudson.plugins.folder.Folder;
 import hudson.model.FreeStyleBuild;
@@ -46,19 +43,21 @@ import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.configfiles.folder.FolderConfigFileAction;
 import org.jenkinsci.plugins.configfiles.folder.FolderConfigFileProperty;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 /**
  * Runs some {@link ScriptContentTest} in a secured Jenkins.
  */
-public class ScriptContentSecureTest extends ScriptContentTest {
+@WithJenkins
+class ScriptContentSecureTest extends ScriptContentTest {
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
 
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
@@ -72,31 +71,19 @@ public class ScriptContentSecureTest extends ScriptContentTest {
 
     @Override
     @Test
-    public void testShouldFindScriptOnClassPath() throws Exception {
-        super.testShouldFindScriptOnClassPath();
-    }
-
-    @Override
-    @Test
-    public void testShouldFindTemplateOnClassPath() throws Exception {
-        super.testShouldFindTemplateOnClassPath();
-    }
-
-    @Override
-    @Test
-    public void templateInWorkspace() throws Exception {
+    void templateInWorkspace() throws Exception {
         ScriptApproval.get().clearApprovedScripts();
         super.templateInWorkspace();
     }
 
     @Override
     @Test
-    public void templateInWorkspaceUnsafe() throws Exception {
+    void templateInWorkspaceUnsafe() throws Exception {
         ScriptApproval.get().clearApprovedScripts();
         assertThrows(
-                "Templates in the workspace should use the Groovy sandbox",
                 AssertionError.class,
-                super::templateInWorkspaceUnsafe);
+                super::templateInWorkspaceUnsafe,
+                "Templates in the workspace should use the Groovy sandbox");
         // Error message is a TokenMacro parse error and does not contain a script security warning,
         // perhaps due to EmailExtScript#methodMissing? The message looks like:
         // Error processing tokens: Error while parsing action
@@ -106,25 +93,19 @@ public class ScriptContentSecureTest extends ScriptContentTest {
 
     @Issue("SECURITY-1340")
     @Test
-    public void templateInWorkspaceWithConstructor() throws Exception {
+    void templateInWorkspaceWithConstructor() throws Exception {
         ScriptApproval.get().clearApprovedScripts();
         AssertionError e = assertThrows(
-                "Templates in the workspace should use the Groovy sandbox",
                 AssertionError.class,
-                () -> super.templateInWorkspace("/testConstructor.groovy"));
+                () -> super.templateInWorkspace("/testConstructor.groovy"),
+                "Templates in the workspace should use the Groovy sandbox");
         assertThat(e.getMessage(), containsString("staticMethod jenkins.model.Jenkins getInstance"));
         assertNull(j.jenkins.getItem("should-not-exist"));
     }
 
-    @Override
-    @Test
-    public void testGroovyTemplateWithContentToken() throws Exception {
-        super.testGroovyTemplateWithContentToken();
-    }
-
     @Test
     @Issue("SECURITY-2939")
-    public void managedBadTemplateInFolder() throws Exception {
+    void managedBadTemplateInFolder() throws Exception {
         final Folder folder = j.createProject(Folder.class, "sub");
 
         final FreeStyleProject project = folder.createProject(FreeStyleProject.class, "Free");

--- a/src/test/java/hudson/plugins/emailext/plugins/content/TestCountsContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/TestCountsContentTest.java
@@ -1,6 +1,6 @@
 package hudson.plugins.emailext.plugins.content;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -8,34 +8,29 @@ import hudson.model.AbstractBuild;
 import hudson.model.TaskListener;
 import hudson.tasks.test.AbstractTestResultAction;
 import hudson.util.StreamTaskListener;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for TestCountsContentTest.
  *
  * @author Seiji Sogabe
  */
-public class TestCountsContentTest {
+class TestCountsContentTest {
 
     private TestCountsContent target;
     private AbstractBuild<?, ?> build;
     private TaskListener listener;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         target = new TestCountsContent();
         build = mock(AbstractBuild.class);
         listener = StreamTaskListener.fromStdout();
     }
 
-    @After
-    public void tearDown() {}
-
     @Test
-    @SuppressWarnings("unchecked")
-    public void testGetContent_NoTestResults() throws Exception {
+    void testGetContent_NoTestResults() throws Exception {
         target.var = "total";
         assertEquals("", target.evaluate(build, listener, TestCountsContent.MACRO_NAME));
     }
@@ -44,15 +39,13 @@ public class TestCountsContentTest {
      * Verifies that token expansion works for pipeline builds (JENKINS-38519).
      */
     @Test
-    @SuppressWarnings("unchecked")
-    public void testGetContent_withWorkspaceAndNoTestResults() throws Exception {
+    void testGetContent_withWorkspaceAndNoTestResults() throws Exception {
         target.var = "total";
         assertEquals("", target.evaluate(build, build.getWorkspace(), listener, TestCountsContent.MACRO_NAME));
     }
 
     @Test
-    @SuppressWarnings("unchecked")
-    public void testGetContent() throws Exception {
+    void testGetContent() throws Exception {
         AbstractTestResultAction<?> results = mock(AbstractTestResultAction.class);
         when(results.getTotalCount()).thenReturn(5);
         when(results.getTotalCount() - results.getFailCount() - results.getSkipCount())

--- a/src/test/java/hudson/plugins/emailext/plugins/content/TriggerNameContentTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/content/TriggerNameContentTest.java
@@ -2,7 +2,7 @@ package hudson.plugins.emailext.plugins.content;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
@@ -14,26 +14,27 @@ import hudson.plugins.emailext.plugins.trigger.PreBuildTrigger;
 import jakarta.mail.Message;
 import java.util.Collections;
 import java.util.List;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.mock_javamail.Mailbox;
 
 /**
  *
  * @author acearl
  */
-public class TriggerNameContentTest {
+@WithJenkins
+class TriggerNameContentTest {
     private ExtendedEmailPublisher publisher;
     private FreeStyleProject project;
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+    private JenkinsRule j;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp(JenkinsRule j) throws Exception {
+        this.j = j;
         publisher = new ExtendedEmailPublisher();
         publisher.defaultSubject = "%DEFAULT_SUBJECT";
         publisher.defaultContent = "%DEFAULT_CONTENT";
@@ -46,13 +47,13 @@ public class TriggerNameContentTest {
         project.getPublishersList().add(publisher);
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         Mailbox.clearAll();
     }
 
     @Test
-    public void testTriggerName() throws Exception {
+    void testTriggerName() throws Exception {
         List<RecipientProvider> recProviders = Collections.emptyList();
         PreBuildTrigger trigger = new PreBuildTrigger(
                 recProviders,
@@ -78,7 +79,7 @@ public class TriggerNameContentTest {
         assertEquals(PreBuildTrigger.TRIGGER_NAME, message.getSubject());
     }
 
-    private void addEmailType(EmailTrigger trigger) {
+    private static void addEmailType(EmailTrigger trigger) {
         trigger.setEmail(new EmailType() {
             {
                 setRecipientList("mickey@disney.com");

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/ContributorMetadataRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/ContributorMetadataRecipientProviderTest.java
@@ -6,24 +6,30 @@ import java.util.Collections;
 import jenkins.scm.api.metadata.ContributorMetadataAction;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.mock_javamail.Mailbox;
 
-public class ContributorMetadataRecipientProviderTest {
+@WithJenkins
+class ContributorMetadataRecipientProviderTest {
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+    private JenkinsRule j;
 
-    @After
-    public void tearDown() {
+    @BeforeEach
+    void setUp(JenkinsRule j) {
+        this.j = j;
+    }
+
+    @AfterEach
+    void tearDown() {
         Mailbox.clearAll();
     }
 
     @Test
-    public void testAddRecipients() throws Exception {
+    void testAddRecipients() throws Exception {
         User user = User.get("someone", true, Collections.emptyMap());
         user.addProperty(new Mailer.UserProperty("someone@DOMAIN"));
 
@@ -35,7 +41,7 @@ public class ContributorMetadataRecipientProviderTest {
     }
 
     @Test
-    public void testAddRecipients_NotUser() throws Exception {
+    void testAddRecipients_NotUser() throws Exception {
         WorkflowJob job = j.createProject(WorkflowJob.class, "test");
         WorkflowRun run = job.scheduleBuild2(0).get();
         run.addAction(new ContributorMetadataAction("someoneelse", "Some One Else", "someoneelse@DOMAIN"));

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/CulpritsRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/CulpritsRecipientProviderTest.java
@@ -6,19 +6,19 @@ import hudson.tasks.Mailer;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-public class CulpritsRecipientProviderTest {
+class CulpritsRecipientProviderTest {
 
     private MockedStatic<Jenkins> mockedJenkins;
     private MockedStatic<Mailer> mockedMailer;
 
-    @Before
-    public void before() {
+    @BeforeEach
+    void before() {
         final Jenkins jenkins = Mockito.mock(Jenkins.class);
         Mockito.when(jenkins.isUseSecurity()).thenReturn(false);
         final ExtendedEmailPublisherDescriptor extendedEmailPublisherDescriptor =
@@ -37,14 +37,14 @@ public class CulpritsRecipientProviderTest {
         mockedMailer.when(Mailer::descriptor).thenReturn(descriptor);
     }
 
-    @After
-    public void after() {
+    @AfterEach
+    void after() {
         mockedMailer.close();
         mockedJenkins.close();
     }
 
     @Test
-    public void testAddRecipients1() throws Exception {
+    void testAddRecipients1() throws Exception {
         final WorkflowJob j = Mockito.mock(WorkflowJob.class);
         final WorkflowRun build1 = Mockito.spy(new WorkflowRun(j));
         Mockito.when(build1.getResult()).thenReturn(Result.UNSTABLE);
@@ -70,7 +70,7 @@ public class CulpritsRecipientProviderTest {
     }
 
     @Test
-    public void testAddRecipients2() throws Exception {
+    void testAddRecipients2() throws Exception {
         final WorkflowJob j = Mockito.mock(WorkflowJob.class);
         final WorkflowRun build1 = Mockito.spy(new WorkflowRun(j));
         Mockito.when(build1.getResult()).thenReturn(Result.UNSTABLE);

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/DevelopersRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/DevelopersRecipientProviderTest.java
@@ -9,19 +9,19 @@ import hudson.tasks.Mailer;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-public class DevelopersRecipientProviderTest {
+class DevelopersRecipientProviderTest {
 
     private MockedStatic<Jenkins> mockedJenkins;
     private MockedStatic<Mailer> mockedMailer;
 
-    @Before
-    public void before() {
+    @BeforeEach
+    void before() {
         final Jenkins jenkins = Mockito.mock(Jenkins.class);
         Mockito.when(jenkins.isUseSecurity()).thenReturn(false);
         final ExtendedEmailPublisherDescriptor extendedEmailPublisherDescriptor =
@@ -40,14 +40,14 @@ public class DevelopersRecipientProviderTest {
         mockedMailer.when(Mailer::descriptor).thenReturn(descriptor);
     }
 
-    @After
-    public void after() {
+    @AfterEach
+    void after() {
         mockedMailer.close();
         mockedJenkins.close();
     }
 
     @Test
-    public void testAddRecipients() throws Exception {
+    void testAddRecipients() throws Exception {
         try (MockedStatic<User> mockedUser = Mockito.mockStatic(User.class)) {
             final FreeStyleProject p = Mockito.mock(FreeStyleProject.class);
             final FreeStyleBuild build1 = Mockito.spy(new FreeStyleBuild(p));

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/FailingTestSuspectsRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/FailingTestSuspectsRecipientProviderTest.java
@@ -31,19 +31,19 @@ import hudson.plugins.emailext.ExtendedEmailPublisherDescriptor;
 import hudson.tasks.Mailer;
 import hudson.tasks.test.AbstractTestResultAction;
 import jenkins.model.Jenkins;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-public class FailingTestSuspectsRecipientProviderTest {
+class FailingTestSuspectsRecipientProviderTest {
 
     private MockedStatic<Jenkins> mockedJenkins;
     private MockedStatic<Mailer> mockedMailer;
 
-    @Before
-    public void before() {
+    @BeforeEach
+    void before() {
         final Jenkins jenkins = Mockito.mock(Jenkins.class);
         Mockito.when(jenkins.isUseSecurity()).thenReturn(false);
         final ExtendedEmailPublisherDescriptor extendedEmailPublisherDescriptor =
@@ -63,14 +63,14 @@ public class FailingTestSuspectsRecipientProviderTest {
         mockedMailer.when(Mailer::descriptor).thenReturn(descriptor);
     }
 
-    @After
-    public void after() {
+    @AfterEach
+    void after() {
         mockedMailer.close();
         mockedJenkins.close();
     }
 
     @Test
-    public void testAddRecipients() throws Exception {
+    void testAddRecipients() throws Exception {
 
         /*
          * Requestor: A

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/FirstFailingBuildSuspectsRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/FirstFailingBuildSuspectsRecipientProviderTest.java
@@ -30,19 +30,19 @@ import hudson.model.User;
 import hudson.plugins.emailext.ExtendedEmailPublisherDescriptor;
 import hudson.tasks.Mailer;
 import jenkins.model.Jenkins;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-public class FirstFailingBuildSuspectsRecipientProviderTest {
+class FirstFailingBuildSuspectsRecipientProviderTest {
 
     private MockedStatic<Jenkins> mockedJenkins;
     private MockedStatic<Mailer> mockedMailer;
 
-    @Before
-    public void before() {
+    @BeforeEach
+    void before() {
         final Jenkins jenkins = Mockito.mock(Jenkins.class);
         Mockito.when(jenkins.isUseSecurity()).thenReturn(false);
         final ExtendedEmailPublisherDescriptor extendedEmailPublisherDescriptor =
@@ -61,14 +61,14 @@ public class FirstFailingBuildSuspectsRecipientProviderTest {
         mockedMailer.when(Mailer::descriptor).thenReturn(descriptor);
     }
 
-    @After
-    public void after() {
+    @AfterEach
+    void after() {
         mockedMailer.close();
         mockedJenkins.close();
     }
 
     @Test
-    public void testAddRecipients() throws Exception {
+    void testAddRecipients() throws Exception {
 
         /*
          * Requestor: A

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/MockUtilities.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/MockUtilities.java
@@ -23,6 +23,7 @@
  */
 package hudson.plugins.emailext.plugins.recipients;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.AbstractBuild;
 import hudson.model.Cause;
 import hudson.model.Run;
@@ -72,7 +73,8 @@ import org.mockito.stubbing.Answer;
         }
 
         @Override
-        public Iterator iterator() {
+        @NonNull
+        public Iterator<ChangeLogSet.Entry> iterator() {
             return new TransformIterator(Arrays.asList(authors).iterator(), inAuthor -> new Entry() {
                 @Override
                 public String getMsg() {

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/PreviousRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/PreviousRecipientProviderTest.java
@@ -30,19 +30,19 @@ import hudson.model.User;
 import hudson.plugins.emailext.ExtendedEmailPublisherDescriptor;
 import hudson.tasks.Mailer;
 import jenkins.model.Jenkins;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-public class PreviousRecipientProviderTest {
+class PreviousRecipientProviderTest {
 
     private MockedStatic<Jenkins> mockedJenkins;
     private MockedStatic<Mailer> mockedMailer;
 
-    @Before
-    public void before() {
+    @BeforeEach
+    void before() {
         final Jenkins jenkins = Mockito.mock(Jenkins.class);
         Mockito.when(jenkins.isUseSecurity()).thenReturn(false);
         final ExtendedEmailPublisherDescriptor extendedEmailPublisherDescriptor =
@@ -61,14 +61,14 @@ public class PreviousRecipientProviderTest {
         mockedMailer.when(Mailer::descriptor).thenReturn(descriptor);
     }
 
-    @After
-    public void after() {
+    @AfterEach
+    void after() {
         mockedMailer.close();
         mockedJenkins.close();
     }
 
     @Test
-    public void testAddRecipients() throws Exception {
+    void testAddRecipients() throws Exception {
 
         /*
          * No previous build means no previous recipients.

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/RecipientProviderUtilitiesTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/RecipientProviderUtilitiesTest.java
@@ -14,16 +14,16 @@ import java.util.Set;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class RecipientProviderUtilitiesTest {
-    public static class Debug implements RecipientProviderUtilities.IDebug {
+class RecipientProviderUtilitiesTest {
+    private static class Debug implements RecipientProviderUtilities.IDebug {
 
         @Override
         public void send(String format, Object... args) {}
     }
 
-    public static Set<String> usersToEMails(Set<User> users) {
+    private static Set<String> usersToEMails(Set<User> users) {
         Set<String> emails = new HashSet<>(users.size());
         for (User user : users) {
             emails.add(user.getProperty(Mailer.UserProperty.class).getAddress());
@@ -32,7 +32,7 @@ public class RecipientProviderUtilitiesTest {
     }
 
     @Test
-    public void getChangeSetAuthors() {
+    void getChangeSetAuthors() {
         Debug debug = new Debug();
         WorkflowRun run1 = mock(WorkflowRun.class);
         Set<User> authors = RecipientProviderUtilities.getChangeSetAuthors(Collections.singleton(run1), debug);
@@ -53,13 +53,4 @@ public class RecipientProviderUtilitiesTest {
                 usersToEMails(authors),
                 CoreMatchers.equalTo(new HashSet<>(Arrays.asList("A@DOMAIN", "B@DOMAIN", "C@DOMAIN"))));
     }
-
-    @Test
-    public void getUsersTriggeringTheBuilds() {}
-
-    @Test
-    public void getUserTriggeringTheBuild() {}
-
-    @Test
-    public void addUsers() {}
 }

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/TestUtilities.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/TestUtilities.java
@@ -23,8 +23,8 @@
  */
 package hudson.plugins.emailext.plugins.recipients;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.EnvVars;
 import hudson.Launcher;

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/UpstreamComitterRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/UpstreamComitterRecipientProviderTest.java
@@ -1,7 +1,7 @@
 package hudson.plugins.emailext.plugins.recipients;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -16,29 +16,35 @@ import hudson.tasks.BuildTrigger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.FakeChangeLogSCM;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SequenceLock;
 import org.jvnet.hudson.test.TestBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.mock_javamail.Mailbox;
 
-public class UpstreamComitterRecipientProviderTest {
+@WithJenkins
+class UpstreamComitterRecipientProviderTest {
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+    private JenkinsRule j;
 
-    @After
-    public void tearDown() {
+    @BeforeEach
+    void setUp(JenkinsRule j) {
+        this.j = j;
+    }
+
+    @AfterEach
+    void tearDown() {
         Mailbox.clearAll();
     }
 
     @Issue("JENKINS-46821")
     @Test
-    public void multipleUpstreamJobs() throws Exception {
+    void multipleUpstreamJobs() throws Exception {
         FreeStyleProject us1 = j.createFreeStyleProject("us1");
         FakeChangeLogSCM scm = new FakeChangeLogSCM();
         scm.addChange().withAuthor("First Person <first@example.com>");

--- a/src/test/java/hudson/plugins/emailext/plugins/trigger/AbstractScriptTriggerTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/trigger/AbstractScriptTriggerTest.java
@@ -5,10 +5,7 @@ import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
@@ -23,29 +20,26 @@ import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.jenkinsci.plugins.scriptsecurity.scripts.UnapprovedUsageException;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.BuildWatcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
 
 /**
  * Tests {@link PreBuildScriptTrigger} and {@link ScriptTrigger}.
  */
-public class AbstractScriptTriggerTest {
+@WithJenkins
+class AbstractScriptTriggerTest {
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+    private JenkinsRule j;
 
-    @ClassRule
-    public static BuildWatcher bw = new BuildWatcher();
+    @BeforeEach
+    void setUp(JenkinsRule j) {
+        this.j = j;
 
-    @Before
-    public void setUp() {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
                 // otherwise we would need to create users for each email address tested, to bypass SECURITY-372 fix:
@@ -59,7 +53,7 @@ public class AbstractScriptTriggerTest {
 
     @Test
     @Issue("SECURITY-257")
-    public void configRoundtrip() throws Exception {
+    void configRoundtrip() throws Exception {
         ExtendedEmailPublisher publisher = new ExtendedEmailPublisher();
         publisher.defaultSubject = "%DEFAULT_SUBJECT";
         publisher.defaultContent = "%DEFAULT_CONTENT";
@@ -113,20 +107,20 @@ public class AbstractScriptTriggerTest {
     @Test
     @LocalData
     @Issue("SECURITY-257")
-    public void beforeBuildTriggerMigration() throws Exception {
+    void beforeBuildTriggerMigration() throws Exception {
         checkTrigger(PreBuildScriptTrigger.class, "Before", Result.FAILURE, UnapprovedUsageException.class, true);
     }
 
     @Test
     @LocalData
     @Issue("SECURITY-257")
-    public void afterBuildTriggerMigration() throws Exception {
+    void afterBuildTriggerMigration() throws Exception {
         checkTrigger(ScriptTrigger.class, "After", Result.SUCCESS, UnapprovedUsageException.class, true);
     }
 
     @Test
     @Issue("SECURITY-1340")
-    public void doNotExecuteConstructorsOutsideOfSandbox() throws Exception {
+    void doNotExecuteConstructorsOutsideOfSandbox() throws Exception {
         ExtendedEmailPublisher publisher = new ExtendedEmailPublisher();
         publisher.defaultSubject = "%DEFAULT_SUBJECT";
         publisher.defaultContent = "%DEFAULT_CONTENT";

--- a/src/test/java/hudson/plugins/emailext/plugins/trigger/BuildingTriggerTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/trigger/BuildingTriggerTest.java
@@ -2,13 +2,13 @@ package hudson.plugins.emailext.plugins.trigger;
 
 import hudson.model.Result;
 import hudson.plugins.emailext.plugins.EmailTrigger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  *
  * @author acearl
  */
-public class BuildingTriggerTest extends TriggerTestBase {
+class BuildingTriggerTest extends TriggerTestBase {
 
     @Override
     EmailTrigger newInstance() {
@@ -16,32 +16,32 @@ public class BuildingTriggerTest extends TriggerTestBase {
     }
 
     @Test
-    public void testTrigger_success() {
+    void testTrigger_success() {
         assertNotTriggered(Result.SUCCESS);
     }
 
     @Test
-    public void testTrigger_failure() {
+    void testTrigger_failure() {
         assertNotTriggered(Result.SUCCESS);
     }
 
     @Test
-    public void testTrigger_failureUnstable() {
+    void testTrigger_failureUnstable() {
         assertTriggered(Result.FAILURE, Result.UNSTABLE);
     }
 
     @Test
-    public void testTrigger_multipleFailure() {
+    void testTrigger_multipleFailure() {
         assertTriggered(Result.FAILURE, Result.FAILURE, Result.FAILURE, Result.UNSTABLE);
     }
 
     @Test
-    public void testTrigger_failureSuccess() {
+    void testTrigger_failureSuccess() {
         assertNotTriggered(Result.FAILURE, Result.SUCCESS);
     }
 
     @Test
-    public void testTrigger_failureSuccessUnstable() {
+    void testTrigger_failureSuccessUnstable() {
         assertNotTriggered(Result.FAILURE, Result.SUCCESS, Result.UNSTABLE);
     }
 }

--- a/src/test/java/hudson/plugins/emailext/plugins/trigger/FirstFailureTriggerTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/trigger/FirstFailureTriggerTest.java
@@ -2,9 +2,9 @@ package hudson.plugins.emailext.plugins.trigger;
 
 import hudson.model.Result;
 import hudson.plugins.emailext.plugins.EmailTrigger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class FirstFailureTriggerTest extends TriggerTestBase {
+class FirstFailureTriggerTest extends TriggerTestBase {
 
     @Override
     EmailTrigger newInstance() {
@@ -12,33 +12,33 @@ public class FirstFailureTriggerTest extends TriggerTestBase {
     }
 
     @Test
-    public void testTrigger_success() {
+    void testTrigger_success() {
         assertNotTriggered(Result.SUCCESS);
     }
 
     @Test
-    public void testTrigger_multipleSuccess() {
+    void testTrigger_multipleSuccess() {
         assertNotTriggered(Result.SUCCESS, Result.SUCCESS, Result.SUCCESS);
     }
 
     @Test
-    public void testTrigger_firstFailureAfterSuccess() {
+    void testTrigger_firstFailureAfterSuccess() {
         assertTriggered(Result.SUCCESS, Result.FAILURE);
         assertTriggered(Result.FAILURE, Result.FAILURE, Result.FAILURE, Result.SUCCESS, Result.FAILURE);
     }
 
     @Test
-    public void testTrigger_secondFailureAfterSuccess() {
+    void testTrigger_secondFailureAfterSuccess() {
         assertNotTriggered(Result.SUCCESS, Result.FAILURE, Result.FAILURE);
     }
 
     @Test
-    public void testTrigger_firstBuildFails() {
+    void testTrigger_firstBuildFails() {
         assertTriggered(Result.FAILURE);
     }
 
     @Test
-    public void testTrigger_firstTwoBuildsFail() {
+    void testTrigger_firstTwoBuildsFail() {
         assertNotTriggered(Result.FAILURE, Result.FAILURE);
     }
 }

--- a/src/test/java/hudson/plugins/emailext/plugins/trigger/FirstUnstableTriggerTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/trigger/FirstUnstableTriggerTest.java
@@ -2,12 +2,12 @@ package hudson.plugins.emailext.plugins.trigger;
 
 import hudson.model.Result;
 import hudson.plugins.emailext.plugins.EmailTrigger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Adrien Lecharpentier <adrien.lecharpentier@zenika.com>
  */
-public class FirstUnstableTriggerTest extends TriggerTestBase {
+class FirstUnstableTriggerTest extends TriggerTestBase {
 
     @Override
     EmailTrigger newInstance() {
@@ -15,42 +15,42 @@ public class FirstUnstableTriggerTest extends TriggerTestBase {
     }
 
     @Test
-    public void testTrigger_unstable() {
+    void testTrigger_unstable() {
         assertTriggered(Result.UNSTABLE);
     }
 
     @Test
-    public void testTrigger_success() {
+    void testTrigger_success() {
         assertNotTriggered(Result.SUCCESS);
     }
 
     @Test
-    public void testTrigger_failure() {
+    void testTrigger_failure() {
         assertNotTriggered(Result.FAILURE);
     }
 
     @Test
-    public void testTrigger_failureUnstable() {
+    void testTrigger_failureUnstable() {
         assertTriggered(Result.FAILURE, Result.UNSTABLE);
     }
 
     @Test
-    public void testTrigger_multipleFailure() {
+    void testTrigger_multipleFailure() {
         assertTriggered(Result.FAILURE, Result.FAILURE, Result.FAILURE, Result.UNSTABLE);
     }
 
     @Test
-    public void testTrigger_failureSuccess() {
+    void testTrigger_failureSuccess() {
         assertNotTriggered(Result.FAILURE, Result.SUCCESS);
     }
 
     @Test
-    public void testTrigger_failureSuccessUnstable() {
+    void testTrigger_failureSuccessUnstable() {
         assertTriggered(Result.FAILURE, Result.SUCCESS, Result.UNSTABLE);
     }
 
     @Test
-    public void testTrigger_unstableUnstable() {
+    void testTrigger_unstableUnstable() {
         assertNotTriggered(Result.UNSTABLE, Result.UNSTABLE);
     }
 }

--- a/src/test/java/hudson/plugins/emailext/plugins/trigger/SecondFailureTriggerTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/trigger/SecondFailureTriggerTest.java
@@ -2,9 +2,9 @@ package hudson.plugins.emailext.plugins.trigger;
 
 import hudson.model.Result;
 import hudson.plugins.emailext.plugins.EmailTrigger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SecondFailureTriggerTest extends TriggerTestBase {
+class SecondFailureTriggerTest extends TriggerTestBase {
 
     @Override
     EmailTrigger newInstance() {
@@ -12,38 +12,38 @@ public class SecondFailureTriggerTest extends TriggerTestBase {
     }
 
     @Test
-    public void testTrigger_success() {
+    void testTrigger_success() {
         assertNotTriggered(Result.SUCCESS);
     }
 
     @Test
-    public void testTrigger_firstFailureAfterSuccess() {
+    void testTrigger_firstFailureAfterSuccess() {
         assertNotTriggered(Result.SUCCESS, Result.FAILURE);
     }
 
     @Test
-    public void testTrigger_secondFailureAfterSuccess() {
+    void testTrigger_secondFailureAfterSuccess() {
         assertTriggered(Result.SUCCESS, Result.FAILURE, Result.FAILURE);
         assertTriggered(Result.FAILURE, Result.FAILURE, Result.SUCCESS, Result.FAILURE, Result.FAILURE);
     }
 
     @Test
-    public void testTrigger_thirdFailureAfterSuccess() {
+    void testTrigger_thirdFailureAfterSuccess() {
         assertNotTriggered(Result.SUCCESS, Result.FAILURE, Result.FAILURE, Result.FAILURE);
     }
 
     @Test
-    public void testTrigger_firstBuildFails() {
+    void testTrigger_firstBuildFails() {
         assertNotTriggered(Result.FAILURE);
     }
 
     @Test
-    public void testTrigger_firstTwoBuildsFail() {
+    void testTrigger_firstTwoBuildsFail() {
         assertTriggered(Result.FAILURE, Result.FAILURE);
     }
 
     @Test
-    public void testTrigger_firstThreeBuildsFail() {
+    void testTrigger_firstThreeBuildsFail() {
         assertNotTriggered(Result.FAILURE, Result.FAILURE, Result.FAILURE);
     }
 }

--- a/src/test/java/hudson/plugins/emailext/plugins/trigger/StatusChangedTriggerTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/trigger/StatusChangedTriggerTest.java
@@ -2,14 +2,14 @@ package hudson.plugins.emailext.plugins.trigger;
 
 import hudson.model.Result;
 import hudson.plugins.emailext.plugins.EmailTrigger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for the "Status changed" trigger.
  *
  * @author francois_ritaly
  */
-public class StatusChangedTriggerTest extends TriggerTestBase {
+class StatusChangedTriggerTest extends TriggerTestBase {
 
     @Override
     EmailTrigger newInstance() {
@@ -18,31 +18,31 @@ public class StatusChangedTriggerTest extends TriggerTestBase {
 
     // --- Transitions from <no-status> to <status> --- //
     @Test
-    public void testTrigger_Success() {
+    void testTrigger_Success() {
         // Notification expected since this is the first build status defined
         assertTriggered(Result.SUCCESS);
     }
 
     @Test
-    public void testTrigger_Aborted() {
+    void testTrigger_Aborted() {
         // Notification expected since this is the first build status defined
         assertTriggered(Result.ABORTED);
     }
 
     @Test
-    public void testTrigger_Failure() {
+    void testTrigger_Failure() {
         // Notification expected since this is the first build status defined
         assertTriggered(Result.FAILURE);
     }
 
     @Test
-    public void testTrigger_NotBuilt() {
+    void testTrigger_NotBuilt() {
         // Notification expected since this is the first build status defined
         assertTriggered(Result.NOT_BUILT);
     }
 
     @Test
-    public void testTrigger_Unstable() {
+    void testTrigger_Unstable() {
         // Notification expected since this is the first build status defined
         assertTriggered(Result.UNSTABLE);
     }
@@ -52,131 +52,131 @@ public class StatusChangedTriggerTest extends TriggerTestBase {
     // so we must test 5x5 = 25 transitions
     // Transitions from the "success" status
     @Test
-    public void testTrigger_SuccessSuccess() {
+    void testTrigger_SuccessSuccess() {
         assertNotTriggered(Result.SUCCESS, Result.SUCCESS);
     }
 
     @Test
-    public void testTrigger_SuccessAborted() {
+    void testTrigger_SuccessAborted() {
         assertTriggered(Result.SUCCESS, Result.ABORTED);
     }
 
     @Test
-    public void testTrigger_SuccessFailure() {
+    void testTrigger_SuccessFailure() {
         assertTriggered(Result.SUCCESS, Result.FAILURE);
     }
 
     @Test
-    public void testTrigger_SuccessNotBuilt() {
+    void testTrigger_SuccessNotBuilt() {
         assertTriggered(Result.SUCCESS, Result.NOT_BUILT);
     }
 
     @Test
-    public void testTrigger_SuccessUnstable() {
+    void testTrigger_SuccessUnstable() {
         assertTriggered(Result.SUCCESS, Result.UNSTABLE);
     }
 
     // Transitions from the "aborted" status
     @Test
-    public void testTrigger_AbortedSuccess() {
+    void testTrigger_AbortedSuccess() {
         assertTriggered(Result.ABORTED, Result.SUCCESS);
     }
 
     @Test
-    public void testTrigger_AbortedAborted() {
+    void testTrigger_AbortedAborted() {
         assertNotTriggered(Result.ABORTED, Result.ABORTED);
     }
 
     @Test
-    public void testTrigger_AbortedFailure() {
+    void testTrigger_AbortedFailure() {
         assertTriggered(Result.ABORTED, Result.FAILURE);
     }
 
     @Test
-    public void testTrigger_AbortedNotBuilt() {
+    void testTrigger_AbortedNotBuilt() {
         assertTriggered(Result.ABORTED, Result.NOT_BUILT);
     }
 
     @Test
-    public void testTrigger_AbortedUnstable() {
+    void testTrigger_AbortedUnstable() {
         assertTriggered(Result.ABORTED, Result.UNSTABLE);
     }
 
     // Transitions from the "failure" status
     @Test
-    public void testTrigger_FailureSuccess() {
+    void testTrigger_FailureSuccess() {
         assertTriggered(Result.FAILURE, Result.SUCCESS);
     }
 
     @Test
-    public void testTrigger_FailureAborted() {
+    void testTrigger_FailureAborted() {
         assertTriggered(Result.FAILURE, Result.ABORTED);
     }
 
     @Test
-    public void testTrigger_FailureFailure() {
+    void testTrigger_FailureFailure() {
         assertNotTriggered(Result.FAILURE, Result.FAILURE);
     }
 
     @Test
-    public void testTrigger_FailureNotBuilt() {
+    void testTrigger_FailureNotBuilt() {
         assertTriggered(Result.FAILURE, Result.NOT_BUILT);
     }
 
     @Test
-    public void testTrigger_FailureUnstable() {
+    void testTrigger_FailureUnstable() {
         assertTriggered(Result.FAILURE, Result.UNSTABLE);
     }
 
     // Transitions from the "not_built" status
     @Test
-    public void testTrigger_NotBuiltSuccess() {
+    void testTrigger_NotBuiltSuccess() {
         assertTriggered(Result.NOT_BUILT, Result.SUCCESS);
     }
 
     @Test
-    public void testTrigger_NotBuiltAborted() {
+    void testTrigger_NotBuiltAborted() {
         assertTriggered(Result.NOT_BUILT, Result.ABORTED);
     }
 
     @Test
-    public void testTrigger_NotBuiltFailure() {
+    void testTrigger_NotBuiltFailure() {
         assertTriggered(Result.NOT_BUILT, Result.FAILURE);
     }
 
     @Test
-    public void testTrigger_NotBuiltNotBuilt() {
+    void testTrigger_NotBuiltNotBuilt() {
         assertNotTriggered(Result.NOT_BUILT, Result.NOT_BUILT);
     }
 
     @Test
-    public void testTrigger_NotBuiltUnstable() {
+    void testTrigger_NotBuiltUnstable() {
         assertTriggered(Result.NOT_BUILT, Result.UNSTABLE);
     }
 
     // Transitions from the "unstable" status
     @Test
-    public void testTrigger_UnstableSuccess() {
+    void testTrigger_UnstableSuccess() {
         assertTriggered(Result.UNSTABLE, Result.SUCCESS);
     }
 
     @Test
-    public void testTrigger_UnstableAborted() {
+    void testTrigger_UnstableAborted() {
         assertTriggered(Result.UNSTABLE, Result.ABORTED);
     }
 
     @Test
-    public void testTrigger_UnstableFailure() {
+    void testTrigger_UnstableFailure() {
         assertTriggered(Result.UNSTABLE, Result.FAILURE);
     }
 
     @Test
-    public void testTrigger_UnstableNotBuilt() {
+    void testTrigger_UnstableNotBuilt() {
         assertTriggered(Result.UNSTABLE, Result.NOT_BUILT);
     }
 
     @Test
-    public void testTrigger_UnstableUnstable() {
+    void testTrigger_UnstableUnstable() {
         assertNotTriggered(Result.UNSTABLE, Result.UNSTABLE);
     }
 }

--- a/src/test/java/hudson/plugins/emailext/plugins/trigger/TriggerTestBase.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/trigger/TriggerTestBase.java
@@ -1,7 +1,7 @@
 package hudson.plugins.emailext.plugins.trigger;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -18,9 +18,9 @@ import java.util.List;
 /**
  * Base class for testing
  */
-public abstract class TriggerTestBase {
+abstract class TriggerTestBase {
 
-    protected List<RecipientProvider> recProviders = Collections.emptyList();
+    protected final List<RecipientProvider> recProviders = Collections.emptyList();
 
     abstract EmailTrigger newInstance();
 
@@ -29,7 +29,7 @@ public abstract class TriggerTestBase {
     }
 
     /**
-     * Asserts the the specified result history triggers the EmailTrigger.
+     * Asserts the specified result history triggers the EmailTrigger.
      */
     void assertTriggered(Result... resultHistory) {
         EmailTrigger trigger = newInstance();
@@ -38,7 +38,7 @@ public abstract class TriggerTestBase {
     }
 
     /**
-     * Asserts the the specified result history does not trigger the
+     * Asserts the specified result history does not trigger the
      * EmailTrigger.
      */
     void assertNotTriggered(Result... resultHistory) {

--- a/src/test/java/hudson/plugins/emailext/plugins/trigger/XNthFailureTriggerJTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/trigger/XNthFailureTriggerJTest.java
@@ -6,19 +6,18 @@ import static org.hamcrest.Matchers.is;
 import hudson.model.FreeStyleProject;
 import hudson.plugins.emailext.ExtendedEmailPublisher;
 import java.util.Collections;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 /**
  * @author Kanstantsin Shautsou
  */
-public class XNthFailureTriggerJTest {
-    @Rule
-    public JenkinsRule jRule = new JenkinsRule();
+@WithJenkins
+class XNthFailureTriggerJTest {
 
     @Test
-    public void testConfigRoundTrip() throws Exception {
+    void testConfigRoundTrip(JenkinsRule jRule) throws Exception {
         FreeStyleProject project = jRule.createFreeStyleProject();
 
         final ExtendedEmailPublisher publisher = new ExtendedEmailPublisher();

--- a/src/test/java/hudson/plugins/emailext/plugins/trigger/XNthFailureTriggerTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/trigger/XNthFailureTriggerTest.java
@@ -2,12 +2,13 @@ package hudson.plugins.emailext.plugins.trigger;
 
 import hudson.model.Result;
 import hudson.plugins.emailext.plugins.EmailTrigger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Kanstantsin Shautsou
  */
-public class XNthFailureTriggerTest extends TriggerTestBase {
+class XNthFailureTriggerTest extends TriggerTestBase {
+
     @Override
     EmailTrigger newInstance() {
         XNthFailureTrigger trigger = new XNthFailureTrigger(recProviders, "", "", "", "", "", 0, "project");
@@ -16,7 +17,7 @@ public class XNthFailureTriggerTest extends TriggerTestBase {
     }
 
     @Test
-    public void testTrigger_success() {
+    void testTrigger_success() {
         assertNotTriggered(Result.SUCCESS);
         assertNotTriggered(Result.SUCCESS, Result.SUCCESS);
         assertNotTriggered(Result.SUCCESS, Result.SUCCESS, Result.SUCCESS);
@@ -24,18 +25,18 @@ public class XNthFailureTriggerTest extends TriggerTestBase {
     }
 
     @Test
-    public void testTrigger_thirdFailureAfterSuccess() {
+    void testTrigger_thirdFailureAfterSuccess() {
         assertTriggered(Result.FAILURE, Result.SUCCESS, Result.FAILURE, Result.FAILURE, Result.FAILURE);
     }
 
     @Test
-    public void testTrigger_thirdBuildFails() {
+    void testTrigger_thirdBuildFails() {
         assertTriggered(Result.FAILURE, Result.FAILURE, Result.FAILURE);
         assertTriggered(Result.SUCCESS, Result.FAILURE, Result.FAILURE, Result.FAILURE);
     }
 
     @Test
-    public void testTrigger_failure() {
+    void testTrigger_failure() {
         assertNotTriggered(Result.FAILURE);
         assertNotTriggered(Result.FAILURE, Result.FAILURE);
         assertNotTriggered(Result.SUCCESS, Result.FAILURE, Result.FAILURE);

--- a/src/test/java/hudson/plugins/emailext/recipients/EmailRecipientUtilsTest.java
+++ b/src/test/java/hudson/plugins/emailext/recipients/EmailRecipientUtilsTest.java
@@ -3,7 +3,7 @@ package hudson.plugins.emailext.recipients;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import hudson.EnvVars;
 import hudson.model.User;
@@ -18,29 +18,30 @@ import java.io.UnsupportedEncodingException;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import org.apache.commons.collections.CollectionUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class EmailRecipientUtilsTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-
-    @Before
-    public void setUp() {
-        emailRecipientUtils = new EmailRecipientUtils();
-        envVars = new EnvVars();
-    }
+@WithJenkins
+class EmailRecipientUtilsTest {
 
     private EmailRecipientUtils emailRecipientUtils;
     private EnvVars envVars;
 
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule j) {
+        this.j = j;
+        emailRecipientUtils = new EmailRecipientUtils();
+        envVars = new EnvVars();
+    }
+
     @Test
     @Issue("JENKINS-32889")
-    public void testDelimiters() throws Exception {
+    void testDelimiters() throws Exception {
         String[] testStrings = {
             "mickey@disney.com;donald@disney.com;goofy@disney.com;pluto@disney.com",
             "mickey@disney.com donald@disney.com goofy@disney.com pluto@disney.com",
@@ -56,7 +57,7 @@ public class EmailRecipientUtilsTest {
     }
 
     @Test
-    public void testConvertRecipientList_emptyRecipientStringShouldResultInEmptyEmailList()
+    void testConvertRecipientList_emptyRecipientStringShouldResultInEmptyEmailList()
             throws AddressException, UnsupportedEncodingException {
         Set<InternetAddress> internetAddresses = EmailRecipientUtils.convertRecipientString("", envVars);
 
@@ -64,7 +65,7 @@ public class EmailRecipientUtilsTest {
     }
 
     @Test
-    public void testConvertRecipientList_emptyRecipientStringWithWhitespaceShouldResultInEmptyEmailList()
+    void testConvertRecipientList_emptyRecipientStringWithWhitespaceShouldResultInEmptyEmailList()
             throws AddressException, UnsupportedEncodingException {
         Set<InternetAddress> internetAddresses = EmailRecipientUtils.convertRecipientString("   ", envVars);
 
@@ -72,7 +73,7 @@ public class EmailRecipientUtilsTest {
     }
 
     @Test
-    public void testConvertRecipientList_singleRecipientShouldResultInOneEmailAddressInList()
+    void testConvertRecipientList_singleRecipientShouldResultInOneEmailAddressInList()
             throws AddressException, UnsupportedEncodingException {
         Set<InternetAddress> internetAddresses =
                 EmailRecipientUtils.convertRecipientString("ashlux@gmail.com", envVars);
@@ -81,7 +82,7 @@ public class EmailRecipientUtilsTest {
     }
 
     @Test
-    public void testConvertRecipientList_singleRecipientWithWhitespaceShouldResultInOneEmailAddressInList()
+    void testConvertRecipientList_singleRecipientWithWhitespaceShouldResultInOneEmailAddressInList()
             throws AddressException, UnsupportedEncodingException {
         Set<InternetAddress> internetAddresses =
                 EmailRecipientUtils.convertRecipientString(" ashlux@gmail.com ", envVars);
@@ -90,7 +91,7 @@ public class EmailRecipientUtilsTest {
     }
 
     @Test
-    public void testConvertRecipientList_commaSeparatedRecipientStringShouldResultInMultipleEmailAddressesInList()
+    void testConvertRecipientList_commaSeparatedRecipientStringShouldResultInMultipleEmailAddressesInList()
             throws AddressException, UnsupportedEncodingException {
         Set<InternetAddress> internetAddresses =
                 EmailRecipientUtils.convertRecipientString("ashlux@gmail.com, mickeymouse@disney.com", envVars);
@@ -99,7 +100,7 @@ public class EmailRecipientUtilsTest {
     }
 
     @Test
-    public void testConvertRecipientList_spaceSeparatedRecipientStringShouldResultInMultipleEmailAddressesInList()
+    void testConvertRecipientList_spaceSeparatedRecipientStringShouldResultInMultipleEmailAddressesInList()
             throws AddressException, UnsupportedEncodingException {
         Set<InternetAddress> internetAddresses =
                 EmailRecipientUtils.convertRecipientString("ashlux@gmail.com mickeymouse@disney.com", envVars);
@@ -108,8 +109,7 @@ public class EmailRecipientUtilsTest {
     }
 
     @Test
-    public void testConvertRecipientList_emailAddressesShouldBeUnique()
-            throws AddressException, UnsupportedEncodingException {
+    void testConvertRecipientList_emailAddressesShouldBeUnique() throws AddressException, UnsupportedEncodingException {
         Set<InternetAddress> internetAddresses = EmailRecipientUtils.convertRecipientString(
                 "ashlux@gmail.com, mickeymouse@disney.com, ashlux@gmail.com", envVars);
 
@@ -117,7 +117,7 @@ public class EmailRecipientUtilsTest {
     }
 
     @Test
-    public void testConvertRecipientList_recipientStringShouldBeExpanded()
+    void testConvertRecipientList_recipientStringShouldBeExpanded()
             throws AddressException, UnsupportedEncodingException {
         envVars.put("EMAIL_LIST", "ashlux@gmail.com");
 
@@ -127,7 +127,7 @@ public class EmailRecipientUtilsTest {
     }
 
     @Test
-    public void testValidateFormRecipientList_validationShouldPassAListOfGoodEmailAddresses() {
+    void testValidateFormRecipientList_validationShouldPassAListOfGoodEmailAddresses() {
         FormValidation formValidation =
                 emailRecipientUtils.validateFormRecipientList("ashlux@gmail.com internal somewhere@domain");
 
@@ -135,14 +135,14 @@ public class EmailRecipientUtilsTest {
     }
 
     @Test
-    public void testValidateFormRecipientList_validationShouldFailWithBadEmailAddress() {
+    void testValidateFormRecipientList_validationShouldFailWithBadEmailAddress() {
         FormValidation formValidation = emailRecipientUtils.validateFormRecipientList("@@@");
 
         assertEquals(FormValidation.Kind.ERROR, formValidation.kind);
     }
 
     @Test
-    public void testConvertRecipientList_defaultSuffix() throws AddressException, UnsupportedEncodingException {
+    void testConvertRecipientList_defaultSuffix() throws AddressException, UnsupportedEncodingException {
         ExtendedEmailPublisher.descriptor().setDefaultSuffix("@gmail.com");
         Set<InternetAddress> internetAddresses = EmailRecipientUtils.convertRecipientString("ashlux", envVars);
 
@@ -150,7 +150,7 @@ public class EmailRecipientUtilsTest {
     }
 
     @Test
-    public void testConvertRecipientList_userName() throws AddressException, IOException {
+    void testConvertRecipientList_userName() throws AddressException, IOException {
         ExtendedEmailPublisher.descriptor().setDefaultSuffix("@gmail.com");
         User u = User.getById("advantiss", true);
         u.setFullName("Peter Samoshkin");
@@ -163,7 +163,7 @@ public class EmailRecipientUtilsTest {
     }
 
     @Test
-    public void testCC() throws Exception {
+    void testCC() throws Exception {
         envVars.put("EMAIL_LIST", "ashlux@gmail.com, cc:slide.o.mix@gmail.com, another@gmail.com");
 
         Set<InternetAddress> internetAddresses = EmailRecipientUtils.convertRecipientString("$EMAIL_LIST", envVars);
@@ -176,7 +176,7 @@ public class EmailRecipientUtilsTest {
     }
 
     @Test
-    public void testBCC() throws Exception {
+    void testBCC() throws Exception {
         envVars.put("EMAIL_LIST", "ashlux@gmail.com, bcc:slide.o.mix@gmail.com, another@gmail.com");
 
         Set<InternetAddress> internetAddresses = EmailRecipientUtils.convertRecipientString("$EMAIL_LIST", envVars);
@@ -189,7 +189,7 @@ public class EmailRecipientUtilsTest {
     }
 
     @Test
-    public void testBCCandCC() throws Exception {
+    void testBCCandCC() throws Exception {
         envVars.put(
                 "EMAIL_LIST", "ashlux@gmail.com, bcc:slide.o.mix@gmail.com, another@gmail.com, cc:example@gmail.com");
 
@@ -207,7 +207,7 @@ public class EmailRecipientUtilsTest {
     }
 
     @Test
-    public void testSameRecipientInTOandCCandBCC_ShouldNotBeFilteredFromTOandCC() throws Exception {
+    void testSameRecipientInTOandCCandBCC_ShouldNotBeFilteredFromTOandCC() throws Exception {
         String recipientListString = "user@gmail.com, bcc:user@gmail.com, cc:user@gmail.com";
 
         Set<InternetAddress> toInternetAddresses =
@@ -227,7 +227,7 @@ public class EmailRecipientUtilsTest {
     }
 
     @Test
-    public void testUTF8() throws Exception {
+    void testUTF8() throws Exception {
         envVars.put("EMAIL_LIST", "ashlux@gmail.com, cc:slide.o.mix@gmail.com, 愛嬋 <another@gmail.com>");
 
         Set<InternetAddress> internetAddresses = EmailRecipientUtils.convertRecipientString("$EMAIL_LIST", envVars);
@@ -241,7 +241,7 @@ public class EmailRecipientUtilsTest {
     }
 
     @Test
-    public void testBackwardsNames() throws Exception {
+    void testBackwardsNames() throws Exception {
         envVars.put("EMAIL_LIST", "\"Mouse, Mickey\" <mickey@disney.com>, minnie@disney.com");
 
         Set<InternetAddress> internetAddresses = EmailRecipientUtils.convertRecipientString("$EMAIL_LIST", envVars);
@@ -251,7 +251,7 @@ public class EmailRecipientUtilsTest {
 
     // Test helper:
 
-    private Set<InternetAddress> setOf(String... emailAddresses) throws AddressException {
+    private static Set<InternetAddress> setOf(String... emailAddresses) throws AddressException {
         final Set<InternetAddress> addresses = new LinkedHashSet<>();
         for (String emailAddress : emailAddresses) {
             addresses.add(new InternetAddress(emailAddress));


### PR DESCRIPTION
Now that the permission `Jenkins.MANAGE` is out of beta (https://github.com/jenkinsci/jenkins/pull/10183) the `useBeta` property is no longer required.

This is still a draft, since it will take some time until that change is shipped in an LTS and this plugin updates to it.
I would like to use this PR as a reminder and update / merge it once the requirements are met.

### Testing done

Validated with `mvn clean verify`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
