### PR TITLE
test: add unit tests for EmailExtTemplateActionFactory

### DIFF
--- a/src/test/java/hudson/plugins/emailext/EmailExtTemplateActionFactoryTest.java
+++ b/src/test/java/hudson/plugins/emailext/EmailExtTemplateActionFactoryTest.java
@@ -1,0 +1,28 @@
+package hudson.plugins.emailext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import hudson.model.FreeStyleProject;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class EmailExtTemplateActionFactoryTest {
+
+    @Test
+    void testCreateForReturnsEmptyListWhenNoEmailExt(JenkinsRule j) throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject();
+        EmailExtTemplateActionFactory factory = new EmailExtTemplateActionFactory();
+        assertTrue(factory.createFor(project).isEmpty());
+    }
+
+    @Test
+    void testCreateForReturnsActionWhenEmailExtPresent(JenkinsRule j) throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject();
+        project.getPublishersList().add(new ExtendedEmailPublisher());
+        EmailExtTemplateActionFactory factory = new EmailExtTemplateActionFactory();
+        assertEquals(1, factory.createFor(project).size());
+    }
+}


### PR DESCRIPTION
### What was missing 

The EmailExtTemplateActionFactory is a core class in Jenkins that controls whether the "email template preview" action appears in the UI for a project. It checks if the project has the ExtendedEmailPublisher configured and based on that it either shows or hides the action. However this crucial functionality had no test coverage at all. Without tests any future changes to this logic could break the template preview feature without anyone noticing during continuous integration (CI).

### What the class does
The createFor() method is responsible for two things:

1) If the project has ExtendedEmailPublisher in its list of publishers it returns a list containing the EmailExtTemplateAction.

2) If the project doesn't have it configured it returns an empty list.

### What I added
I added two unit tests in the EmailExtTemplateActionFactoryTest class - 

1) testCreateForReturnsEmptyListWhenNoEmailExt - This test ensures that when a project doesn't have ExtendedEmailPublisher it returns an empty list.

2) testCreateForReturnsActionWhenEmailExtPresent-  This test checks that when ExtendedEmailPublisher is configured exactly one EmailExtTemplateAction is returned.

### Why this matters
Before these tests there was no automated check to ensure that the factory correctly adds the template preview action only when the email ext plugin is configured. These tests are important because they will help catch any issues if the factory logic is changed in the future ensuring that the behavior doesn't accidentally break.

### Tests

Tests run - 2
Failures - 0
Errors - 0