### PR TITLE
Move comment to fix spotless formatting

### DIFF
--- a/src/main/java/hudson/plugins/emailext/EmailRecipientUtils.java
+++ b/src/main/java/hudson/plugins/emailext/EmailRecipientUtils.java
@@ -62,9 +62,9 @@ public class EmailRecipientUtils {
                         cc.add(address);
                         break;
                     case RecipientListStringAnalyser.NOT_FOUND:
-                    // Fallback: Treat NOT_FOUND like TO in case RecipientListStringAnalyser fails due to whatever
-                    // reason (maybe encoding of personal?)
                     case TO:
+                        // Fallback: Treat NOT_FOUND like TO in case RecipientListStringAnalyser fails due to whatever
+                        // reason (maybe encoding of personal?)
                         to.add(address);
                         break;
                     default:


### PR DESCRIPTION
## Move comment to fix spotless formatting

Spotless seems to generate different results when running on Windows agents of ci.jenkins.io and Linux agents of ci.jenkins.io.

This avoids the difference by moving the comment into a section where Windows and Linux formatting does not result in a difference.  This will fix the build on the main branch @slide .

### Testing done

Ran `mvn spotless:apply` on Linux.  Rely on ci.jenkins.io to test both Windows and Linux.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
