### PR TITLE
Docs: clarify ${FILE} token behavior when workspace file is missing

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -159,6 +159,17 @@ Include Culprits:: If this recipient provider _and_ the *Developers* recipient p
 Previous:: Add this recipient provider to send an email to the the culprits, requestor and developers of the previous build(s).
 Advanced:: Configure properties at a per-trigger level:
  Recipient List::: A comma (or whitespace) separated list of email address that should receive this email if it is triggered. This list is appended to the *Project Recipient List* described above.
+**Using the `${FILE}` token**
+
+The `${FILE}` token reads recipient addresses from a file located in the build workspace.
+
+If the specified file does not exist at the time the email is generated, the token will expand to an empty or invalid value and no recipients may be resolved. This can cause the email step to be skipped.
+
+Best practices:
+
+* Ensure the file is created earlier in the build before email-ext executes.
+* Prefer relative paths (e.g. `${FILE,path="commit_authors.txt"}`) instead of absolute workspace paths.
+* Configure fallback static recipients or additional recipient providers when dynamic recipient resolution may produce no results.
  Subject::: Specify the subject line of the selected email.
  Content::: Specify the body of the selected email.
 


### PR DESCRIPTION
## Summary

Clarifies documentation for the ${FILE} token used in email recipient configuration.

The documentation now explains that:

- The referenced file must exist in the workspace at email generation time.
- Missing files can result in empty recipient resolution and skipped email notifications.

Adds best-practice guidance to help users avoid common misconfiguration issues reported in support channels.

---

## Motivation

Users may encounter errors like:

Failed to create e-mail address ... File 'commit_authors.txt' does not exist
An attempt to send an e-mail to empty list of recipients, ignored.

This change improves discoverability of the root cause by documenting expected behavior and recommended configuration practices.

---

## Testing done

Documentation-only change.

- Verified formatting renders correctly in preview.
- Verified behavior locally using ${FILE} token.

---

## Submitter checklist

- [x] Opened from a topic branch
- [x] PR title reflects change
- [x] Documentation updated
- [x] Linked to related issue (#1443)