### PR TITLE
Test with Java 25

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,6 @@
  * https://github.com/jenkins-infra/pipeline-library/
  */
 buildPlugin(useContainerAgent: true, forkCount: '1C', configurations: [
-  [platform: 'linux', jdk: 21],
-  [platform: 'windows', jdk: 17],
+  [platform: 'linux', jdk: 25],
+  [platform: 'windows', jdk: 21],
 ])


### PR DESCRIPTION
## Test with Java 25 and Java 21

Java 25 released September 16, 2025.  The Jenkins project wants to support Java 25 soon.  Compile and test on ci.jenkins.io with Java 25 and Java 21.

Intentionally continues to generate Java 17 byte code as configured by the plugin parent pom.

Does not compile or test with Java 17 any longer because we have found no issues in the past that were specific to the Java 17 compiler.  The plan is to drop support for Java 17 in the not too distant future so that the Jenkins project is only supporting two major Java versions at a time, Java 21 and Java 25.

### Testing done

* Confirmed that automated tests pass with Java 25

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
