### PR TITLE
test: Add unit tests for RequesterRecipientProvider

### DIFF
--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/RequesterRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/RequesterRecipientProviderTest.java
@@ -1,0 +1,118 @@
+package hudson.plugins.emailext.plugins.recipients;
+
+import hudson.model.Cause;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Job;
+import hudson.model.Result;
+import hudson.model.User;
+import hudson.plugins.emailext.ExtendedEmailPublisherDescriptor;
+import hudson.tasks.Mailer;
+import jenkins.model.Jenkins;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+class RequesterRecipientProviderTest {
+
+    private MockedStatic<Jenkins> mockedJenkins;
+    private MockedStatic<Mailer> mockedMailer;
+    private Jenkins jenkins;
+
+    @BeforeEach
+    void before() {
+        jenkins = Mockito.mock(Jenkins.class);
+        Mockito.when(jenkins.isUseSecurity()).thenReturn(false);
+        final ExtendedEmailPublisherDescriptor descriptor =
+                Mockito.mock(ExtendedEmailPublisherDescriptor.class);
+        descriptor.setDebugMode(true);
+        Mockito.when(descriptor.getExcludedCommitters()).thenReturn("");
+        Mockito.when(jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class))
+                .thenReturn(descriptor);
+        mockedJenkins = Mockito.mockStatic(Jenkins.class);
+        mockedJenkins.when(Jenkins::get).thenReturn(jenkins);
+
+        final Mailer.DescriptorImpl mailerDescriptor = Mockito.mock(Mailer.DescriptorImpl.class);
+        Mockito.when(mailerDescriptor.getDefaultSuffix()).thenReturn("DOMAIN");
+        mockedMailer = Mockito.mockStatic(Mailer.class);
+        mockedMailer.when(Mailer::descriptor).thenReturn(mailerDescriptor);
+    }
+
+    @AfterEach
+    void after() {
+        mockedMailer.close();
+        mockedJenkins.close();
+    }
+
+    @Test
+    @DisplayName("User who directly triggered the build receives email when no upstream cause exists")
+    void testDirectUserTriggerReceivesEmail() throws Exception {
+        try (MockedStatic<User> mockedUser = Mockito.mockStatic(User.class)) {
+            final FreeStyleProject project = Mockito.mock(FreeStyleProject.class);
+            final FreeStyleBuild build = Mockito.spy(new FreeStyleBuild(project));
+            Mockito.doReturn(Result.FAILURE).when(build).getResult();
+            Mockito.doReturn(null).when(build).getCause(Cause.UpstreamCause.class);
+            MockUtilities.addRequestor(mockedUser, build, "A");
+            TestUtilities.checkRecipients(build, new RequesterRecipientProvider(), "A");
+        }
+    }
+
+    @Test
+    @DisplayName("No email sent when build was not triggered by a user and has no upstream cause")
+    void testNoEmailWhenNoUserAndNoUpstreamCause() throws Exception {
+        try (MockedStatic<User> mockedUser = Mockito.mockStatic(User.class)) {
+            final FreeStyleProject project = Mockito.mock(FreeStyleProject.class);
+            final FreeStyleBuild build = Mockito.spy(new FreeStyleBuild(project));
+            Mockito.doReturn(Result.FAILURE).when(build).getResult();
+            Mockito.doReturn(null).when(build).getCause(Cause.UpstreamCause.class);
+            Mockito.doReturn(null).when(build).getCause(Cause.UserIdCause.class);
+            TestUtilities.checkRecipients(build, new RequesterRecipientProvider());
+        }
+    }
+
+    @Test
+    @DisplayName("Original upstream user receives email when build was triggered by upstream project")
+    void testUpstreamUserReceivesEmail() throws Exception {
+        try (MockedStatic<User> mockedUser = Mockito.mockStatic(User.class)) {
+            final FreeStyleProject upstreamProject = Mockito.mock(FreeStyleProject.class);
+            final FreeStyleBuild upstreamBuild = Mockito.spy(new FreeStyleBuild(upstreamProject));
+            Mockito.doReturn(Result.SUCCESS).when(upstreamBuild).getResult();
+            Mockito.doReturn(null).when(upstreamBuild).getCause(Cause.UpstreamCause.class);
+            MockUtilities.addRequestor(mockedUser, upstreamBuild, "A");
+
+            final FreeStyleProject project = Mockito.mock(FreeStyleProject.class);
+            final FreeStyleBuild build = Mockito.spy(new FreeStyleBuild(project));
+            Mockito.doReturn(Result.FAILURE).when(build).getResult();
+
+            Cause.UpstreamCause upstreamCause = Mockito.mock(Cause.UpstreamCause.class);
+            Mockito.when(upstreamCause.getUpstreamProject()).thenReturn("upstream-project");
+            Mockito.when(upstreamCause.getUpstreamBuild()).thenReturn(1);
+            Mockito.doReturn(upstreamCause).when(build).getCause(Cause.UpstreamCause.class);
+
+            Mockito.when(jenkins.getItemByFullName("upstream-project")).thenReturn((Job) upstreamProject);
+            Mockito.when(upstreamProject.getBuildByNumber(1)).thenReturn((FreeStyleBuild) upstreamBuild);
+
+            TestUtilities.checkRecipients(build, new RequesterRecipientProvider(), "A");
+        }
+    }
+
+    @Test
+    @DisplayName("No email and no crash when upstream project linkage is broken")
+    void testBrokenUpstreamProjectLinkage() throws Exception {
+        try (MockedStatic<User> mockedUser = Mockito.mockStatic(User.class)) {
+            final FreeStyleProject project = Mockito.mock(FreeStyleProject.class);
+            final FreeStyleBuild build = Mockito.spy(new FreeStyleBuild(project));
+            Mockito.doReturn(Result.FAILURE).when(build).getResult();
+
+            Cause.UpstreamCause upstreamCause = Mockito.mock(Cause.UpstreamCause.class);
+            Mockito.when(upstreamCause.getUpstreamProject()).thenReturn("missing-project");
+            Mockito.doReturn(upstreamCause).when(build).getCause(Cause.UpstreamCause.class);
+            Mockito.when(jenkins.getItemByFullName("missing-project")).thenReturn(null);
+
+            TestUtilities.checkRecipients(build, new RequesterRecipientProvider());
+        }
+    }
+}

