### PR TITLE
Add Null Checks  and Unit Test for StaticProxyInstanceWhitelist

### DIFF
--- a/src/main/java/hudson/plugins/emailext/groovy/sandbox/StaticProxyInstanceWhitelist.java
+++ b/src/main/java/hudson/plugins/emailext/groovy/sandbox/StaticProxyInstanceWhitelist.java
@@ -5,6 +5,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.logging.Logger;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.Whitelist;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.StaticWhitelist;
 
@@ -12,6 +14,9 @@ import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.StaticWhitelist;
  * {@link ObjectInstanceWhitelist} backed by a set of {@link StaticWhitelist}s.
  */
 public class StaticProxyInstanceWhitelist extends ObjectInstanceWhitelist<Object> {
+
+    private static final Logger LOGGER = Logger.getLogger(StaticProxyInstanceWhitelist.class.getName());
+
     private Whitelist[] proxies;
 
     public StaticProxyInstanceWhitelist(Object instance, @NonNull String... resources) throws IOException {
@@ -19,7 +24,11 @@ public class StaticProxyInstanceWhitelist extends ObjectInstanceWhitelist<Object
         proxies = new Whitelist[resources.length];
         for (int i = 0; i < resources.length; i++) {
             String resource = resources[i];
-            proxies[i] = StaticWhitelist.from(getClass().getResource(resource));
+            URL url = getClass().getResource(resource);
+            if (url == null) {
+                throw new IllegalArgumentException("Whitelist resource not found on classpath: " + resource);
+            }
+            proxies[i] = StaticWhitelist.from(url);
         }
     }
 
@@ -31,6 +40,8 @@ public class StaticProxyInstanceWhitelist extends ObjectInstanceWhitelist<Object
                     return true;
                 }
             }
+            LOGGER.fine(() -> "No proxy permitted method: " + method.getName() + " on "
+                    + receiver.getClass().getName());
         }
         return false;
     }
@@ -43,6 +54,8 @@ public class StaticProxyInstanceWhitelist extends ObjectInstanceWhitelist<Object
                     return true;
                 }
             }
+            LOGGER.fine(() -> "No proxy permitted field get: " + field.getName() + " on "
+                    + receiver.getClass().getName());
         }
         return false;
     }

--- a/src/test/java/hudson/plugins/emailext/groovy/sandbox/StaticProxyInstanceWhitelistTest.java
+++ b/src/test/java/hudson/plugins/emailext/groovy/sandbox/StaticProxyInstanceWhitelistTest.java
@@ -1,0 +1,91 @@
+package hudson.plugins.emailext.groovy.sandbox;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class StaticProxyInstanceWhitelistTest {
+
+    private Object instance;
+
+    @BeforeEach
+    void setUp() {
+        instance = new Object();
+    }
+
+    @Test
+    void constructorThrowsOnMissingResource() {
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> new StaticProxyInstanceWhitelist(instance, "/non/existent/resource.txt"));
+
+        assertTrue(
+                ex.getMessage().contains("/non/existent/resource.txt"),
+                "Exception message should mention the missing resource path");
+    }
+
+    @Test
+    void constructorThrowsOnOneOfMultipleMissingResources() {
+        // verifies the check works when multiple resources are passed
+        // and one of them is missing
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> new StaticProxyInstanceWhitelist(
+                        instance, "/non/existent/resource.txt", "/another/missing/resource.txt"));
+
+        assertTrue(
+                ex.getMessage().contains("not found on classpath"),
+                "Exception message should indicate the resource was not found");
+    }
+
+    @Test
+    void permitsMethodReturnsFalseForUnwhitelistedMethod() throws Exception {
+        // empty whitelist — no resources, so nothing is permitted
+        StaticProxyInstanceWhitelist whitelist = new StaticProxyInstanceWhitelist(instance);
+
+        Method method = String.class.getMethod("toString");
+
+        assertFalse(
+                whitelist.permitsMethod(method, instance, new Object[0]),
+                "permitsMethod should return false when no proxies permit it");
+    }
+
+    @Test
+    void permitsMethodReturnsFalseForWrongReceiver() throws Exception {
+        StaticProxyInstanceWhitelist whitelist = new StaticProxyInstanceWhitelist(instance);
+
+        Method method = String.class.getMethod("toString");
+        Object differentInstance = new Object();
+
+        assertFalse(
+                whitelist.permitsMethod(method, differentInstance, new Object[0]),
+                "permitsMethod should return false when receiver is not the whitelisted instance");
+    }
+
+    @Test
+    void permitsFieldGetReturnsFalseForUnwhitelistedField() throws Exception {
+        StaticProxyInstanceWhitelist whitelist = new StaticProxyInstanceWhitelist(instance);
+
+        Field field = String.class.getDeclaredField("value");
+
+        assertFalse(
+                whitelist.permitsFieldGet(field, instance),
+                "permitsFieldGet should return false when no proxies permit it");
+    }
+
+    @Test
+    void permitsFieldSetAlwaysReturnsFalse() throws Exception {
+        StaticProxyInstanceWhitelist whitelist = new StaticProxyInstanceWhitelist(instance);
+
+        Field field = String.class.getDeclaredField("value");
+
+        assertFalse(
+                whitelist.permitsFieldSet(field, instance, null),
+                "permitsFieldSet should always return false unconditionally");
+    }
+}

