### PR TITLE
[JENKINS-75845] Fix select name for Attach Build Log

### DIFF
--- a/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/config.groovy
+++ b/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/config.groovy
@@ -41,7 +41,7 @@ f.entry(title: _("Attachments"), help: "/plugin/email-ext/help/projectConfig/att
   f.textbox(name: "attachmentsPattern", value: configured ? instance.attachmentsPattern : "")
 }
 f.entry(title: _("Attach Build Log"), help: "/plugin/email-ext/help/projectConfig/attachBuildLog.html") {
-  select(name: "attachBuildLogSelect") {
+  select(name: "attachBuildLog") {
     f.option(value: 0, selected: instance != null ? !instance.attachBuildLog : true, _("Do Not Attach Build Log"))
     f.option(value: 1, selected: instance != null ? instance.attachBuildLog && !instance.compressBuildLog : false, _("Attach Build Log"))
     f.option(value: 2, selected: instance != null ? instance.attachBuildLog && instance.compressBuildLog : false, _("Compress and Attach Build Log"))


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Fix for https://issues.jenkins.io/browse/JENKINS-75845

Sorry I introduced a regression while working on https://github.com/jenkinsci/email-ext-plugin/pull/618.

Tested manually:
![image](https://github.com/user-attachments/assets/51e0b4c1-b74f-416e-8bc7-588c49100f29)


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
