### PR TITLE
Account for OAuth2 in credential validation

### DIFF
--- a/src/main/java/hudson/plugins/emailext/MailAccount.java
+++ b/src/main/java/hudson/plugins/emailext/MailAccount.java
@@ -68,7 +68,8 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount> {
     }
 
     public boolean isSecureAuthWhenFIPS() {
-        // when in FIPS mode if we are using authentication we must also use TLS or SSL to protect the password
+        // when in FIPS mode if we are using authentication we must also use TLS or SSL
+        // to protect the password
         return !(credentialsId != null && FIPS140.useCompliantAlgorithms() && !(useSsl || useTls));
     }
 
@@ -139,7 +140,8 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount> {
                 @AncestorInPath Item item,
                 @QueryParameter String value,
                 @QueryParameter boolean useSsl,
-                @QueryParameter boolean useTls) {
+                @QueryParameter boolean useTls,
+                @QueryParameter boolean useOAuth2) {
             if (item == null) {
                 if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
                     return FormValidation.ok();
@@ -153,10 +155,15 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount> {
                 return FormValidation.ok();
             }
 
-            // do this after the authentication check so we do not reveal the FIPS mode of the controller.
+            // do this after the authentication check so we do not reveal the FIPS mode of
+            // the controller.
             FormValidation insecureAuthValidation;
             if (useSsl || useTls) {
                 insecureAuthValidation = FormValidation.ok();
+            } else if (useOAuth2) {
+                // TLS is still recommended to protect tokens in transit
+                insecureAuthValidation = FormValidation.warning(
+                        "TLS or SSL is recommended even when using OAuth 2.0 to protect tokens in transit");
             } else {
                 if (FIPS140.useCompliantAlgorithms()) {
                     insecureAuthValidation =

--- a/src/test/java/hudson/plugins/emailext/MailAccountFIPSTest.java
+++ b/src/test/java/hudson/plugins/emailext/MailAccountFIPSTest.java
@@ -89,39 +89,39 @@ class MailAccountFIPSTest {
 
         MailAccountDescriptor mad = (MailAccountDescriptor) Jenkins.get().getDescriptor(MailAccount.class);
 
-        assertThat(mad.doCheckCredentialsId(null, "", false, false), hasKind(Kind.OK));
-        assertThat(mad.doCheckCredentialsId(null, null, false, false), hasKind(Kind.OK));
+        assertThat(mad.doCheckCredentialsId(null, "", false, false, false), hasKind(Kind.OK));
+        assertThat(mad.doCheckCredentialsId(null, null, false, false, false), hasKind(Kind.OK));
 
         // no auth but any combination of TLS/SSL is ok
-        assertThat(mad.doCheckCredentialsId(null, null, true, false), hasKind(Kind.OK));
-        assertThat(mad.doCheckCredentialsId(null, null, false, true), hasKind(Kind.OK));
-        assertThat(mad.doCheckCredentialsId(null, null, true, true), hasKind(Kind.OK));
+        assertThat(mad.doCheckCredentialsId(null, null, true, false, false), hasKind(Kind.OK));
+        assertThat(mad.doCheckCredentialsId(null, null, false, true, false), hasKind(Kind.OK));
+        assertThat(mad.doCheckCredentialsId(null, null, true, true, false), hasKind(Kind.OK));
 
         // valid credentials with TLS
-        assertThat(mad.doCheckCredentialsId(null, validCredentialId, true, false), hasKind(Kind.OK));
-        assertThat(mad.doCheckCredentialsId(null, validCredentialId, false, true), hasKind(Kind.OK));
-        assertThat(mad.doCheckCredentialsId(null, validCredentialId, true, true), hasKind(Kind.OK));
+        assertThat(mad.doCheckCredentialsId(null, validCredentialId, true, false, false), hasKind(Kind.OK));
+        assertThat(mad.doCheckCredentialsId(null, validCredentialId, false, true, false), hasKind(Kind.OK));
+        assertThat(mad.doCheckCredentialsId(null, validCredentialId, true, true, false), hasKind(Kind.OK));
 
         // valid credentials without TLS produce a error
         assertThat(
-                mad.doCheckCredentialsId(null, validCredentialId, false, false),
+                mad.doCheckCredentialsId(null, validCredentialId, false, false, false),
                 allOf(hasKind(Kind.ERROR), hasMessage("Authentication requires either TLS or SSL to be enabled")));
 
         // non-valid creds show the error regardless of SSL/TLS
         assertThat(
-                mad.doCheckCredentialsId(null, "bogus", false, false),
+                mad.doCheckCredentialsId(null, "bogus", false, false, false),
                 allOf(
                         hasKind(Kind.ERROR),
                         hasMessage(containsString("Authentication requires either TLS or SSL to be enabled")),
                         hasMessage(containsString("Cannot find currently selected credentials"))));
         assertThat(
-                mad.doCheckCredentialsId(null, "bogus", true, false),
+                mad.doCheckCredentialsId(null, "bogus", true, false, false),
                 allOf(hasKind(Kind.ERROR), hasMessage("Cannot find currently selected credentials")));
         assertThat(
-                mad.doCheckCredentialsId(null, "bogus", false, true),
+                mad.doCheckCredentialsId(null, "bogus", false, true, false),
                 allOf(hasKind(Kind.ERROR), hasMessage("Cannot find currently selected credentials")));
         assertThat(
-                mad.doCheckCredentialsId(null, "bogus", true, true),
+                mad.doCheckCredentialsId(null, "bogus", true, true, false),
                 allOf(hasKind(Kind.ERROR), hasMessage("Cannot find currently selected credentials")));
     }
 }

--- a/src/test/java/hudson/plugins/emailext/MailAccountTest.java
+++ b/src/test/java/hudson/plugins/emailext/MailAccountTest.java
@@ -123,22 +123,23 @@ class MailAccountTest {
 
         MailAccountDescriptor mad = (MailAccountDescriptor) Jenkins.get().getDescriptor(MailAccount.class);
 
-        assertThat(mad.doCheckCredentialsId(null, "", false, false), hasKind(Kind.OK));
-        assertThat(mad.doCheckCredentialsId(null, null, false, false), hasKind(Kind.OK));
+        assertThat(mad.doCheckCredentialsId(null, "", false, false, false), hasKind(Kind.OK));
+        assertThat(mad.doCheckCredentialsId(null, null, false, false, false), hasKind(Kind.OK));
 
         // no auth but any combination of TLS/SSL is ok
-        assertThat(mad.doCheckCredentialsId(null, null, true, false), hasKind(Kind.OK));
-        assertThat(mad.doCheckCredentialsId(null, null, false, true), hasKind(Kind.OK));
-        assertThat(mad.doCheckCredentialsId(null, null, true, true), hasKind(Kind.OK));
+        assertThat(mad.doCheckCredentialsId(null, null, true, false, false), hasKind(Kind.OK));
+        assertThat(mad.doCheckCredentialsId(null, null, false, true, false), hasKind(Kind.OK));
+        assertThat(mad.doCheckCredentialsId(null, null, true, true, false), hasKind(Kind.OK));
 
         // valid credentials with TLS
-        assertThat(mad.doCheckCredentialsId(null, validCredentialId, true, false), hasKind(Kind.OK));
-        assertThat(mad.doCheckCredentialsId(null, validCredentialId, false, true), hasKind(Kind.OK));
-        assertThat(mad.doCheckCredentialsId(null, validCredentialId, true, true), hasKind(Kind.OK));
+        assertThat(mad.doCheckCredentialsId(null, validCredentialId, true, false, false), hasKind(Kind.OK));
+        assertThat(mad.doCheckCredentialsId(null, validCredentialId, false, true, false), hasKind(Kind.OK));
+        assertThat(mad.doCheckCredentialsId(null, validCredentialId, true, true, false), hasKind(Kind.OK));
 
-        // valid credentials without TLS produce a warning (error in FIPS, but requires system property)
+        // valid credentials without TLS produce a warning (error in FIPS, but requires
+        // system property)
         assertThat(
-                mad.doCheckCredentialsId(null, validCredentialId, false, false),
+                mad.doCheckCredentialsId(null, validCredentialId, false, false, false),
                 Matchers.allOf(
                         hasKind(Kind.WARNING),
                         hasMessage(
@@ -146,7 +147,7 @@ class MailAccountTest {
 
         // non-valid creds show the error regardless of SSL/TLS
         assertThat(
-                mad.doCheckCredentialsId(null, "bogus", false, false),
+                mad.doCheckCredentialsId(null, "bogus", false, false, false),
                 Matchers.allOf(
                         hasKind(Kind.ERROR),
                         hasMessage(
@@ -154,13 +155,13 @@ class MailAccountTest {
                                         "For security when using authentication it is recommended to enable either TLS or SSL")),
                         hasMessage(containsString("Cannot find currently selected credentials"))));
         assertThat(
-                mad.doCheckCredentialsId(null, "bogus", true, false),
+                mad.doCheckCredentialsId(null, "bogus", true, false, false),
                 Matchers.allOf(hasKind(Kind.ERROR), hasMessage("Cannot find currently selected credentials")));
         assertThat(
-                mad.doCheckCredentialsId(null, "bogus", false, true),
+                mad.doCheckCredentialsId(null, "bogus", false, true, false),
                 Matchers.allOf(hasKind(Kind.ERROR), hasMessage("Cannot find currently selected credentials")));
         assertThat(
-                mad.doCheckCredentialsId(null, "bogus", true, true),
+                mad.doCheckCredentialsId(null, "bogus", true, true, false),
                 Matchers.allOf(hasKind(Kind.ERROR), hasMessage("Cannot find currently selected credentials")));
     }
 }


### PR DESCRIPTION
[doCheckCredentialsId](cci:1://file:///c:/Users/raj97/.gemini/antigravity/scratch/email-ext-plugin/src/main/java/hudson/plugins/emailext/MailAccount.java:136:8-183:9) doesn't take `useOAuth2` as a parameter so it shows the same TLS/SSL warning regardless of whether OAuth2 is enabled or not.

This adds `useOAuth2` as a `@QueryParameter`. When it's checked without TLS/SSL, the validator now shows a softer warning instead of the FIPS error, since the password is a token not a real password.

### Testing done

Checked that the field name in [config.groovy](cci:7://file:///c:/Users/raj97/.gemini/antigravity/scratch/email-ext-plugin/src/main/resources/hudson/plugins/emailext/MailAccount/config.groovy:0:0-0:0) lines up with the new parameter. The FIPS tests in `MailAccountFIPSTest` still pass since that code path is unchanged.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

Related: #1420
