### PR TITLE
test: add unit tests for EmailThrottler

### DIFF
--- a/src/test/java/hudson/plugins/emailext/EmailThrottlerTest.java
+++ b/src/test/java/hudson/plugins/emailext/EmailThrottlerTest.java
@@ -1,0 +1,50 @@
+package hudson.plugins.emailext;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class EmailThrottlerTest {
+
+    private EmailThrottler throttler;
+
+    @BeforeEach
+    void setUp() {
+        throttler = new EmailThrottler();
+    }
+
+    @Test
+    void isThrottlingLimitNotExceededInitially() {
+        assertFalse(throttler.isThrottlingLimitExceeded());
+    }
+
+    @Test
+    void isThrottlingLimitExceededAfterLimit() {
+        for (int i = 0; i < EmailThrottler.THROTTLING_LIMIT; i++) {
+            throttler.incrementEmailCount();
+        }
+        assertTrue(throttler.isThrottlingLimitExceeded());
+    }
+
+    @Test
+    void resetEmailCountResetsCorrectly() {
+        for (int i = 0; i < EmailThrottler.THROTTLING_LIMIT; i++) {
+            throttler.incrementEmailCount();
+        }
+        assertTrue(throttler.isThrottlingLimitExceeded());
+        throttler.resetEmailCount();
+        assertFalse(throttler.isThrottlingLimitExceeded());
+    }
+
+    @Test
+    void getInstanceReturnsSameInstance() {
+        EmailThrottler instance1 = EmailThrottler.getInstance();
+        EmailThrottler instance2 = EmailThrottler.getInstance();
+        assertNotNull(instance1);
+        assertSame(instance1, instance2);
+    }
+}


### PR DESCRIPTION
### Summary
`EmailThrottler` is a singleton class responsible for rate limiting 
email sending in the plugin. Despite being a core utility class it 
had no test coverage. This PR adds unit tests to verify its behavior.

### Problem
Without tests, there is no automated verification that:
- The throttling limit works correctly
- The reset mechanism functions as expected
- The singleton pattern is properly enforced

Any future change to `EmailThrottler` could silently break these 
behaviors without being caught by CI.

### Changes
Added `EmailThrottlerTest.java` covering the following cases:
- Throttling limit is not exceeded initially (fresh instance)
- Throttling limit is exceeded after incrementing to the limit
- Reset correctly clears the email count
- Singleton pattern returns the same instance across calls

### Testing
All 4 tests passing locally. No functional changes test only.