--- a/src/test/java/hudson/plugins/emailext/groovy/sandbox/StaticProxyInstanceWhitelistTest.java
+++ b/src/test/java/hudson/plugins/emailext/groovy/sandbox/StaticProxyInstanceWhitelistTest.java
@@ -37,15 +37,12 @@ class StaticProxyInstanceWhitelistTest {
     void constructorThrowsOnOneOfMultipleMissingResources() {
         IllegalArgumentException ex = assertThrows(
                 IllegalArgumentException.class,
-                () -> new StaticProxyInstanceWhitelist(instance,
-                        "test-whitelist.txt",
-                        "no/such/resource.txt"
-                )
-        );
+                () -> new StaticProxyInstanceWhitelist(instance, "test-whitelist.txt", "no/such/resource.txt"));
         assertTrue(
                 ex.getMessage().contains("no/such/resource.txt"),
                 "Exception message should mention the missing resource path");
     }
+
     @Test
     void permitsMethodReturnsFalseForUnwhitelistedMethod() throws Exception {
         // empty whitelist — no resources, so nothing is permitted

--- a/src/test/java/hudson/plugins/emailext/groovy/sandbox/StaticProxyInstanceWhitelistTest.java
+++ b/src/test/java/hudson/plugins/emailext/groovy/sandbox/StaticProxyInstanceWhitelistTest.java
@@ -11,6 +11,10 @@ import org.junit.jupiter.api.Test;
 
 class StaticProxyInstanceWhitelistTest {
 
+    private static class FieldHolder {
+        public String name;
+    }
+
     private Object instance;
 
     @BeforeEach
@@ -31,18 +35,17 @@ class StaticProxyInstanceWhitelistTest {
 
     @Test
     void constructorThrowsOnOneOfMultipleMissingResources() {
-        // verifies the check works when multiple resources are passed
-        // and one of them is missing
         IllegalArgumentException ex = assertThrows(
                 IllegalArgumentException.class,
-                () -> new StaticProxyInstanceWhitelist(
-                        instance, "/non/existent/resource.txt", "/another/missing/resource.txt"));
-
+                () -> new StaticProxyInstanceWhitelist(instance,
+                        "test-whitelist.txt",
+                        "no/such/resource.txt"
+                )
+        );
         assertTrue(
-                ex.getMessage().contains("not found on classpath"),
-                "Exception message should indicate the resource was not found");
+                ex.getMessage().contains("no/such/resource.txt"),
+                "Exception message should mention the missing resource path");
     }
-
     @Test
     void permitsMethodReturnsFalseForUnwhitelistedMethod() throws Exception {
         // empty whitelist — no resources, so nothing is permitted
@@ -71,7 +74,7 @@ class StaticProxyInstanceWhitelistTest {
     void permitsFieldGetReturnsFalseForUnwhitelistedField() throws Exception {
         StaticProxyInstanceWhitelist whitelist = new StaticProxyInstanceWhitelist(instance);
 
-        Field field = String.class.getDeclaredField("value");
+        Field field = FieldHolder.class.getDeclaredField("name");
 
         assertFalse(
                 whitelist.permitsFieldGet(field, instance),
@@ -82,7 +85,7 @@ class StaticProxyInstanceWhitelistTest {
     void permitsFieldSetAlwaysReturnsFalse() throws Exception {
         StaticProxyInstanceWhitelist whitelist = new StaticProxyInstanceWhitelist(instance);
 
-        Field field = String.class.getDeclaredField("value");
+        Field field = FieldHolder.class.getDeclaredField("name");
 
         assertFalse(
                 whitelist.permitsFieldSet(field, instance, null),

--- a/src/test/resources/hudson/plugins/emailext/groovy/sandbox/test-whitelist.txt
+++ b/src/test/resources/hudson/plugins/emailext/groovy/sandbox/test-whitelist.txt
@@ -1,0 +1,1 @@
+# empty test whitelist


### PR DESCRIPTION
Improve error handling and observability in `StaticProxyInstanceWhitelist`

Currently, `getClass().getResource(resource)` returns `null` silently when a 
classpath resource is missing. `StaticWhitelist.from(null)` then throws a 
`NullPointerException` with no indication of which resource was missing or why, 
making it difficult for developers and administrators to diagnose misconfiguration.

This PR adds a defensive null check with a descriptive `IllegalArgumentException` 
naming the missing resource path, and adds `FINE` level logging in `permitsMethod` 
and `permitsFieldGet` to help administrators understand which rules are being 
evaluated — without producing log spam in production (FINE is silent by default 
and can be enabled via Jenkins log configuration when needed).

### Testing done

Added 6 unit tests in `StaticProxyInstanceWhitelistTest` covering:
- Missing single resource throws `IllegalArgumentException` with the resource path in the message
- Missing resource among multiple resources is correctly caught
- `permitsMethod` returns false when no proxy permits the method
- `permitsMethod` returns false when the receiver is not the whitelisted instance
- `permitsFieldGet` returns false when no proxy permits the field
- `permitsFieldSet` always returns false unconditionally

All 6 tests pass locally:
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed