### PR TITLE
test: add unit tests for EmailExtensionPlugin static initializer

### DIFF
--- a/src/main/java/hudson/plugins/emailext/EmailExtensionPlugin.java
+++ b/src/main/java/hudson/plugins/emailext/EmailExtensionPlugin.java
@@ -37,6 +37,11 @@ import java.util.Arrays;
  */
 public class EmailExtensionPlugin extends Plugin {
     static {
+        initializeSendPartialProperties();
+    }
+
+    /** Package private for testing only. */
+    static void initializeSendPartialProperties() {
         for (String property : Arrays.asList("mail.smtp.sendpartial", "mail.smtps.sendpartial")) {
             if (System.getProperty(property) == null) {
                 System.setProperty(property, "true");

--- a/src/test/java/hudson/plugins/emailext/EmailExtensionPluginTest.java
+++ b/src/test/java/hudson/plugins/emailext/EmailExtensionPluginTest.java
@@ -1,0 +1,62 @@
+package hudson.plugins.emailext;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for {@link EmailExtensionPlugin}.
+ */
+class EmailExtensionPluginTest {
+
+    private String originalSmtp;
+    private String originalSmtps;
+
+    @BeforeEach
+    void setUp() {
+        originalSmtp = System.getProperty("mail.smtp.sendpartial");
+        originalSmtps = System.getProperty("mail.smtps.sendpartial");
+        System.clearProperty("mail.smtp.sendpartial");
+        System.clearProperty("mail.smtps.sendpartial");
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (originalSmtp != null) {
+            System.setProperty("mail.smtp.sendpartial", originalSmtp);
+        } else {
+            System.clearProperty("mail.smtp.sendpartial");
+        }
+        if (originalSmtps != null) {
+            System.setProperty("mail.smtps.sendpartial", originalSmtps);
+        } else {
+            System.clearProperty("mail.smtps.sendpartial");
+        }
+    }
+
+    /**
+     * Verifies that sendpartial properties are set to {@code true}
+     * when they are not already defined.
+     */
+    @Test
+    void whenPropertiesNotSet_shouldSetThemToTrue() {
+        EmailExtensionPlugin.initializeSendPartialProperties();
+        assertEquals("true", System.getProperty("mail.smtp.sendpartial"));
+        assertEquals("true", System.getProperty("mail.smtps.sendpartial"));
+    }
+
+    /**
+     * Verifies that pre-existing sendpartial property values
+     * are not overridden by the plugin initializer.
+     */
+    @Test
+    void whenPropertiesAlreadySet_shouldNotOverrideThem() {
+        System.setProperty("mail.smtp.sendpartial", "false");
+        System.setProperty("mail.smtps.sendpartial", "false");
+        EmailExtensionPlugin.initializeSendPartialProperties();
+        assertEquals("false", System.getProperty("mail.smtp.sendpartial"));
+        assertEquals("false", System.getProperty("mail.smtps.sendpartial"));
+    }
+}

--- a/src/test/java/hudson/plugins/emailext/EmailExtensionPluginTest.java
+++ b/src/test/java/hudson/plugins/emailext/EmailExtensionPluginTest.java
@@ -1,10 +1,10 @@
 package hudson.plugins.emailext;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit tests for {@link EmailExtensionPlugin}.

--- a/src/test/java/hudson/plugins/emailext/EmailExtensionPluginTest.java
+++ b/src/test/java/hudson/plugins/emailext/EmailExtensionPluginTest.java
@@ -59,4 +59,11 @@ class EmailExtensionPluginTest {
         assertEquals("false", System.getProperty("mail.smtp.sendpartial"));
         assertEquals("false", System.getProperty("mail.smtps.sendpartial"));
     }
+@Test
+    void whenOnlyOnePropertySet_shouldSetTheOther() {
+        System.setProperty("mail.smtp.sendpartial", "false");
+        EmailExtensionPlugin.initializeSendPartialProperties();
+        assertEquals("false", System.getProperty("mail.smtp.sendpartial"));
+        assertEquals("true", System.getProperty("mail.smtps.sendpartial"));
+    }
 }

--- a/src/test/java/hudson/plugins/emailext/EmailExtensionPluginTest.java
+++ b/src/test/java/hudson/plugins/emailext/EmailExtensionPluginTest.java
@@ -59,7 +59,8 @@ class EmailExtensionPluginTest {
         assertEquals("false", System.getProperty("mail.smtp.sendpartial"));
         assertEquals("false", System.getProperty("mail.smtps.sendpartial"));
     }
-@Test
+
+    @Test
     void whenOnlyOnePropertySet_shouldSetTheOther() {
         System.setProperty("mail.smtp.sendpartial", "false");
         EmailExtensionPlugin.initializeSendPartialProperties();


### PR DESCRIPTION
### Summary

So there’s a class called **EmailExtensionPlugin** and it has a static initializer block that takes care of setting two system properties **mail.smtp.sendpartial** and **mail.smtps.sendpartial** to **"true"**. But here’s the thing this block runs when the class is loaded and doesn't have any tests to verify its behavior.

### The Issue

The problem is that static initializers run only once when the class is first loaded which means we can’t directly test them. This left two important things untested:

1) Whether the properties are set to **"true"** if they weren’t already defined.

2) Whether the properties stay the same if they were already set to something else.

### What Was Done

To make things easier to test, I extracted the logic from the static initializer block into a separate static method called **initializeSendPartialProperties()**. This allows us to test the behavior without worrying about the class loading. The static block now simply calls this method so the production behavior remains the same.

I also created a new test class **EmailExtensionPluginTest** and added two test cases

1) **whenPropertiesNotSet_shouldSetThemToTrue** This test checks if the properties are set to **"true"** when they aren’t already defined.

2) **whenPropertiesAlreadySet_shouldNotOverrideThem** This one ensures that if the properties already have values they won’t get overwritten.

### Test Setup

To keep everything isolated I made sure to save and clear the properties before each test with **@BeforeEach** and then restore their original values afterward using **@AfterEach**. This ensures no tests interfere with each other and the changes are properly cleaned up.