### PR TITLE
Update appearance of selects

### DIFF
--- a/src/main/resources/hudson/plugins/emailext/EmailExtTemplateAction/index.groovy
+++ b/src/main/resources/hudson/plugins/emailext/EmailExtTemplateAction/index.groovy
@@ -24,9 +24,11 @@ l.layout {
                         f.textbox(name: "template_file_name", id: "template_file_name", clazz: "required", checkUrl:"templateFileCheck", checkDependsOn: "")
                     }
                     f.entry(title: _("Build To Test")) {
-                        select(name: "template_build", id: "template_build") {
-                            my.project.builds.each { build ->
-                                f.option(value: build.id, "#${build.number} (${build.result})")
+                        div(class: "jenkins-select") {
+                            select(name: "template_build", id: "template_build", class: "jenkins-select__input") {
+                                my.project.builds.each { build ->
+                                    f.option(value: build.id, "#${build.number} (${build.result})")
+                                }
                             }
                         }
                     }

--- a/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/config.groovy
+++ b/src/main/resources/hudson/plugins/emailext/ExtendedEmailPublisher/config.groovy
@@ -24,11 +24,13 @@ f.entry(title: _("Project Reply-To List"), help: "/plugin/email-ext/help/project
   f.textarea(name: "replyTo", value: configured ? instance.replyTo : "\$DEFAULT_REPLYTO", checkUrl: "${rootURL}/publisher/ExtendedEmailPublisher/recipientListRecipientsCheck", checkDependsOn: "")
 }
 f.entry(title: _("Content Type"), help: "/plugin/email-ext/help/projectConfig/contentType.html") {
-  select(name: "contentType", class: "setting-input") {
-    f.option(selected: 'default'==instance?.contentType, value: "default", _("Default Content Type")) 
-    f.option(selected: 'text/plain'==instance?.contentType, value: "text/plain", _("projectContentType.plainText")) 
-    f.option(selected: 'text/html'==instance?.contentType, value: "text/html", _("projectContentType.html")) 
-    f.option(selected: 'both'==instance?.contentType, value: "both", _("projectContentType.both")) 
+  div(class: "jenkins-select") {
+    select(name: "contentType", class: "jenkins-select__input setting-input") {
+      f.option(selected: 'default'==instance?.contentType, value: "default", _("Default Content Type"))
+      f.option(selected: 'text/plain'==instance?.contentType, value: "text/plain", _("projectContentType.plainText"))
+      f.option(selected: 'text/html'==instance?.contentType, value: "text/html", _("projectContentType.html"))
+      f.option(selected: 'both'==instance?.contentType, value: "both", _("projectContentType.both"))
+    }
   }
 }
 f.entry(title: _("Default Subject"), help: "/plugin/email-ext/help/projectConfig/defaultSubject.html") {
@@ -41,11 +43,13 @@ f.entry(title: _("Attachments"), help: "/plugin/email-ext/help/projectConfig/att
   f.textbox(name: "attachmentsPattern", value: configured ? instance.attachmentsPattern : "")
 }
 f.entry(title: _("Attach Build Log"), help: "/plugin/email-ext/help/projectConfig/attachBuildLog.html") {
-  select(name: "attachBuildLog") {
-    f.option(value: 0, selected: instance != null ? !instance.attachBuildLog : true, _("Do Not Attach Build Log"))
-    f.option(value: 1, selected: instance != null ? instance.attachBuildLog && !instance.compressBuildLog : false, _("Attach Build Log"))
-    f.option(value: 2, selected: instance != null ? instance.attachBuildLog && instance.compressBuildLog : false, _("Compress and Attach Build Log"))
-  }      
+  div(class: "jenkins-select") {
+    select(name: "attachBuildLog", class: "jenkins-select__input") {
+      f.option(value: 0, selected: instance != null ? !instance.attachBuildLog : true, _("Do Not Attach Build Log"))
+      f.option(value: 1, selected: instance != null ? instance.attachBuildLog && !instance.compressBuildLog : false, _("Attach Build Log"))
+      f.option(value: 2, selected: instance != null ? instance.attachBuildLog && instance.compressBuildLog : false, _("Compress and Attach Build Log"))
+    }
+  }
 }
 
 f.entry(title: _("Content Token Reference"), field: "tokens")

--- a/src/main/resources/hudson/plugins/emailext/plugins/EmailTrigger/config.groovy
+++ b/src/main/resources/hudson/plugins/emailext/plugins/EmailTrigger/config.groovy
@@ -36,9 +36,9 @@ f.advanced() {
     div(class: "jenkins-select") {
       select(name: "contentType", class: "jenkins-select__input setting-input") {
         f.option(selected: 'project' == (instance != null ? instance.email.contentType : ""), value: "project", _("Project Content Type"))
-        f.option(selected: 'text/plain '= =(instance != null ? instance.email.contentType : ""), value: "text/plain", _("projectContentType.plainText"))
-        f.option(selected: 'text/html '= =(instance != null ? instance.email.contentType : ""), value: "text/html", _("projectContentType.html"))
-        f.option(selected: 'both '= =(instance != null ? instance.email.contentType : ""), value: "both", _("projectContentType.both"))
+        f.option(selected: 'text/plain' == (instance != null ? instance.email.contentType : ""), value: "text/plain", _("projectContentType.plainText"))
+        f.option(selected: 'text/html' == (instance != null ? instance.email.contentType : ""), value: "text/html", _("projectContentType.html"))
+        f.option(selected: 'both' == (instance != null ? instance.email.contentType : ""), value: "both", _("projectContentType.both"))
       }
     }
   }

--- a/src/main/resources/hudson/plugins/emailext/plugins/EmailTrigger/config.groovy
+++ b/src/main/resources/hudson/plugins/emailext/plugins/EmailTrigger/config.groovy
@@ -33,11 +33,13 @@ f.advanced() {
   }
 
   f.entry(title: _("Content Type"), help: "/plugin/email-ext/help/projectConfig/contentType.html") {
-    select(name: "contentType", class: "setting-input") {
-      f.option(selected: 'project'== (instance != null ? instance.email.contentType : ""), value: "project", _("Project Content Type")) 
-      f.option(selected: 'text/plain'==(instance != null ? instance.email.contentType : ""), value: "text/plain", _("projectContentType.plainText")) 
-      f.option(selected: 'text/html'==(instance != null ? instance.email.contentType : ""), value: "text/html", _("projectContentType.html")) 
-      f.option(selected: 'both'==(instance != null ? instance.email.contentType : ""), value: "both", _("projectContentType.both")) 
+    div(class: "jenkins-select") {
+      select(name: "contentType", class: "jenkins-select__input setting-input") {
+        f.option(selected: 'project' == (instance != null ? instance.email.contentType : ""), value: "project", _("Project Content Type"))
+        f.option(selected: 'text/plain '= =(instance != null ? instance.email.contentType : ""), value: "text/plain", _("projectContentType.plainText"))
+        f.option(selected: 'text/html '= =(instance != null ? instance.email.contentType : ""), value: "text/html", _("projectContentType.html"))
+        f.option(selected: 'both '= =(instance != null ? instance.email.contentType : ""), value: "both", _("projectContentType.both"))
+      }
     }
   }
   f.entry(title: _("Subject"), help: "/plugin/email-ext/help/projectConfig/mailType/subject.html") {
@@ -50,10 +52,12 @@ f.advanced() {
     f.textbox(name: "attachmentsPattern", value: instance != null ? instance.email.attachmentsPattern : "")
   }
   f.entry(title: _("Attach Build Log"), help: "/plugin/email-ext/help/projectConfig/attachBuildLog.html") {
-    select(name:"attachBuildLog") {
-      f.option(value: 0, selected: instance != null ? !instance.email.attachBuildLog : true, _("Do Not Attach Build Log"))
-      f.option(value: 1, selected: instance != null ? instance.email.attachBuildLog && !instance.email.compressBuildLog : false, _("Attach Build Log"))
-      f.option(value: 2, selected: instance != null ? instance.email.attachBuildLog && instance.email.compressBuildLog : false, _("Compress and Attach Build Log"))
-    }      
-  }   
+    div(class: "jenkins-select") {
+      select(name: "attachBuildLog", class: "jenkins-select__input") {
+        f.option(value: 0, selected: instance != null ? !instance.email.attachBuildLog : true, _("Do Not Attach Build Log"))
+        f.option(value: 1, selected: instance != null ? instance.email.attachBuildLog && !instance.email.compressBuildLog : false, _("Attach Build Log"))
+        f.option(value: 2, selected: instance != null ? instance.email.attachBuildLog && instance.email.compressBuildLog : false, _("Compress and Attach Build Log"))
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR updates the appearance of `<select>`s so that they follow the [Jenkins Design Library](https://weekly.ci.jenkins.io/design-library/select/).

**Before**
<img width="1106" height="75" alt="image" src="https://github.com/user-attachments/assets/fd33eb49-9134-4a3f-aa0a-148eeeb0a2da" />

**After**
<img width="1114" height="86" alt="image" src="https://github.com/user-attachments/assets/7e584871-462d-4f8a-8603-7cbe2eccba90" />

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
