### PR TITLE
fix: replace broad Exception catch with specific exceptions in ContentBuilder.transformText()

### DIFF
--- a/src/main/java/hudson/plugins/emailext/plugins/ContentBuilder.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/ContentBuilder.java
@@ -7,7 +7,6 @@ import hudson.model.BuildListener;
 import hudson.plugins.emailext.ExtendedEmailPublisher;
 import hudson.plugins.emailext.ExtendedEmailPublisherContext;
 import hudson.tasks.Publisher;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;

--- a/src/main/java/hudson/plugins/emailext/plugins/ContentBuilder.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/ContentBuilder.java
@@ -7,6 +7,7 @@ import hudson.model.BuildListener;
 import hudson.plugins.emailext.ExtendedEmailPublisher;
 import hudson.plugins.emailext.ExtendedEmailPublisherContext;
 import hudson.tasks.Publisher;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -92,7 +93,10 @@ public final class ContentBuilder {
             }
         } catch (MacroEvaluationException e) {
             context.getListener().getLogger().println("Error evaluating token: " + e.getMessage());
-        } catch (Exception e) {
+        } catch (IOException e) {
+            Logger.getLogger(ContentBuilder.class.getName()).log(Level.SEVERE, null, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             Logger.getLogger(ContentBuilder.class.getName()).log(Level.SEVERE, null, e);
         }
         return newText != null ? newText.trim() : "";

--- a/src/main/java/hudson/plugins/emailext/plugins/ContentBuilder.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/ContentBuilder.java
@@ -7,6 +7,7 @@ import hudson.model.BuildListener;
 import hudson.plugins.emailext.ExtendedEmailPublisher;
 import hudson.plugins.emailext.ExtendedEmailPublisherContext;
 import hudson.tasks.Publisher;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -92,7 +93,10 @@ public final class ContentBuilder {
             }
         } catch (MacroEvaluationException e) {
             context.getListener().getLogger().println("Error evaluating token: " + e.getMessage());
-        } catch (Exception e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            Logger.getLogger(ContentBuilder.class.getName()).log(Level.SEVERE, null, e);
+        } catch (IOException e) {
             Logger.getLogger(ContentBuilder.class.getName()).log(Level.SEVERE, null, e);
         }
         return newText != null ? newText.trim() : "";


### PR DESCRIPTION
In the transformText method in ContentBuilder.java, there was originally a broad catch block that was catching every exception after the call to TokenMacro.expandAll. The issue with this approach is that it didn't differentiate between different types of errors. Since TokenMacro.expandAll can throw specific exceptions like IOException and InterruptedException it’s more logical to handle them separately based on the type of error that occurred.

So the broad catch block has been replaced with specific handlers

1) IOException: This handles any issues related to input and output operations.

2) InterruptedException: In this case the code now calls Thread.currentThread().interrupt() before logging the error. This is the recommended approach when catching an InterruptedException and not rethrowing it as it ensures that the interrupt flag is properly set.