### PR TITLE
test: Add unit tests for BuildUserRecipientProvider

### DIFF
--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/BuildUserRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/BuildUserRecipientProviderTest.java
@@ -9,6 +9,7 @@ import hudson.tasks.Mailer;
 import jenkins.model.Jenkins;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -43,41 +44,54 @@ class BuildUserRecipientProviderTest {
     }
 
     @Test
+    @DisplayName("User who triggered build should receive email")
     void testUserWhoTriggeredBuildReceivesEmail() throws Exception {
         try (MockedStatic<User> mockedUser = Mockito.mockStatic(User.class)) {
             final FreeStyleProject project = Mockito.mock(FreeStyleProject.class);
             final FreeStyleBuild build = Mockito.spy(new FreeStyleBuild(project));
             Mockito.doReturn(Result.FAILURE).when(build).getResult();
-            // User "A" triggered the build via UserIdCause
             MockUtilities.addRequestor(mockedUser, build, "A");
-            // User "A" should receive the email
             TestUtilities.checkRecipients(build, new BuildUserRecipientProvider(), "A");
         }
     }
 
     @Test
+    @DisplayName("No email sent when build was not triggered by a user")
     void testNoEmailWhenBuildNotTriggeredByUser() throws Exception {
         try (MockedStatic<User> mockedUser = Mockito.mockStatic(User.class)) {
             final FreeStyleProject project = Mockito.mock(FreeStyleProject.class);
             final FreeStyleBuild build = Mockito.spy(new FreeStyleBuild(project));
             Mockito.doReturn(Result.FAILURE).when(build).getResult();
-            // No UserIdCause — simulates a timer/SCM-triggered build
-            Mockito.doReturn(null).when(build).getCause(hudson.model.Cause.UserIdCause.class);
-            // No recipients expected
+
+            // Prevent deep Jenkins core calls in lightweight unit tests
+            Mockito.doReturn(null).when(build).getCause();
+
+            // No addRequestor call - simulates SCM/timer-triggered build
             TestUtilities.checkRecipients(build, new BuildUserRecipientProvider());
         }
     }
 
     @Test
+    @DisplayName("Only triggering user receives email, not changeset committers")
     void testOnlyTriggeringUserReceivesEmailNotCommitters() throws Exception {
         try (MockedStatic<User> mockedUser = Mockito.mockStatic(User.class)) {
             final FreeStyleProject project = Mockito.mock(FreeStyleProject.class);
             final FreeStyleBuild build = Mockito.spy(new FreeStyleBuild(project));
             Mockito.doReturn(Result.FAILURE).when(build).getResult();
-            // User "A" triggered the build, users "X" and "Y" made commits
             MockUtilities.addRequestor(mockedUser, build, "A");
             MockUtilities.addChangeSet(build, "X", "Y");
-            // Only "A" should receive email — not the committers X and Y
+            TestUtilities.checkRecipients(build, new BuildUserRecipientProvider(), "A");
+        }
+    }
+
+    @Test
+    @DisplayName("Triggering user receives email regardless of build result")
+    void testEmailSentRegardlessOfBuildResult() throws Exception {
+        try (MockedStatic<User> mockedUser = Mockito.mockStatic(User.class)) {
+            final FreeStyleProject project = Mockito.mock(FreeStyleProject.class);
+            final FreeStyleBuild build = Mockito.spy(new FreeStyleBuild(project));
+            Mockito.doReturn(Result.SUCCESS).when(build).getResult();
+            MockUtilities.addRequestor(mockedUser, build, "A");
             TestUtilities.checkRecipients(build, new BuildUserRecipientProvider(), "A");
         }
     }

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/BuildUserRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/BuildUserRecipientProviderTest.java
@@ -1,5 +1,6 @@
 package hudson.plugins.emailext.plugins.recipients;
 
