### PR TITLE
Fix operator precedence in autoConfigure() condition

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -251,8 +251,9 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
             return;
         }
 
-        if (Jenkins.get().isUseSecurity() && !StringUtils.isBlank(descriptor.getDefaultPostsendScript())
-                || !StringUtils.isBlank(descriptor.getDefaultPresendScript())) {
+        if (Jenkins.get().isUseSecurity()
+                && (!StringUtils.isBlank(descriptor.getDefaultPostsendScript())
+                        || !StringUtils.isBlank(descriptor.getDefaultPresendScript()))) {
             descriptor.setDefaultPostsendScript(descriptor.getDefaultPostsendScript());
             descriptor.setDefaultPresendScript(descriptor.getDefaultPresendScript());
             try {


### PR DESCRIPTION
Fixes #1472

The conditional in ExtendedEmailPublisherDescriptor.autoConfigure() relied on default Java operator precedence:

if (A && B || C)

which is evaluated as:

(A && B) || C

This allowed the block to execute when the default pre-send script was non-blank even if security was disabled.

## Fix

This change adds explicit parentheses to ensure the intended logic:

if (Jenkins.get().isUseSecurity()
    && (!StringUtils.isBlank(descriptor.getDefaultPostsendScript())
        || !StringUtils.isBlank(descriptor.getDefaultPresendScript())))

Now the block executes only when:

- Security is enabled, and
- At least one of the default scripts is non-blank.

This clarifies intent and prevents unintended execution when security is disabled.

## Testing

Manual testing was performed using mvn hpi:run.

### Security disabled
- Security Realm: None
- Authorization: Anyone can do anything
- Default Pre-send Script set to non-blank value
- After restart, verified that the conditional block in autoConfigure() did not execute.

### Security enabled
- Security enabled in Global Security configuration
- Default Pre-send Script set to non-blank value
- After restart, verified that the conditional block executed as expected.

Verified:
- No startup errors
- No ScriptApproval regressions
- mvn clean install passes
- Spotless formatting passes

This change does not alter behavior when security is enabled. It only prevents execution when security is disabled.

## Submitter checklist

- [x] Opening from a topic branch (fix-autoconfigure-precedence)
- [x] Title reflects the change
- [x] Linked related issue (#1472)
- [x] Change is minimal and scoped
- [x] Verified build passes locally
- [ ] No automated tests added (logic clarification only)
