### PR TITLE
Replace broad Exception catch with specific exceptions in renderTemplate

### DIFF
--- a/src/main/java/hudson/plugins/emailext/EmailExtTemplateAction.java
+++ b/src/main/java/hudson/plugins/emailext/EmailExtTemplateAction.java
@@ -15,17 +15,17 @@ import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collection;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
-import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 
 /**
  *
@@ -155,7 +155,7 @@ public class EmailExtTemplateAction implements Action {
             }
             result[1] = hudson.Util.xmlEscape(
                     stream.toString(ExtendedEmailPublisher.descriptor().getCharset()));
-       } catch (MacroEvaluationException ex) {
+        } catch (MacroEvaluationException ex) {
             result[0] = renderError(ex);
         } catch (UnsupportedEncodingException ex) {
             result[0] = renderError(ex);

--- a/src/main/java/hudson/plugins/emailext/EmailExtTemplateAction.java
+++ b/src/main/java/hudson/plugins/emailext/EmailExtTemplateAction.java
@@ -15,6 +15,7 @@ import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -24,6 +25,7 @@ import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
+import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 
 /**
  *
@@ -153,7 +155,14 @@ public class EmailExtTemplateAction implements Action {
             }
             result[1] = hudson.Util.xmlEscape(
                     stream.toString(ExtendedEmailPublisher.descriptor().getCharset()));
-        } catch (Exception ex) {
+       } catch (MacroEvaluationException ex) {
+            result[0] = renderError(ex);
+        } catch (UnsupportedEncodingException ex) {
+            result[0] = renderError(ex);
+        } catch (IOException ex) {
+            result[0] = renderError(ex);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
             result[0] = renderError(ex);
         }
         return result;


### PR DESCRIPTION
In the original **renderTemplate** method in EmailExtTemplateAction.java a broad catch (Exception ex) block was used which caught all exceptions without differentiating between various types of errors.

However certain methods, such as evaluate() on **JellyScriptContent** and **ScriptContent** can throw specific exceptions like **MacroEvaluationException** and **IOException.** Additionally calling **stream.toString()** can throw an **UnsupportedEncodingException**. These are distinct failure scenarios and it makes more sense to handle them separately rather than catching them all in one block.

To improve this the broad catch block has been replaced with specific exception handlers for

**1) MacroEvaluationException
2 ) UnsupportedEncodingException
3) IOException
4) InterruptedException**

For **InterruptedException** we now call **Thread.currentThread()**.interrupt() before handling the error. This restores the thread's interrupted status which is the recommended practice when catching and not rethrowing an **InterruptedException.**