### PR TITLE
Fix XSS in EmailExtTemplateAction error rendering

### DIFF
--- a/src/main/java/hudson/plugins/emailext/EmailExtTemplateAction.java
+++ b/src/main/java/hudson/plugins/emailext/EmailExtTemplateAction.java
@@ -3,6 +3,7 @@ package hudson.plugins.emailext;
 import hudson.ExtensionList;
 import hudson.FilePath;
 import hudson.Plugin;
+import hudson.Util;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
@@ -53,16 +54,20 @@ public class EmailExtTemplateAction implements Action {
         return "templateTest";
     }
 
+    // ✅ FIXED METHOD (XSS SAFE)
     private String renderError(Exception ex) {
+        String message = (ex != null && ex.getMessage() != null) ? ex.toString() : "Unknown error";
+
+        String escaped = Util.xmlEscape(message).replace("\n", "<br/>");
+
         return "<h3>An error occurred trying to render the template:</h3><br/>"
                 + "<span style=\"color:red; font-weight:bold\">"
-                + ex.toString().replace("\n", "<br/>")
+                + escaped
                 + "</span>";
     }
 
     @SuppressWarnings("lgtm[jenkins/csrf]")
     public FormValidation doTemplateFileCheck(@QueryParameter final String value) {
-        // See src/main/resources/hudson/plugins/emailext/EmailExtTemplateAction/{index,action}.groovy
         if (Jenkins.get()
                 .getDescriptorByType(ExtendedEmailPublisherDescriptor.class)
                 .isAdminRequiredForTemplateTesting()) {
@@ -75,7 +80,6 @@ public class EmailExtTemplateAction implements Action {
             if (value.startsWith("managed:")) {
                 return checkForManagedFile(StringUtils.removeStart(value, "managed:"));
             } else {
-                // first check in the default resources area...
                 InputStream inputStream = Thread.currentThread()
                         .getContextClassLoader()
                         .getResourceAsStream("hudson/plugins/emailext/templates/" + value);
@@ -89,7 +93,6 @@ public class EmailExtTemplateAction implements Action {
                             return FormValidation.error("The file '" + value + "' does not exist");
                         }
                     } catch (IOException | InterruptedException e) {
-                        // Don't want to expose too much info to a potential file fishing attempt
                         return FormValidation.error("I/O Error.");
                     }
                 }
@@ -101,7 +104,6 @@ public class EmailExtTemplateAction implements Action {
     private FormValidation checkForManagedFile(final String value) {
         Plugin plugin = Jenkins.get().getPlugin("config-file-provider");
         if (plugin != null) {
-            Config config = null;
             Collection<ConfigProvider> providers = getTemplateConfigProviders();
             for (ConfigProvider provider : providers) {
                 for (Config c : provider.getAllConfigs()) {

--- a/src/main/java/hudson/plugins/emailext/EmailExtTemplateAction.java
+++ b/src/main/java/hudson/plugins/emailext/EmailExtTemplateAction.java
@@ -106,6 +106,7 @@ public class EmailExtTemplateAction implements Action {
     private FormValidation checkForManagedFile(final String value) {
         Plugin plugin = Jenkins.get().getPlugin("config-file-provider");
         if (plugin != null) {
+            Config config = null;
             Collection<ConfigProvider> providers = getTemplateConfigProviders();
             for (ConfigProvider provider : providers) {
                 for (Config c : provider.getAllConfigs()) {

--- a/src/main/java/hudson/plugins/emailext/EmailExtTemplateAction.java
+++ b/src/main/java/hudson/plugins/emailext/EmailExtTemplateAction.java
@@ -93,6 +93,7 @@ public class EmailExtTemplateAction implements Action {
                             return FormValidation.error("The file '" + value + "' does not exist");
                         }
                     } catch (IOException | InterruptedException e) {
+                        // Avoid exposing detailed file system info to prevent potential file fishing attacks
                         return FormValidation.error("I/O Error.");
                     }
                 }

--- a/src/main/java/hudson/plugins/emailext/EmailExtTemplateAction.java
+++ b/src/main/java/hudson/plugins/emailext/EmailExtTemplateAction.java
@@ -68,6 +68,7 @@ public class EmailExtTemplateAction implements Action {
 
     @SuppressWarnings("lgtm[jenkins/csrf]")
     public FormValidation doTemplateFileCheck(@QueryParameter final String value) {
+        // See src/main/resources/hudson/plugins/emailext/EmailExtTemplateAction/{index,action}.groovy
         if (Jenkins.get()
                 .getDescriptorByType(ExtendedEmailPublisherDescriptor.class)
                 .isAdminRequiredForTemplateTesting()) {
@@ -93,7 +94,7 @@ public class EmailExtTemplateAction implements Action {
                             return FormValidation.error("The file '" + value + "' does not exist");
                         }
                     } catch (IOException | InterruptedException e) {
-                        // Avoid exposing detailed file system info to prevent potential file fishing attacks
+                        // Don't want to expose too much info to a potential file fishing attempt
                         return FormValidation.error("I/O Error.");
                     }
                 }

--- a/src/test/java/hudson/plugins/emailext/EmailExtTemplateActionTest.java
+++ b/src/test/java/hudson/plugins/emailext/EmailExtTemplateActionTest.java
@@ -1,0 +1,38 @@
+package hudson.plugins.emailext;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+public class EmailExtTemplateActionTest {
+
+    @Test
+    void testRenderErrorEscapesXSS() throws Exception {
+        Exception ex = new RuntimeException("<script>alert('xss')</script>");
+
+        EmailExtTemplateAction action = new EmailExtTemplateAction(null);
+
+        Method method = EmailExtTemplateAction.class.getDeclaredMethod("renderError", Exception.class);
+        method.setAccessible(true);
+
+        String result = (String) method.invoke(action, ex);
+
+        assertFalse(result.contains("<script>"));
+        assertTrue(result.contains("&lt;script&gt;"));
+    }
+
+    @Test
+    void testRenderErrorWithNewlines() throws Exception {
+        Exception ex = new RuntimeException("line1\nline2");
+
+        EmailExtTemplateAction action = new EmailExtTemplateAction(null);
+
+        Method method = EmailExtTemplateAction.class.getDeclaredMethod("renderError", Exception.class);
+        method.setAccessible(true);
+
+        String result = (String) method.invoke(action, ex);
+
+        assertTrue(result.contains("<br/>"));
+    }
+}


### PR DESCRIPTION
### Summary
Fixes a potential Cross-Site Scripting (XSS) vulnerability in EmailExtTemplateAction when rendering error messages.

### Problem
Previously, exception messages were embedded into HTML without escaping:

    ex.toString().replace("\n", "<br/>")

Since exception messages may contain user-controlled content, this could allow injection of malicious HTML or scripts.

### Solution
- Escape exception messages using hudson.Util.xmlEscape
- Preserve formatting by converting newlines to <br/>
- Add null-safety for exception handling

### Security Impact
Prevents injection of arbitrary HTML/JavaScript in template preview output.

### Testing
- Verified build passes locally (mvn clean install)

### Notes
This change is minimal and does not modify existing rendering logic beyond sanitization.