### PR TITLE
Expand tests to verify multipart structure and body content

### DIFF
--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
@@ -45,8 +45,8 @@ import jakarta.mail.Address;
 import jakarta.mail.BodyPart;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
+import jakarta.mail.Part;
 import jakarta.mail.Session;
-import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeMultipart;
 import java.io.IOException;
@@ -746,20 +746,20 @@ class ExtendedEmailPublisherTest {
         Message msg = mailbox.get(0);
         assertThat("Message should be multipart", msg.getContentType(), containsString("multipart/mixed"));
 
-        // TODO: add more tests for getting the multipart information.
-        if (msg instanceof MimeMessage mimeMsg) {
-            assertEquals(
-                    MimeMultipart.class,
-                    mimeMsg.getContent().getClass(),
-                    "Message content should be a MimeMultipart instance");
-            MimeMultipart multipart = (MimeMultipart) mimeMsg.getContent();
-            assertTrue(multipart.getCount() >= 1, "There should be at least one part in the email");
-            MimeBodyPart bodyPart = (MimeBodyPart) multipart.getBodyPart(0);
-            assertThat("UTF-8 charset should be used.", bodyPart.getContentType(), containsString("charset=UTF-8"));
-        } else {
-            assertThat(
-                    "UTF-8 charset should be used.", mailbox.get(0).getContentType(), containsString("charset=UTF-8"));
-        }
+        MimeMessage mimeMsg = assertInstanceOf(MimeMessage.class, msg, "Message should be a MimeMessage instance");
+        MimeMultipart multipart = assertInstanceOf(
+                MimeMultipart.class, mimeMsg.getContent(), "Message content should be a MimeMultipart instance");
+        assertMultipartSubtype(msg, multipart, "mixed");
+        assertEquals(1, multipart.getCount(), "The email body should contain exactly one body part");
+
+        BodyPart bodyPart = multipart.getBodyPart(0);
+        assertThat("Body part should be plain text.", bodyPart.getContentType(), containsString("text/plain"));
+        assertThat("UTF-8 charset should be used.", bodyPart.getContentType(), containsString("charset=UTF-8"));
+
+        String plainText = IOUtils.toString(
+                        bodyPart.getInputStream(), publisher.getDescriptor().getCharset())
+                .replace("\r", "");
+        assertEquals("Boom goes the dynamite.", plainText, "Body content should match the configured trigger content");
     }
 
     @Test
