### PR TITLE
Make `matrix-project` dep optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -10,7 +10,6 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
-import hudson.matrix.MatrixProject;
 import hudson.model.AbstractProject;
 import hudson.model.Run;
 import hudson.plugins.emailext.plugins.EmailTriggerDescriptor;
@@ -846,7 +845,7 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
     }
 
     public boolean isMatrixProject(Object project) {
-        return project instanceof MatrixProject;
+        return project.getClass().getName().equals("hudson.matrix.MatrixProject");
     }
 
     public boolean isDebugMode() {


### PR DESCRIPTION
Uses https://github.com/jenkinsci/matrix-project-plugin/pull/53. Tested lightly interactively with matrix, freestyle, and Pipeline jobs with an unconfigured publisher just to see if it would say there were no emails to send, vs. printing `NoClassDefFoundError`s.