### PR TITLE
Fix inline CID attachments by using multipart/related to avoid duplicate attachment previews

### DIFF
--- a/src/main/java/hudson/plugins/emailext/AttachmentUtils.java
+++ b/src/main/java/hudson/plugins/emailext/AttachmentUtils.java
@@ -163,7 +163,9 @@ public class AttachmentUtils implements Serializable {
                     try {
                         attachmentPart.setDataHandler(new DataHandler(fileDataSource));
                         attachmentPart.setFileName(MimeUtility.encodeText(file.getName()));
-                        attachmentPart.setContentID("<%s>".formatted(file.getName()));
+                        if (isInline) {
+                            attachmentPart.setContentID("<%s>".formatted(file.getName()));
+                        }
                         attachmentPart.setDisposition(isInline ? Part.INLINE : Part.ATTACHMENT);
                         attachments.add(attachmentPart);
                         totalAttachmentSize += file.length();

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -995,39 +995,51 @@ public class ExtendedEmailPublisher extends Notifier {
         msg.setSentDate(new Date());
         setSubject(context, msg, charset);
 
-        Multipart multipart = addContent(context, charset);
+        MimeMultipart rootMultipart = new MimeMultipart("mixed");
+        MimeMultipart relatedMultipart = new MimeMultipart("related");
+        
+        MimeBodyPart contentPart = createTextContentPart(context, charset);
+        relatedMultipart.addBodyPart(contentPart);
 
         AttachmentUtils attachments = new AttachmentUtils(attachmentsPattern);
-        attachments.attach(multipart, context);
+        attachments.attach(rootMultipart, context);
 
         if (StringUtils.isNotBlank(inlineAttachmentsPattern)) {
             AttachmentUtils inlineAttachments = new AttachmentUtils(inlineAttachmentsPattern);
-            inlineAttachments.attachInline(multipart, context);
+            inlineAttachments.attachInline(relatedMultipart, context);
         }
 
         // add attachments from the email type if they are setup
         if (StringUtils.isNotBlank(context.getTrigger().getEmail().getAttachmentsPattern())) {
             AttachmentUtils typeAttachments =
                     new AttachmentUtils(context.getTrigger().getEmail().getAttachmentsPattern());
-            typeAttachments.attach(multipart, context);
+            typeAttachments.attach(rootMultipart, context);
         }
 
         // add inline attachments from the email type if they are setup
         if (StringUtils.isNotBlank(context.getTrigger().getEmail().getInlineAttachmentsPattern())) {
             AttachmentUtils inlineAttachments =
                     new AttachmentUtils(context.getTrigger().getEmail().getInlineAttachmentsPattern());
-            inlineAttachments.attachInline(multipart, context);
+            inlineAttachments.attachInline(relatedMultipart, context);
         }
 
         if (attachBuildLog || context.getTrigger().getEmail().getAttachBuildLog()) {
             debug(context.getListener().getLogger(), "Request made to attach build log");
             AttachmentUtils.attachBuildLog(
                     context,
-                    multipart,
+                    rootMultipart,
                     compressBuildLog || context.getTrigger().getEmail().getCompressBuildLog());
         }
 
-        msg.setContent(multipart);
+        if (relatedMultipart.getCount() > 1) {
+            MimeBodyPart relatedBodyPart = new MimeBodyPart();
+            relatedBodyPart.setContent(relatedMultipart);
+            rootMultipart.addBodyPart(relatedBodyPart, 0); // Insert body at the beginning
+        } else {
+            rootMultipart.addBodyPart(contentPart, 0); // Insert body at the beginning
+        }
+
+        msg.setContent(rootMultipart);
 
         EnvVars env = null;
         try {
@@ -1157,10 +1169,9 @@ public class ExtendedEmailPublisher extends Notifier {
         return MatrixTriggerMode.BOTH == mtm || MatrixTriggerMode.ONLY_CONFIGURATIONS == mtm;
     }
 
-    private Multipart addContent(ExtendedEmailPublisherContext context, String charset) throws MessagingException {
+    private MimeBodyPart createTextContentPart(ExtendedEmailPublisherContext context, String charset) throws MessagingException {
         final String text = ContentBuilder.transformText(
                 context.getTrigger().getEmail().getBody(), context, getRuntimeMacros(context));
-        final Multipart multipart;
         boolean doBoth = false;
 
         String messageContentType =
@@ -1177,12 +1188,11 @@ public class ExtendedEmailPublisher extends Notifier {
             }
         }
 
+        Multipart alternative = null;
         if ("both".equals(messageContentType)) {
             doBoth = true;
-            multipart = new MimeMultipart("alternative");
+            alternative = new MimeMultipart("alternative");
             messageContentType = "text/html";
-        } else {
-            multipart = new MimeMultipart();
         }
 
         messageContentType += "; charset=" + charset;
@@ -1221,7 +1231,7 @@ public class ExtendedEmailPublisher extends Notifier {
             if (doBoth) {
                 MimeBodyPart plainTextPart = new MimeBodyPart();
                 plainTextPart.setContent(inliner.stripHtml(text), "text/plain; charset=" + charset);
-                multipart.addBodyPart(plainTextPart);
+                alternative.addBodyPart(plainTextPart);
             }
             String inlinedCssHtml = inliner.process(text);
             msgPart.setContent(inlinedCssHtml, messageContentType);
@@ -1229,9 +1239,14 @@ public class ExtendedEmailPublisher extends Notifier {
             msgPart.setContent(text, messageContentType);
         }
 
-        multipart.addBodyPart(msgPart);
-
-        return multipart;
+        if (doBoth) {
+            alternative.addBodyPart(msgPart);
+            MimeBodyPart contentPart = new MimeBodyPart();
+            contentPart.setContent(alternative);
+            return contentPart;
+        } else {
+            return msgPart;
+        }
     }
 
     @Override


### PR DESCRIPTION
This change improves how inline attachments are sent so clients like Microsoft Teams render CID images correctly without also showing them as normal attachment previews. #1438 #1465 

Changes:
- Refactored email body construction in `ExtendedEmailPublisher` to build a MIME tree with:
  - root: `multipart/mixed`
  - nested body+inline block: `multipart/related`
- Moved body creation into `createTextContentPart(...)` to make it reusable in the new MIME structure.
- Added inline attachments to the `multipart/related` section instead of the root mixed section.
- Kept regular attachments and build-log attachments on the root `multipart/mixed`.
- Updated `AttachmentUtils` to only set `Content-ID` for inline attachments (not regular attachments).
- Preserved support for project-level and trigger-level inline attachment patterns.

note: I apologize that the branch merging from is the main branch and not the feature branch from my forked repo.