### PR TITLE
Validation for SmtpServer, hostname and/or IP

### DIFF
--- a/src/main/java/hudson/plugins/emailext/MailAccount.java
+++ b/src/main/java/hudson/plugins/emailext/MailAccount.java
@@ -93,19 +93,20 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount> {
     }
 
     private boolean isSyntacticallyValid(String host) {
-        // Hostname pattern (RFC 1123): letters, digits, hyphens, dots
-        Pattern HOSTNAME_PATTERN = Pattern.compile(
+        // Check if it looks like an IPv4 address (four dot‑separated numbers)
+        java.util.regex.Pattern ipv4Structure = java.util.regex.Pattern.compile("^(\\d{1,3}\\.){3}\\d{1,3}$");
+        if (ipv4Structure.matcher(host).matches()) {
+            // Strict IPv4 validation
+            java.util.regex.Pattern ipv4Valid = java.util.regex.Pattern.compile(
+                    "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+            );
+            return ipv4Valid.matcher(host).matches();
+        }
+        // Otherwise treat as hostname (RFC 1123)
+        java.util.regex.Pattern hostnameValid = java.util.regex.Pattern.compile(
                 "^(?![0-9]+$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$"
         );
-        // IPv4 pattern
-        Pattern IPV4_PATTERN = Pattern.compile(
-                "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
-        );
-        return HOSTNAME_PATTERN.matcher(host).matches()
-                || IPV4_PATTERN.matcher(host).matches();
-        // IPv6 is not covered by fallback – but if the host was a valid IPv6 literal,
-        // InetAddress.getByName would have succeeded in a real environment.
-        // For CI tests that never use IPv6, this is fine.
+        return hostnameValid.matcher(host).matches() && host.length() <= 255;
     }
 
     public boolean isSmtpAuthValid() {

--- a/src/main/java/hudson/plugins/emailext/MailAccount.java
+++ b/src/main/java/hudson/plugins/emailext/MailAccount.java
@@ -86,14 +86,12 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount> {
     }
 
     private boolean isHostnameValid(String host) {
-        String hostnamePattern =
-                "^(?![0-9]+$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$";
+        String hostnamePattern = "^(?![0-9]+$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$";
         return host.matches(hostnamePattern);
     }
 
     private boolean isIpAddressValid(String host) {
-        String ipPattern =
-                "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$";
+        String ipPattern = "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$";
         return host.matches(ipPattern);
     }
 

--- a/src/main/java/hudson/plugins/emailext/MailAccount.java
+++ b/src/main/java/hudson/plugins/emailext/MailAccount.java
@@ -77,10 +77,24 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount> {
     }
 
     public boolean isSmtpServerValid() {
-        return true;
-        // Note: having no SMTP server is fine, it means localhost.
-        // More control could be implemented here when not null though,
-        // like checking the value looks like an FQDN or IP address.
+        // Empty means "localhost", which is always valid.
+        if (StringUtils.isBlank(smtpHost)) {
+            return true;
+        }
+        // Validate hostname or IP address syntax.
+        return isHostnameValid(smtpHost) || isIpAddressValid(smtpHost);
+    }
+
+    private boolean isHostnameValid(String host) {
+        String hostnamePattern =
+                "^(?![0-9]+$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$";
+        return host.matches(hostnamePattern);
+    }
+
+    private boolean isIpAddressValid(String host) {
+        String ipPattern =
+                "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$";
+        return host.matches(ipPattern);
     }
 
     public boolean isSmtpAuthValid() {

--- a/src/main/java/hudson/plugins/emailext/MailAccount.java
+++ b/src/main/java/hudson/plugins/emailext/MailAccount.java
@@ -26,6 +26,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 import jenkins.model.Jenkins;
 import jenkins.security.FIPS140;
 import net.sf.json.JSONObject;
@@ -93,16 +94,16 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount> {
 
     private boolean isSyntacticallyValid(String host) {
         // Check if it looks like an IPv4 address (four dot‑separated numbers)
-        java.util.regex.Pattern ipv4Structure = java.util.regex.Pattern.compile("^(\\d{1,3}\\.){3}\\d{1,3}$");
+        Pattern ipv4Structure = Pattern.compile("^(\\d{1,3}\\.){3}\\d{1,3}$");
         if (ipv4Structure.matcher(host).matches()) {
             // Strict IPv4 validation
-            java.util.regex.Pattern ipv4Valid = java.util.regex.Pattern.compile(
+            Pattern ipv4Valid = Pattern.compile(
                     "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$");
             return ipv4Valid.matcher(host).matches();
         }
         // Otherwise treat as hostname (RFC 1123)
-        java.util.regex.Pattern hostnameValid = java.util.regex.Pattern.compile(
-                "^(?![0-9]+$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$");
+        Pattern hostnameValid =
+                Pattern.compile("^(?![0-9]+$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$");
         return hostnameValid.matcher(host).matches() && host.length() <= 255;
     }
 

--- a/src/main/java/hudson/plugins/emailext/MailAccount.java
+++ b/src/main/java/hudson/plugins/emailext/MailAccount.java
@@ -22,11 +22,10 @@ import hudson.util.FormValidation;
 import hudson.util.FormValidation.Kind;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
-import java.util.Collections;
-import java.util.List;
-import java.util.regex.Pattern;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.List;
 import jenkins.model.Jenkins;
 import jenkins.security.FIPS140;
 import net.sf.json.JSONObject;
@@ -98,14 +97,12 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount> {
         if (ipv4Structure.matcher(host).matches()) {
             // Strict IPv4 validation
             java.util.regex.Pattern ipv4Valid = java.util.regex.Pattern.compile(
-                    "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
-            );
+                    "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$");
             return ipv4Valid.matcher(host).matches();
         }
         // Otherwise treat as hostname (RFC 1123)
         java.util.regex.Pattern hostnameValid = java.util.regex.Pattern.compile(
-                "^(?![0-9]+$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$"
-        );
+                "^(?![0-9]+$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$");
         return hostnameValid.matcher(host).matches() && host.length() <= 255;
     }
 

--- a/src/main/java/hudson/plugins/emailext/MailAccount.java
+++ b/src/main/java/hudson/plugins/emailext/MailAccount.java
@@ -24,6 +24,9 @@ import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import jenkins.model.Jenkins;
 import jenkins.security.FIPS140;
 import net.sf.json.JSONObject;
@@ -77,22 +80,32 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount> {
     }
 
     public boolean isSmtpServerValid() {
-        // Empty means "localhost", which is always valid.
         if (StringUtils.isBlank(smtpHost)) {
-            return true;
+            return true; // empty means localhost
         }
-        // Validate hostname or IP address syntax.
-        return isHostnameValid(smtpHost) || isIpAddressValid(smtpHost);
+        try {
+            InetAddress.getByName(smtpHost);
+            return true; // resolved successfully (IPv4, IPv6, or hostname)
+        } catch (UnknownHostException e) {
+            // Offline or unresolvable – fall back to syntax checks
+            return isSyntacticallyValid(smtpHost);
+        }
     }
 
-    private boolean isHostnameValid(String host) {
-        String hostnamePattern = "^(?![0-9]+$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$";
-        return host.matches(hostnamePattern);
-    }
-
-    private boolean isIpAddressValid(String host) {
-        String ipPattern = "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$";
-        return host.matches(ipPattern);
+    private boolean isSyntacticallyValid(String host) {
+        // Hostname pattern (RFC 1123): letters, digits, hyphens, dots
+        Pattern HOSTNAME_PATTERN = Pattern.compile(
+                "^(?![0-9]+$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$"
+        );
+        // IPv4 pattern
+        Pattern IPV4_PATTERN = Pattern.compile(
+                "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+        );
+        return HOSTNAME_PATTERN.matcher(host).matches()
+                || IPV4_PATTERN.matcher(host).matches();
+        // IPv6 is not covered by fallback – but if the host was a valid IPv6 literal,
+        // InetAddress.getByName would have succeeded in a real environment.
+        // For CI tests that never use IPv6, this is fine.
     }
 
     public boolean isSmtpAuthValid() {

--- a/src/main/java/hudson/plugins/emailext/MailAccount.java
+++ b/src/main/java/hudson/plugins/emailext/MailAccount.java
@@ -49,6 +49,13 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount> {
     private boolean defaultAccount;
 
     private boolean useOAuth2;
+    private static final Pattern IPV4_STRUCTURE = Pattern.compile("^(\\d{1,3}\\.){3}\\d{1,3}$");
+    private static final Pattern IPV4_VALID = Pattern.compile(
+            "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+    );
+    private static final Pattern HOSTNAME_VALID = Pattern.compile(
+            "^(?![0-9]+$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$"
+    );
 
     @Deprecated
     public MailAccount(JSONObject jo) {
@@ -83,28 +90,25 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount> {
         if (StringUtils.isBlank(smtpHost)) {
             return true; // empty means localhost
         }
-        try {
-            InetAddress.getByName(smtpHost);
-            return true; // resolved successfully (IPv4, IPv6, or hostname)
-        } catch (UnknownHostException e) {
-            // Offline or unresolvable – fall back to syntax checks
-            return isSyntacticallyValid(smtpHost);
-        }
+        return isSyntacticallyValid(smtpHost);
     }
 
     private boolean isSyntacticallyValid(String host) {
-        // Check if it looks like an IPv4 address (four dot‑separated numbers)
-        Pattern ipv4Structure = Pattern.compile("^(\\d{1,3}\\.){3}\\d{1,3}$");
-        if (ipv4Structure.matcher(host).matches()) {
-            // Strict IPv4 validation
-            Pattern ipv4Valid = Pattern.compile(
-                    "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$");
-            return ipv4Valid.matcher(host).matches();
+        // 1) IPv4 check
+        if (IPV4_STRUCTURE.matcher(host).matches()) {
+            return IPV4_VALID.matcher(host).matches();
         }
-        // Otherwise treat as hostname (RFC 1123)
-        Pattern hostnameValid =
-                Pattern.compile("^(?![0-9]+$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$");
-        return hostnameValid.matcher(host).matches() && host.length() <= 255;
+        // 2) IPv6 literal check (no DNS – the JVM parses literals locally)
+        if (host.contains(":")) {
+            try {
+                InetAddress.getByName(host);
+                return true;
+            } catch (UnknownHostException e) {
+                return false;
+            }
+        }
+        // 3) Hostname (RFC 1123)
+        return HOSTNAME_VALID.matcher(host).matches() && host.length() <= 255;
     }
 
     public boolean isSmtpAuthValid() {

--- a/src/main/java/hudson/plugins/emailext/MailAccount.java
+++ b/src/main/java/hudson/plugins/emailext/MailAccount.java
@@ -49,13 +49,8 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount> {
     private boolean defaultAccount;
 
     private boolean useOAuth2;
-    private static final Pattern IPV4_STRUCTURE = Pattern.compile("^(\\d{1,3}\\.){3}\\d{1,3}$");
-    private static final Pattern IPV4_VALID = Pattern.compile(
-            "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
-    );
-    private static final Pattern HOSTNAME_VALID = Pattern.compile(
-            "^(?![0-9]+$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$"
-    );
+    private static final Pattern HOSTNAME_VALID =
+            Pattern.compile("^(?![0-9]+$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$");
 
     @Deprecated
     public MailAccount(JSONObject jo) {
@@ -95,11 +90,7 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount> {
 
     private boolean isSyntacticallyValid(String host) {
         // 1) IPv4 check
-        if (IPV4_STRUCTURE.matcher(host).matches()) {
-            return IPV4_VALID.matcher(host).matches();
-        }
-        // 2) IPv6 literal check (no DNS – the JVM parses literals locally)
-        if (host.contains(":")) {
+        if (host.contains(":") || host.matches("^(\\d{1,3}\\.){3}\\d{1,3}$")) {
             try {
                 InetAddress.getByName(host);
                 return true;
@@ -107,7 +98,7 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount> {
                 return false;
             }
         }
-        // 3) Hostname (RFC 1123)
+        // Otherwise treat as hostname
         return HOSTNAME_VALID.matcher(host).matches() && host.length() <= 255;
     }
 

--- a/src/test/java/hudson/plugins/emailext/MailAccountTest.java
+++ b/src/test/java/hudson/plugins/emailext/MailAccountTest.java
@@ -197,5 +197,9 @@ class MailAccountTest {
         account.setSmtpHost("invalid..host");
         assertFalse(account.isSmtpServerValid());
 
+        // Invalid IPv4 address
+         account.setSmtpHost("999.999.999.999");
+         assertFalse(account.isSmtpServerValid());
+
     }
 }

--- a/src/test/java/hudson/plugins/emailext/MailAccountTest.java
+++ b/src/test/java/hudson/plugins/emailext/MailAccountTest.java
@@ -184,10 +184,10 @@ class MailAccountTest {
         assertTrue(account.isSmtpServerValid());
 
         // Valid IPv6 addresses
-        // account.setSmtpHost("::1");
-        // assertTrue(account.isSmtpServerValid());
-        // account.setSmtpHost("2001:db8::1");
-        // assertTrue(account.isSmtpServerValid());
+        account.setSmtpHost("::1");
+        assertTrue(account.isSmtpServerValid());
+        account.setSmtpHost("2001:db8::1");
+        assertTrue(account.isSmtpServerValid());
 
         // Valid hostname that resolves (localhost is reliable)
         account.setSmtpHost("localhost");

--- a/src/test/java/hudson/plugins/emailext/MailAccountTest.java
+++ b/src/test/java/hudson/plugins/emailext/MailAccountTest.java
@@ -163,4 +163,43 @@ class MailAccountTest {
                 mad.doCheckCredentialsId(null, "bogus", true, true),
                 Matchers.allOf(hasKind(Kind.ERROR), hasMessage("Cannot find currently selected credentials")));
     }
+
+    @Test
+    @WithoutJenkins
+    void testIsSmtpServerValid() {
+        MailAccount account = new MailAccount();
+
+        // Blank/null should be considered valid (means localhost)
+        account.setSmtpHost(null);
+        assertTrue(account.isSmtpServerValid());
+        account.setSmtpHost("");
+        assertTrue(account.isSmtpServerValid());
+        account.setSmtpHost("   ");
+        assertTrue(account.isSmtpServerValid());
+
+        // Valid IPv4 addresses
+        account.setSmtpHost("192.168.1.1");
+        assertTrue(account.isSmtpServerValid());
+        account.setSmtpHost("127.0.0.1");
+        assertTrue(account.isSmtpServerValid());
+
+        // Valid IPv6 addresses
+        // account.setSmtpHost("::1");
+        // assertTrue(account.isSmtpServerValid());
+        // account.setSmtpHost("2001:db8::1");
+        // assertTrue(account.isSmtpServerValid());
+
+        // Valid hostname that resolves (localhost is reliable)
+        account.setSmtpHost("localhost");
+        assertTrue(account.isSmtpServerValid());
+
+        // Invalid hostname (syntactically invalid) → should throw UnknownHostException → false
+        account.setSmtpHost("invalid..host");
+        assertFalse(account.isSmtpServerValid());
+
+        // Invalid IPv4 address
+        // account.setSmtpHost("999.999.999.999");
+        // assertFalse(account.isSmtpServerValid());
+
+    }
 }

--- a/src/test/java/hudson/plugins/emailext/MailAccountTest.java
+++ b/src/test/java/hudson/plugins/emailext/MailAccountTest.java
@@ -198,8 +198,7 @@ class MailAccountTest {
         assertFalse(account.isSmtpServerValid());
 
         // Invalid IPv4 address
-         account.setSmtpHost("999.999.999.999");
-         assertFalse(account.isSmtpServerValid());
-
+        account.setSmtpHost("999.999.999.999");
+        assertFalse(account.isSmtpServerValid());
     }
 }

--- a/src/test/java/hudson/plugins/emailext/MailAccountTest.java
+++ b/src/test/java/hudson/plugins/emailext/MailAccountTest.java
@@ -197,9 +197,5 @@ class MailAccountTest {
         account.setSmtpHost("invalid..host");
         assertFalse(account.isSmtpServerValid());
 
-        // Invalid IPv4 address
-        // account.setSmtpHost("999.999.999.999");
-        // assertFalse(account.isSmtpServerValid());
-
     }
 }

--- a/src/test/java/hudson/plugins/emailext/MailAccountTest.java
+++ b/src/test/java/hudson/plugins/emailext/MailAccountTest.java
@@ -200,5 +200,11 @@ class MailAccountTest {
         // Invalid IPv4 address
         account.setSmtpHost("999.999.999.999");
         assertFalse(account.isSmtpServerValid());
+
+        // Valid pattern but exceeds 255 characters
+        String longHost = "a.".repeat(200) + "com";
+        assertTrue(longHost.length() > 255); // sanity check
+        account.setSmtpHost(longHost);
+        assertFalse(account.isSmtpServerValid());
     }
 }

--- a/src/test/java/hudson/plugins/emailext/MailAccountTest.java
+++ b/src/test/java/hudson/plugins/emailext/MailAccountTest.java
@@ -169,7 +169,7 @@ class MailAccountTest {
     void testIsSmtpServerValid() {
         MailAccount account = new MailAccount();
 
-        // Blank/null should be considered valid (means localhost)
+        // Blank / null
         account.setSmtpHost(null);
         assertTrue(account.isSmtpServerValid());
         account.setSmtpHost("");
@@ -177,33 +177,43 @@ class MailAccountTest {
         account.setSmtpHost("   ");
         assertTrue(account.isSmtpServerValid());
 
-        // Valid IPv4 addresses
+        // Valid hostnames
+        account.setSmtpHost("mail.bar.com");
+        assertTrue(account.isSmtpServerValid());
+        account.setSmtpHost("localhost");
+        assertTrue(account.isSmtpServerValid());
+        account.setSmtpHost("smtp.gmail.com");
+        assertTrue(account.isSmtpServerValid());
+
+        // Valid IPv4
         account.setSmtpHost("192.168.1.1");
         assertTrue(account.isSmtpServerValid());
         account.setSmtpHost("127.0.0.1");
         assertTrue(account.isSmtpServerValid());
 
-        // Valid IPv6 addresses
+        // Valid IPv6 literals (no DNS)
         account.setSmtpHost("::1");
         assertTrue(account.isSmtpServerValid());
         account.setSmtpHost("2001:db8::1");
         assertTrue(account.isSmtpServerValid());
 
-        // Valid hostname that resolves (localhost is reliable)
-        account.setSmtpHost("localhost");
-        assertTrue(account.isSmtpServerValid());
-
-        // Invalid hostname (syntactically invalid) → should throw UnknownHostException → false
-        account.setSmtpHost("invalid..host");
-        assertFalse(account.isSmtpServerValid());
-
-        // Invalid IPv4 address
+        // Invalid IPv4
         account.setSmtpHost("999.999.999.999");
         assertFalse(account.isSmtpServerValid());
+        account.setSmtpHost("256.0.0.1");
+        assertFalse(account.isSmtpServerValid());
 
-        // Valid pattern but exceeds 255 characters
+        // Invalid hostnames
+        account.setSmtpHost("invalid..host");
+        assertFalse(account.isSmtpServerValid());
+        account.setSmtpHost("-bad.com");
+        assertFalse(account.isSmtpServerValid());
+        account.setSmtpHost("bad-.com");
+        assertFalse(account.isSmtpServerValid());
+
+        // Too long hostname (valid pattern but > 255 chars)
         String longHost = "a.".repeat(200) + "com";
-        assertTrue(longHost.length() > 255); // sanity check
+        assertTrue(longHost.length() > 255);
         account.setSmtpHost(longHost);
         assertFalse(account.isSmtpServerValid());
     }


### PR DESCRIPTION
- Adds syntax validation for SMTP server hostnames in MailAccount.isSmtpServerValid(), allowing empty values for localhost.
- Checks non‑blank hostnames against RFC‑compliant patterns for hostnames and IP addresses.
### Testing done
Ran mvn spotless:apply
Ran mvn verify -DskipTests

This my first PR. Sorry If I made any mistakes
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed