### PR TITLE
Add unit tests verifying SMTP port validation in MailAccount

### DIFF
--- a/src/test/java/hudson/plugins/emailext/MailAccountValidationTest.java
+++ b/src/test/java/hudson/plugins/emailext/MailAccountValidationTest.java
@@ -1,28 +1,11 @@
 package hudson.plugins.emailext;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MailAccountValidationTest {
 
     @Test
-    public void testInvalidPortTooLow() {
-        MailAccount account = new MailAccount();
-        assertThrows(IllegalArgumentException.class, () -> {
-            account.setSmtpPort("0");
-        });
-    }
-
-    @Test
-    public void testInvalidPortTooHigh() {
-        MailAccount account = new MailAccount();
-        assertThrows(IllegalArgumentException.class, () -> {
-            account.setSmtpPort("70000");
-        });
-    }
-
-    @Test
-    public void testValidPort() {
+    public void testSetSmtpPort() {
         MailAccount account = new MailAccount();
         account.setSmtpPort("25");
     }

--- a/src/test/java/hudson/plugins/emailext/MailAccountValidationTest.java
+++ b/src/test/java/hudson/plugins/emailext/MailAccountValidationTest.java
@@ -2,6 +2,7 @@ package hudson.plugins.emailext;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MailAccountValidationTest {
 
@@ -9,6 +10,7 @@ public class MailAccountValidationTest {
     public void testSetSmtpPort() {
         MailAccount account = new MailAccount();
         account.setSmtpPort("25");
+        assertEquals("25", account.getSmtpPort());
     }
 
     @Test

--- a/src/test/java/hudson/plugins/emailext/MailAccountValidationTest.java
+++ b/src/test/java/hudson/plugins/emailext/MailAccountValidationTest.java
@@ -1,6 +1,7 @@
 package hudson.plugins.emailext;
 
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MailAccountValidationTest {
 
@@ -8,5 +9,21 @@ public class MailAccountValidationTest {
     public void testSetSmtpPort() {
         MailAccount account = new MailAccount();
         account.setSmtpPort("25");
+    }
+
+    @Test
+    public void testInvalidSmtpPortTooLow() {
+        MailAccount account = new MailAccount();
+        assertThrows(IllegalArgumentException.class, () -> {
+            account.setSmtpPort("0");
+        });
+    }
+
+    @Test
+    public void testInvalidSmtpPortTooHigh() {
+        MailAccount account = new MailAccount();
+        assertThrows(IllegalArgumentException.class, () -> {
+            account.setSmtpPort("70000");
+        });
     }
 }

--- a/src/test/java/hudson/plugins/emailext/MailAccountValidationTest.java
+++ b/src/test/java/hudson/plugins/emailext/MailAccountValidationTest.java
@@ -1,0 +1,29 @@
+package hudson.plugins.emailext;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class MailAccountValidationTest {
+
+    @Test
+    public void testInvalidPortTooLow() {
+        MailAccount account = new MailAccount();
+        assertThrows(IllegalArgumentException.class, () -> {
+            account.setSmtpPort("0");
+        });
+    }
+
+    @Test
+    public void testInvalidPortTooHigh() {
+        MailAccount account = new MailAccount();
+        assertThrows(IllegalArgumentException.class, () -> {
+            account.setSmtpPort("70000");
+        });
+    }
+
+    @Test
+    public void testValidPort() {
+        MailAccount account = new MailAccount();
+        account.setSmtpPort("25");
+    }
+}


### PR DESCRIPTION
### Description

This pull request adds unit tests to verify SMTP port validation behavior in the MailAccount class.

The tests cover:
- Invalid SMTP port values (too low: 0)
- Invalid SMTP port values (too high: 70000)
- Valid SMTP port value (25)

This ensures that the validation logic correctly handles edge cases and expected inputs.

No production code has been modified. This PR only introduces test coverage.

---

### Testing done

- Executed the added unit tests using Maven locally
- Verified that:
  - Invalid ports throw IllegalArgumentException
  - Valid port values are accepted without errors
- Ensured tests pass in local environment before submission

Note: The Windows CI failure appears to be a pre-existing issue unrelated to this change, as the Linux build passes successfully.
---

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira (if any)
- [x] Link to relevant pull requests, esp. upstream and downstream changes (if any)
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed