### PR TITLE
Add `EmailExtRecipientStep` test coverage for descriptor and pipeline recipient resolution

### DIFF
--- a/src/test/java/hudson/plugins/emailext/EmailExtRecipientStepTest.java
+++ b/src/test/java/hudson/plugins/emailext/EmailExtRecipientStepTest.java
@@ -9,8 +9,9 @@ import hudson.model.CauseAction;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.model.User;
 import hudson.plugins.emailext.plugins.recipients.RequesterRecipientProvider;
-import java.util.Collections;
+import hudson.tasks.Mailer;
 import java.util.Set;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -18,8 +19,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
-import hudson.model.User;
-import hudson.tasks.Mailer;
 
 /**
  * Tests the class {@link EmailExtRecipientStep}.
@@ -46,9 +45,8 @@ class EmailExtRecipientStepTest {
         assertTrue(requiredContext.contains(TaskListener.class));
         assertTrue(requiredContext.contains(EnvVars.class));
 
-        assertTrue(
-                descriptor.getRecipientProvidersDescriptors().stream()
-                        .anyMatch(d -> d instanceof RequesterRecipientProvider.DescriptorImpl));
+        assertTrue(descriptor.getRecipientProvidersDescriptors().stream()
+                .anyMatch(d -> d instanceof RequesterRecipientProvider.DescriptorImpl));
     }
 
     @Test
@@ -76,7 +74,8 @@ class EmailExtRecipientStepTest {
                         + " }",
                 true));
 
-        Run<?, ?> run = job.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause("kutzi"))).get();
+        Run<?, ?> run = job.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause("kutzi")))
+                .get();
         j.assertBuildStatusSuccess(run);
 
         String log = String.join("\n", run.getLog(2000));

--- a/src/test/java/hudson/plugins/emailext/EmailExtRecipientStepTest.java
+++ b/src/test/java/hudson/plugins/emailext/EmailExtRecipientStepTest.java
@@ -1,0 +1,86 @@
+package hudson.plugins.emailext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import hudson.EnvVars;
+import hudson.model.Cause;
+import hudson.model.CauseAction;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.emailext.plugins.recipients.RequesterRecipientProvider;
+import java.util.Collections;
+import java.util.Set;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import hudson.model.User;
+import hudson.tasks.Mailer;
+
+/**
+ * Tests the class {@link EmailExtRecipientStep}.
+ *
+ * @author Akash Manna
+ */
+@WithJenkins
+class EmailExtRecipientStepTest {
+
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule j) {
+        this.j = j;
+    }
+
+    @Test
+    void descriptorMetadata() {
+        EmailExtRecipientStep.DescriptorImpl descriptor = new EmailExtRecipientStep.DescriptorImpl();
+
+        assertEquals("emailextrecipients", descriptor.getFunctionName());
+        Set<? extends Class<?>> requiredContext = descriptor.getRequiredContext();
+        assertTrue(requiredContext.contains(Run.class));
+        assertTrue(requiredContext.contains(TaskListener.class));
+        assertTrue(requiredContext.contains(EnvVars.class));
+
+        assertTrue(
+                descriptor.getRecipientProvidersDescriptors().stream()
+                        .anyMatch(d -> d instanceof RequesterRecipientProvider.DescriptorImpl));
+    }
+
+    @Test
+    void failsWhenNoRecipientProviders() throws Exception {
+        WorkflowJob job = j.createProject(WorkflowJob.class, "wf-empty-providers");
+        job.setDefinition(new CpsFlowDefinition("node { emailextrecipients(recipientProviders: []) }", true));
+
+        Run<?, ?> run = job.scheduleBuild2(0).get();
+        j.assertBuildStatus(Result.FAILURE, run);
+        j.assertLogContains("You must provide at least one recipient provider", run);
+    }
+
+    @Test
+    void aggregatesRecipientsFromProviders() throws Exception {
+        WorkflowJob job = j.createProject(WorkflowJob.class, "wf-recipients");
+
+        User user = User.getById("kutzi", true);
+        user.setFullName("Christoph Kutzinski");
+        user.addProperty(new Mailer.UserProperty("kutzi@xxx.com"));
+
+        job.setDefinition(new CpsFlowDefinition(
+                "node { "
+                        + "def recipients = emailextrecipients([requestor()]); "
+                        + "echo \"RECIPS=${recipients}\""
+                        + " }",
+                true));
+
+        Run<?, ?> run = job.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause("kutzi"))).get();
+        j.assertBuildStatusSuccess(run);
+
+        String log = String.join("\n", run.getLog(2000));
+        assertTrue(log.contains("RECIPS="), "Pipeline should print resolved recipients");
+        assertTrue(log.contains("kutzi@xxx.com"), "Resolved recipients should include the triggering user");
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Add `EmailExtRecipientStep` test coverage for descriptor and pipeline recipient resolution

Tasks:
- Adds dedicated tests for EmailExtRecipientStep behavior.
- Covers descriptor metadata, empty provider validation, and end-to-end recipient resolution in a pipeline context.
- Improves confidence in the emailextrecipients step without changing production logic.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