--- a/src/test/java/hudson/plugins/emailext/plugins/recipients/RequesterRecipientProviderTest.java
+++ b/src/test/java/hudson/plugins/emailext/plugins/recipients/RequesterRecipientProviderTest.java
@@ -17,7 +17,6 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 class RequesterRecipientProviderTest {
-
     private MockedStatic<Jenkins> mockedJenkins;
     private MockedStatic<Mailer> mockedMailer;
     private Jenkins jenkins;
@@ -26,17 +25,19 @@ class RequesterRecipientProviderTest {
     void before() {
         jenkins = Mockito.mock(Jenkins.class);
         Mockito.when(jenkins.isUseSecurity()).thenReturn(false);
-        final ExtendedEmailPublisherDescriptor descriptor =
-                Mockito.mock(ExtendedEmailPublisherDescriptor.class);
-        descriptor.setDebugMode(true);
+
+        final ExtendedEmailPublisherDescriptor descriptor = Mockito.mock(ExtendedEmailPublisherDescriptor.class);
         Mockito.when(descriptor.getExcludedCommitters()).thenReturn("");
+
         Mockito.when(jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class))
                 .thenReturn(descriptor);
+
         mockedJenkins = Mockito.mockStatic(Jenkins.class);
         mockedJenkins.when(Jenkins::get).thenReturn(jenkins);
 
         final Mailer.DescriptorImpl mailerDescriptor = Mockito.mock(Mailer.DescriptorImpl.class);
         Mockito.when(mailerDescriptor.getDefaultSuffix()).thenReturn("DOMAIN");
+
         mockedMailer = Mockito.mockStatic(Mailer.class);
         mockedMailer.when(Mailer::descriptor).thenReturn(mailerDescriptor);
     }
@@ -52,9 +53,11 @@ class RequesterRecipientProviderTest {
     void testDirectUserTriggerReceivesEmail() throws Exception {
         try (MockedStatic<User> mockedUser = Mockito.mockStatic(User.class)) {
             final FreeStyleProject project = Mockito.mock(FreeStyleProject.class);
-            final FreeStyleBuild build = Mockito.spy(new FreeStyleBuild(project));
+            final FreeStyleBuild build = Mockito.mock(FreeStyleBuild.class);
+
             Mockito.doReturn(Result.FAILURE).when(build).getResult();
             Mockito.doReturn(null).when(build).getCause(Cause.UpstreamCause.class);
+
             MockUtilities.addRequestor(mockedUser, build, "A");
             TestUtilities.checkRecipients(build, new RequesterRecipientProvider(), "A");
         }
@@ -65,10 +68,12 @@ class RequesterRecipientProviderTest {
     void testNoEmailWhenNoUserAndNoUpstreamCause() throws Exception {
         try (MockedStatic<User> mockedUser = Mockito.mockStatic(User.class)) {
             final FreeStyleProject project = Mockito.mock(FreeStyleProject.class);
-            final FreeStyleBuild build = Mockito.spy(new FreeStyleBuild(project));
+            final FreeStyleBuild build = Mockito.mock(FreeStyleBuild.class);
+
             Mockito.doReturn(Result.FAILURE).when(build).getResult();
             Mockito.doReturn(null).when(build).getCause(Cause.UpstreamCause.class);
             Mockito.doReturn(null).when(build).getCause(Cause.UserIdCause.class);
+
             TestUtilities.checkRecipients(build, new RequesterRecipientProvider());
         }
     }
@@ -78,13 +83,15 @@ class RequesterRecipientProviderTest {
     void testUpstreamUserReceivesEmail() throws Exception {
         try (MockedStatic<User> mockedUser = Mockito.mockStatic(User.class)) {
             final FreeStyleProject upstreamProject = Mockito.mock(FreeStyleProject.class);
-            final FreeStyleBuild upstreamBuild = Mockito.spy(new FreeStyleBuild(upstreamProject));
+            final FreeStyleBuild upstreamBuild = Mockito.mock(FreeStyleBuild.class);
+
             Mockito.doReturn(Result.SUCCESS).when(upstreamBuild).getResult();
             Mockito.doReturn(null).when(upstreamBuild).getCause(Cause.UpstreamCause.class);
             MockUtilities.addRequestor(mockedUser, upstreamBuild, "A");
 
             final FreeStyleProject project = Mockito.mock(FreeStyleProject.class);
-            final FreeStyleBuild build = Mockito.spy(new FreeStyleBuild(project));
+            final FreeStyleBuild build = Mockito.mock(FreeStyleBuild.class);
+
             Mockito.doReturn(Result.FAILURE).when(build).getResult();
 
             Cause.UpstreamCause upstreamCause = Mockito.mock(Cause.UpstreamCause.class);
@@ -104,13 +111,38 @@ class RequesterRecipientProviderTest {
     void testBrokenUpstreamProjectLinkage() throws Exception {
         try (MockedStatic<User> mockedUser = Mockito.mockStatic(User.class)) {
             final FreeStyleProject project = Mockito.mock(FreeStyleProject.class);
-            final FreeStyleBuild build = Mockito.spy(new FreeStyleBuild(project));
+            final FreeStyleBuild build = Mockito.mock(FreeStyleBuild.class);
+
             Mockito.doReturn(Result.FAILURE).when(build).getResult();
 
             Cause.UpstreamCause upstreamCause = Mockito.mock(Cause.UpstreamCause.class);
             Mockito.when(upstreamCause.getUpstreamProject()).thenReturn("missing-project");
             Mockito.doReturn(upstreamCause).when(build).getCause(Cause.UpstreamCause.class);
+
             Mockito.when(jenkins.getItemByFullName("missing-project")).thenReturn(null);
+
+            TestUtilities.checkRecipients(build, new RequesterRecipientProvider());
+        }
+    }
+
+    @Test
+    @DisplayName("No email and no crash when upstream project exists but build is not found")
+    void testUpstreamProjectExistsButBuildIsNotFound() throws Exception {
+        try (MockedStatic<User> mockedUser = Mockito.mockStatic(User.class)) {
+            final FreeStyleProject project = Mockito.mock(FreeStyleProject.class);
+            final FreeStyleBuild build = Mockito.mock(FreeStyleBuild.class);
+
+            Mockito.doReturn(Result.FAILURE).when(build).getResult();
+
+            Cause.UpstreamCause upstreamCause = Mockito.mock(Cause.UpstreamCause.class);
+            Mockito.when(upstreamCause.getUpstreamProject()).thenReturn("existing-project");
+            Mockito.when(upstreamCause.getUpstreamBuild()).thenReturn(1);
+            Mockito.doReturn(upstreamCause).when(build).getCause(Cause.UpstreamCause.class);
+
+            final FreeStyleProject upstreamProject = Mockito.mock(FreeStyleProject.class);
+            Mockito.when(jenkins.getItemByFullName("existing-project")).thenReturn((Job) upstreamProject);
+
+            Mockito.when(upstreamProject.getBuildByNumber(1)).thenReturn(null);
 
             TestUtilities.checkRecipients(build, new RequesterRecipientProvider());
         }


### PR DESCRIPTION
RequesterRecipientProvider had no test coverage despite containing
non-trivial upstream cause traversal logic. Add four tests covering:
- Direct user trigger with no upstream cause receives email
- No email sent when no user and no upstream cause exists
- Original upstream user receives email when traversing upstream chain
- No crash when upstream project linkage is broken (graceful degradation)

### Testing done
All four tests pass locally via:
`mvn test -Dtest=RequesterRecipientProviderTest`

Output:
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed