### PR TITLE
Extract SMTP property keys as named constants in ExtendedEmailPublisherDescriptor

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -59,6 +59,19 @@ import org.kohsuke.stapler.StaplerRequest2;
 public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<Publisher> {
 
     public static final Logger LOGGER = Logger.getLogger(ExtendedEmailPublisherDescriptor.class.getName());
+    // SMTP property key constants
+    private static final String SMTP_HOST_PROPERTY = "mail.smtp.host";
+    private static final String SMTP_AUTH_PROPERTY = "mail.smtp.auth";
+    private static final String SMTP_AUTH_MECHANISMS_PROPERTY = "mail.smtp.auth.mechanisms";
+    private static final String SMTP_TIMEOUT_PROPERTY = "mail.smtp.timeout";
+    private static final String SMTP_CONNECTION_TIMEOUT_PROPERTY = "mail.smtp.connectiontimeout";
+    private static final String SMTP_PORT_PROPERTY = "mail.smtp.port";
+    private static final String SMTP_SOCKETFACTORY_PORT_PROPERTY = "mail.smtp.socketFactory.port";
+    private static final String SMTP_SOCKETFACTORY_CLASS_PROPERTY = "mail.smtp.socketFactory.class";
+    private static final String SMTP_SOCKETFACTORY_FALLBACK_PROPERTY = "mail.smtp.socketFactory.fallback";
+    private static final String SMTP_SSL_CHECK_SERVER_IDENTITY_PROPERTY = "mail.smtp.ssl.checkserveridentity";
+    private static final String SMTP_STARTTLS_ENABLE_PROPERTY = "mail.smtp.starttls.enable";
+    private static final String SMTP_STARTTLS_REQUIRED_PROPERTY = "mail.smtp.starttls.required";
     /**
      * The default e-mail address suffix appended to the user name found from
      * changelog, to send e-mails. Null if not configured.
@@ -337,13 +350,11 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
 
     @Restricted(NoExternalUse.class)
     Session createSession(MailAccount acc, ExtendedEmailPublisherContext context) {
-        final String SMTP_PORT_PROPERTY = "mail.smtp.port";
-        final String SMTP_SOCKETFACTORY_PORT_PROPERTY = "mail.smtp.socketFactory.port";
 
         Properties props = new Properties(System.getProperties());
 
         if (acc.getSmtpHost() != null) {
-            props.put("mail.smtp.host", acc.getSmtpHost());
+            props.put(SMTP_HOST_PROPERTY, acc.getSmtpHost());
         }
         if (acc.getSmtpPort() != null) {
             props.put(SMTP_PORT_PROPERTY, acc.getSmtpPort());
@@ -364,17 +375,17 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
                 props.put(SMTP_PORT_PROPERTY, port);
                 props.put(SMTP_SOCKETFACTORY_PORT_PROPERTY, port);
             }
-            if (props.getProperty("mail.smtp.socketFactory.class") == null) {
-                props.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
+            if (props.getProperty(SMTP_SOCKETFACTORY_CLASS_PROPERTY) == null) {
+                props.put(SMTP_SOCKETFACTORY_CLASS_PROPERTY, "javax.net.ssl.SSLSocketFactory");
             }
-            props.put("mail.smtp.socketFactory.fallback", "false");
+            props.put(SMTP_SOCKETFACTORY_FALLBACK_PROPERTY, "false");
 
             // RFC 2595 specifies additional checks that must be performed on the server's
             // certificate to ensure that the server you connected to is the server you
             // intended
             // to connect to. This reduces the risk of "man in the middle" attacks.
-            if (props.getProperty("mail.smtp.ssl.checkserveridentity") == null) {
-                props.put("mail.smtp.ssl.checkserveridentity", "true");
+            if (props.getProperty(SMTP_SSL_CHECK_SERVER_IDENTITY_PROPERTY) == null) {
+                props.put(SMTP_SSL_CHECK_SERVER_IDENTITY_PROPERTY, "true");
             }
         }
         if (acc.isUseTls()) {
@@ -392,20 +403,20 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
                 props.put(SMTP_PORT_PROPERTY, port);
                 props.put(SMTP_SOCKETFACTORY_PORT_PROPERTY, port);
             }
-            props.put("mail.smtp.starttls.enable", "true");
-            props.put("mail.smtp.starttls.required", "true");
+            props.put(SMTP_STARTTLS_ENABLE_PROPERTY, "true");
+            props.put(SMTP_STARTTLS_REQUIRED_PROPERTY, "true");
         }
         if (!StringUtils.isBlank(acc.getCredentialsId())) {
-            props.put("mail.smtp.auth", "true");
+            props.put(SMTP_AUTH_PROPERTY, "true");
         }
 
         if (acc.isUseOAuth2()) {
-            props.put("mail.smtp.auth.mechanisms", "XOAUTH2");
+            props.put(SMTP_AUTH_MECHANISMS_PROPERTY, "XOAUTH2");
         }
 
         // avoid hang by setting some timeout.
-        props.put("mail.smtp.timeout", "60000");
-        props.put("mail.smtp.connectiontimeout", "60000");
+        props.put(SMTP_TIMEOUT_PROPERTY, "60000");
+        props.put(SMTP_CONNECTION_TIMEOUT_PROPERTY, "60000");
 
         try {
             String ap = acc.getAdvProperties();


### PR DESCRIPTION
### Summary

This change extracts hardcoded SMTP property key strings in 
ExtendedEmailPublisherDescriptor.java into private static final 
String constants at the class level.

### Why this change?

Earlier strings like "mail.smtp.host", "mail.smtp.auth", 
"mail.smtp.starttls.enable" etc. were directly hardcoded inside 
the createSession() method. There were also two local constants 
(SMTP_PORT_PROPERTY and SMTP_SOCKETFACTORY_PORT_PROPERTY) defined 
inside the method itself which limited their scope.

### What's changed?

- Introduced 12 private static final String constants at the 
  class level
- Moved the two existing local constants to the class level 
  for consistency
- Replaced all hardcoded SMTP property strings with these constants

### Behavioral changes?

None. This is purely a refactor/cleanup.


This is a clean resubmission of #1536. That PR accidentally 
included commits from other branches. This PR contains only 
the constants extraction change.