@@ -1375,15 +1375,18 @@ class ExtendedEmailPublisherTest {
         assertInstanceOf(MimeMultipart.class, msg.getContent(), "Content should be a MimeMultipart");
 
         MimeMultipart part = (MimeMultipart) msg.getContent();
+        assertMultipartSubtype(msg, part, "alternative");
         assertEquals(2, part.getCount(), "Should have two body items (html + plaintext)");
 
         BodyPart plainText = part.getBodyPart(0);
+        assertNull(plainText.getFileName(), "Plain text body should not be an attachment");
         String plainTextString = IOUtils.toString(
                         plainText.getInputStream(), publisher.getDescriptor().getCharset())
                 .replace("\r", "");
         assertEquals("This is a test\nHello world", plainTextString, "Should have the same plain text body");
 
         BodyPart html = part.getBodyPart(1);
+        assertNull(html.getFileName(), "HTML body should not be an attachment");
         String htmlString = IOUtils.toString(
                 html.getInputStream(), publisher.getDescriptor().getCharset());
 
@@ -1429,6 +1432,7 @@ class ExtendedEmailPublisherTest {
         assertInstanceOf(MimeMultipart.class, msg.getContent(), "Content should be a MimeMultipart");
 
         MimeMultipart part = (MimeMultipart) msg.getContent();
+        assertMultipartSubtype(msg, part, "alternative");
         assertEquals(
                 2, part.getCount(), "Should have two body items (html + plaintext) when using global 'both' default");
 
@@ -1494,13 +1498,25 @@ class ExtendedEmailPublisherTest {
         assertInstanceOf(MimeMultipart.class, msg.getContent(), "Content should be a MimeMultipart");
 
         MimeMultipart part = (MimeMultipart) msg.getContent();
+        assertMultipartSubtype(msg, part, "mixed");
 
         assertEquals(2, part.getCount(), "Should have two body items (message + attachment)");
+
+        BodyPart body = part.getBodyPart(0);
+        assertThat("Body part should be plain text.", body.getContentType(), containsString("text/plain"));
+        assertNull(body.getFileName(), "Body part should not have a file name");
 
         BodyPart attach = part.getBodyPart(1);
         assertTrue(
                 "build.log".equalsIgnoreCase(attach.getFileName()),
                 "There should be a log named \"build.log\" attached");
+        assertEquals(Part.ATTACHMENT, attach.getDisposition(), "Build log should be attached as attachment");
+        assertNotNull(
+                attach.getHeader("Content-Transfer-Encoding"),
+                "Attachment should include a Content-Transfer-Encoding header");
+
+        BodyPart textPart = findFirstPartByContentType(part, "text/plain");
+        assertNotNull(textPart, "Multipart should contain a plain text body part");
     }
 
     @Test
@@ -1962,6 +1978,38 @@ class ExtendedEmailPublisherTest {
         assertNotNull(headers);
         assertEquals(1, headers.length);
         return headers[0];
+    }
+
+    private static void assertMultipartSubtype(Message message, MimeMultipart multipart, String subtype)
+            throws MessagingException {
+        String expected = "multipart/" + subtype;
+        assertThat(
+                "Message should have " + expected + " content type",
+                message.getContentType(),
+                containsString(expected));
+        assertThat(
+                "MimeMultipart should report " + expected + " content type",
+                multipart.getContentType(),
+                containsString(expected));
+    }
+
+    private static BodyPart findFirstPartByContentType(MimeMultipart multipart, String contentTypeToken)
+            throws Exception {
+        for (int i = 0; i < multipart.getCount(); i++) {
+            BodyPart bodyPart = multipart.getBodyPart(i);
+            if (bodyPart.getContentType().contains(contentTypeToken)) {
+                return bodyPart;
+            }
+
+            Object nestedContent = bodyPart.getContent();
+            if (nestedContent instanceof MimeMultipart nestedMultipart) {
+                BodyPart nestedPart = findFirstPartByContentType(nestedMultipart, contentTypeToken);
+                if (nestedPart != null) {
+                    return nestedPart;
+                }
+            }
+        }
+        return null;
     }
 
     @Test

--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherTest.java
@@ -1514,9 +1514,6 @@ class ExtendedEmailPublisherTest {
         assertNotNull(
                 attach.getHeader("Content-Transfer-Encoding"),
                 "Attachment should include a Content-Transfer-Encoding header");
-
-        BodyPart textPart = findFirstPartByContentType(part, "text/plain");
-        assertNotNull(textPart, "Multipart should contain a plain text body part");
     }
 
     @Test
@@ -1991,25 +1988,6 @@ class ExtendedEmailPublisherTest {
                 "MimeMultipart should report " + expected + " content type",
                 multipart.getContentType(),
                 containsString(expected));
-    }
-
-    private static BodyPart findFirstPartByContentType(MimeMultipart multipart, String contentTypeToken)
-            throws Exception {
-        for (int i = 0; i < multipart.getCount(); i++) {
-            BodyPart bodyPart = multipart.getBodyPart(i);
-            if (bodyPart.getContentType().contains(contentTypeToken)) {
-                return bodyPart;
-            }
-
-            Object nestedContent = bodyPart.getContent();
-            if (nestedContent instanceof MimeMultipart nestedMultipart) {
-                BodyPart nestedPart = findFirstPartByContentType(nestedMultipart, contentTypeToken);
-                if (nestedPart != null) {
-                    return nestedPart;
-                }
-            }
-        }
-        return null;
     }
 
     @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Resolves the TODO in `testShouldSendEmailUsingUtf8ByDefault`

this PR tightens and broadens multipart validation by enforcing expected MIME structure and body-part semantics across relevant tests.
`testShouldSendEmailUsingUtf8ByDefault` previously had a silent fallback for if the message wasn't a `MimeMessage`. I've replaced this with a stricter assertion so potentially broken email implementations don't pass through.
Defined a new helper `assertMultipartSubtype` to verify the multipart subtypes (eg: mixed, alternative) on both the outer message header and the parsed `MimeMultipart` object, and applied it to existing tests to increase multipart coverage.


### Testing done
Modifications to tests only
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
