### PR TITLE
fix:improve logging for smtp session creation failure

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -570,8 +570,10 @@ public class ExtendedEmailPublisher extends Notifier {
             }
             Session session = getDescriptor().createSession(mailAccount, context);
             if (session == null) {
-                String host=mailAccount.getSmtpHost();
-                context.getListener().getLogger().println("Could not create session"+(host!=null ? host : "unknown") );
+                String host = mailAccount.getSmtpHost();
+                context.getListener()
+                        .getLogger()
+                        .println("Could not create session" + (host != null ? host : "unknown"));
                 return false;
             }
             MimeMessage msg = createMail(context, fromAddress, session);

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -570,7 +570,7 @@ public class ExtendedEmailPublisher extends Notifier {
             }
             Session session = getDescriptor().createSession(mailAccount, context);
             if (session == null) {
-                context.getListener().getLogger().println("Could not create session"+mailAccount.getSmtpServer());
+                context.getListener().getLogger().println("Could not create session"+mailAccount.getSmtpHost());
                 return false;
             }
             MimeMessage msg = createMail(context, fromAddress, session);

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -570,7 +570,8 @@ public class ExtendedEmailPublisher extends Notifier {
             }
             Session session = getDescriptor().createSession(mailAccount, context);
             if (session == null) {
-                context.getListener().getLogger().println("Could not create session"+mailAccount.getSmtpHost());
+                String host=mailAccount.getSmtpHost();
+                context.getListener().getLogger().println("Could not create session"+(host!=null ? host : "unknown") );
                 return false;
             }
             MimeMessage msg = createMail(context, fromAddress, session);

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -570,7 +570,7 @@ public class ExtendedEmailPublisher extends Notifier {
             }
             Session session = getDescriptor().createSession(mailAccount, context);
             if (session == null) {
-                context.getListener().getLogger().println("Could not create session");
+                context.getListener().getLogger().println("Could not create session"+mailAccount.getSmtpServer());
                 return false;
             }
             MimeMessage msg = createMail(context, fromAddress, session);


### PR DESCRIPTION
The log message before did not provide much context on why the bug was appearing.
Now it includes the smtp server information when smtp session creation fails.