+import hudson.model.Cause.UserIdCause;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
@@ -64,7 +65,7 @@ class BuildUserRecipientProviderTest {
             Mockito.doReturn(Result.FAILURE).when(build).getResult();
 
             // Prevent deep Jenkins core calls in lightweight unit tests
-            Mockito.doReturn(null).when(build).getCause();
+            Mockito.doReturn(null).when(build).getCause(UserIdCause.class);
 
             // No addRequestor call - simulates SCM/timer-triggered build
             TestUtilities.checkRecipients(build, new BuildUserRecipientProvider());

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/BuildUserRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/BuildUserRecipientProviderTest.java
@@ -1,0 +1,85 @@
+package hudson.plugins.emailext.plugins.recipients;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.model.User;
+import hudson.plugins.emailext.ExtendedEmailPublisherDescriptor;
+import hudson.tasks.Mailer;
+import jenkins.model.Jenkins;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+class BuildUserRecipientProviderTest {
+
+    private MockedStatic<Jenkins> mockedJenkins;
+    private MockedStatic<Mailer> mockedMailer;
+
+    @BeforeEach
+    void before() {
+        final Jenkins jenkins = Mockito.mock(Jenkins.class);
+        Mockito.when(jenkins.isUseSecurity()).thenReturn(false);
+        final ExtendedEmailPublisherDescriptor descriptor =
+                Mockito.mock(ExtendedEmailPublisherDescriptor.class);
+        descriptor.setDebugMode(true);
+        Mockito.when(descriptor.getExcludedCommitters()).thenReturn("");
+        Mockito.when(jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class))
+                .thenReturn(descriptor);
+        mockedJenkins = Mockito.mockStatic(Jenkins.class);
+        mockedJenkins.when(Jenkins::get).thenReturn(jenkins);
+
+        final Mailer.DescriptorImpl mailerDescriptor = Mockito.mock(Mailer.DescriptorImpl.class);
+        Mockito.when(mailerDescriptor.getDefaultSuffix()).thenReturn("DOMAIN");
+        mockedMailer = Mockito.mockStatic(Mailer.class);
+        mockedMailer.when(Mailer::descriptor).thenReturn(mailerDescriptor);
+    }
+
+    @AfterEach
+    void after() {
+        mockedMailer.close();
+        mockedJenkins.close();
+    }
+
+    @Test
+    void testUserWhoTriggeredBuildReceivesEmail() throws Exception {
+        try (MockedStatic<User> mockedUser = Mockito.mockStatic(User.class)) {
+            final FreeStyleProject project = Mockito.mock(FreeStyleProject.class);
+            final FreeStyleBuild build = Mockito.spy(new FreeStyleBuild(project));
+            Mockito.doReturn(Result.FAILURE).when(build).getResult();
+            // User "A" triggered the build via UserIdCause
+            MockUtilities.addRequestor(mockedUser, build, "A");
+            // User "A" should receive the email
+            TestUtilities.checkRecipients(build, new BuildUserRecipientProvider(), "A");
+        }
+    }
+
+    @Test
+    void testNoEmailWhenBuildNotTriggeredByUser() throws Exception {
+        try (MockedStatic<User> mockedUser = Mockito.mockStatic(User.class)) {
+            final FreeStyleProject project = Mockito.mock(FreeStyleProject.class);
+            final FreeStyleBuild build = Mockito.spy(new FreeStyleBuild(project));
+            Mockito.doReturn(Result.FAILURE).when(build).getResult();
+            // No UserIdCause — simulates a timer/SCM-triggered build
+            Mockito.doReturn(null).when(build).getCause(hudson.model.Cause.UserIdCause.class);
+            // No recipients expected
+            TestUtilities.checkRecipients(build, new BuildUserRecipientProvider());
+        }
+    }
+
+    @Test
+    void testOnlyTriggeringUserReceivesEmailNotCommitters() throws Exception {
+        try (MockedStatic<User> mockedUser = Mockito.mockStatic(User.class)) {
+            final FreeStyleProject project = Mockito.mock(FreeStyleProject.class);
+            final FreeStyleBuild build = Mockito.spy(new FreeStyleBuild(project));
+            Mockito.doReturn(Result.FAILURE).when(build).getResult();
+            // User "A" triggered the build, users "X" and "Y" made commits
+            MockUtilities.addRequestor(mockedUser, build, "A");
+            MockUtilities.addChangeSet(build, "X", "Y");
+            // Only "A" should receive email — not the committers X and Y
+            TestUtilities.checkRecipients(build, new BuildUserRecipientProvider(), "A");
+        }
+    }
+}

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/BuildUserRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/BuildUserRecipientProviderTest.java
@@ -22,8 +22,7 @@ class BuildUserRecipientProviderTest {
     void before() {
         final Jenkins jenkins = Mockito.mock(Jenkins.class);
         Mockito.when(jenkins.isUseSecurity()).thenReturn(false);
-        final ExtendedEmailPublisherDescriptor descriptor =
-                Mockito.mock(ExtendedEmailPublisherDescriptor.class);
+        final ExtendedEmailPublisherDescriptor descriptor = Mockito.mock(ExtendedEmailPublisherDescriptor.class);
         descriptor.setDebugMode(true);
         Mockito.when(descriptor.getExcludedCommitters()).thenReturn("");
         Mockito.when(jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class))


### PR DESCRIPTION
BuildUserRecipientProvider had no test coverage. Add three tests covering:
- User who triggered the build receives email (happy path)
- No email sent when build was not triggered by a user (SCM/timer cause)
- Only the triggering user receives email, not committers in the changeset

This distinguishes BuildUserRecipientProvider behaviour from
DevelopersRecipientProvider, as documented in the source.

### Testing done
All three tests pass locally via:
`mvn test -Dtest=BuildUserRecipientProviderTest`

Output:
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed