### PR TITLE
Add support for configurable email priority headers (JENKINS-69592)

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -202,6 +202,18 @@ public class ExtendedEmailPublisher extends Notifier {
      * How to theTrigger the email if the project is a matrix project.
      */
     public MatrixTriggerMode matrixTriggerMode;
+    /**
+     * Optional email priority value used to set priority headers on the outgoing email.
+     * When specified, the plugin adds the corresponding "X-Priority" and "Importance"
+     * headers to the generated MimeMessage so that email clients can mark the message
+     * as high or low importance.
+     *
+     * Typical values:
+     * 1 - High priority
+     * 3 - Normal priority
+     * 5 - Low priority
+     */
+    private String priority;
 
     public ExtendedEmailPublisher() {}
 
@@ -332,6 +344,10 @@ public class ExtendedEmailPublisher extends Notifier {
         }
     }
 
+    @DataBoundSetter
+    public void setPriority(String priority) {
+        this.priority = priority;
+    }
     @DataBoundSetter
     public void setPostsendScript(String postsendScript) {
         postsendScript = StringUtils.trim(postsendScript);
@@ -977,6 +993,15 @@ public class ExtendedEmailPublisher extends Notifier {
         final Result result = context.getRun() != null ? context.getRun().getResult() : null;
         if (result != null) {
             msg.addHeader("X-Jenkins-Result", result.toString());
+        }
+        if (StringUtils.isNotBlank(priority)) {
+            msg.addHeader("X-Priority", priority);
+
+            if ("1".equals(priority)) {
+                msg.addHeader("Importance", "High");
+            } else if ("5".equals(priority)) {
+                msg.addHeader("Importance", "Low");
+            }
         }
         msg.setSentDate(new Date());
         setSubject(context, msg, charset);

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -214,9 +214,9 @@ public class ExtendedEmailPublisher extends Notifier {
      * as high or low importance.
      *
      * Typical values:
-     * 1 - High priority
-     * 3 - Normal priority
-     * 5 - Low priority
+     * "1" - High priority
+     * "3" - Normal priority
+     * "5" - Low priority
      */
     private String priority;
 
@@ -353,6 +353,7 @@ public class ExtendedEmailPublisher extends Notifier {
     public void setPriority(String priority) {
         this.priority = priority;
     }
+
     public String getPriority() {
         return priority;
     }

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -348,6 +348,9 @@ public class ExtendedEmailPublisher extends Notifier {
     public void setPriority(String priority) {
         this.priority = priority;
     }
+    public String getPriority() {
+        return priority;
+    }
     @DataBoundSetter
     public void setPostsendScript(String postsendScript) {
         postsendScript = StringUtils.trim(postsendScript);

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
@@ -2076,4 +2076,34 @@ class ExtendedEmailPublisherTest {
                 Mailbox.get("ashlux@gmail.com").size(),
                 "We should only have one email since the first failure doesn't count as 'still failing'.");
     }
+    @Test
+    void testPriorityHeaderIsAdded() throws Exception {
+        publisher.setPriority("1");
+
+        FailureTrigger trigger = new FailureTrigger(
+                recProviders,
+                "$DEFAULT_RECIPIENTS",
+                "$DEFAULT_REPLYTO",
+                "$DEFAULT_SUBJECT",
+                "$DEFAULT_CONTENT",
+                "",
+                0,
+                "project");
+
+        addEmailType(trigger);
+        publisher.getConfiguredTriggers().add(trigger);
+
+        project.getBuildersList().add(new FailureBuilder());
+
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        j.assertBuildStatus(Result.FAILURE, build);
+
+        Mailbox mailbox = Mailbox.get("ashlux@gmail.com");
+        assertEquals(1, mailbox.size());
+
+        Message msg = mailbox.get(0);
+
+        assertEquals("1", getHeader(msg, "X-Priority"));
+        assertEquals("High", getHeader(msg, "Importance"));
+    }
 }


### PR DESCRIPTION
Implements JENKINS-69592

This PR adds support for configuring email priority in the Email Extension Plugin.

A new `priority` field has been introduced in `ExtendedEmailPublisher`.  
When configured, the plugin sets the appropriate email headers when constructing
the `MimeMessage`.

Headers added:
- `X-Priority`
- `Importance`

These headers allow email clients such as Outlook and Thunderbird to mark
messages as high or low importance.

Example values:
- `1` → High priority
- `3` → Normal priority
- `5` → Low priority

Previously users needed to rely on `presendScript` workarounds such as:
```
msg.addHeader("X-Priority", "1")
```


This change enables priority configuration directly in the plugin code
and improves usability for both UI and Pipeline users.

No behavior changes occur unless the `priority` field is explicitly set.