### PR TITLE
Set inline content-disposition for attachments with Content-ID

### DIFF
--- a/src/main/java/hudson/plugins/emailext/AttachmentUtils.java
+++ b/src/main/java/hudson/plugins/emailext/AttachmentUtils.java
@@ -15,6 +15,7 @@ import jakarta.activation.DataSource;
 import jakarta.activation.FileTypeMap;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Multipart;
+import jakarta.mail.Part;
 import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeUtility;
 import java.io.ByteArrayInputStream;
@@ -163,6 +164,7 @@ public class AttachmentUtils implements Serializable {
                         attachmentPart.setDataHandler(new DataHandler(fileDataSource));
                         attachmentPart.setFileName(MimeUtility.encodeText(file.getName()));
                         attachmentPart.setContentID("<%s>".formatted(file.getName()));
+                        attachmentPart.setDisposition(Part.INLINE);
                         attachments.add(attachmentPart);
                         totalAttachmentSize += file.length();
                     } catch (MessagingException e) {


### PR DESCRIPTION
When an attachment has a `Content-ID` (e.g. for `<img src="cid:banner.png">`), it shows up both inline in the email body and again as a file attachment at the bottom. This is especially annoying in Microsoft Teams where you get the image twice.

The fix is just setting `Content-Disposition: inline` on the MIME part via `Part.INLINE`, so mail clients know not to also show it as a separate download.

Fixes [JENKINS-75800].

### Testing done

Compile + existing tests pass. The change itself is one `setDisposition` call on a `MimeBodyPart` — no branching logic to test, it just sets a MIME header.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
