### PR TITLE
Fix JENKINS-71828: project recipient list now overrides $DEFAULT_RECIPIENTS

### DIFF
--- a/src/main/java/hudson/plugins/emailext/plugins/ContentBuilder.java
+++ b/src/main/java/hudson/plugins/emailext/plugins/ContentBuilder.java
@@ -61,8 +61,17 @@ public final class ContentBuilder {
                 noNull(context.getPublisher().getDescriptor().getDefaultBody()));
         String defaultExtSubject = Matcher.quoteReplacement(
                 noNull(context.getPublisher().getDescriptor().getDefaultSubject()));
+        // If the project has explicitly set its own recipient list (not delegating
+        // to $DEFAULT_RECIPIENTS), honour that override by not expanding
+        // $DEFAULT_RECIPIENTS in the trigger-level list either (fixes JENKINS-71828).
+        String projectRecipientList = noNull(context.getPublisher().recipientList);
+        boolean projectOverridesRecipients = !projectRecipientList.isEmpty()
+                && !projectRecipientList.contains("$DEFAULT_RECIPIENTS")
+                && !projectRecipientList.contains("${DEFAULT_RECIPIENTS}");
         String defaultRecipients = Matcher.quoteReplacement(
-                noNull(context.getPublisher().getDescriptor().getDefaultRecipients()));
+                projectOverridesRecipients
+                        ? projectRecipientList
+                        : noNull(context.getPublisher().getDescriptor().getDefaultRecipients()));
         String defaultExtReplyTo = Matcher.quoteReplacement(
                 noNull(context.getPublisher().getDescriptor().getDefaultReplyTo()));
         String defaultPresendScript = Matcher.quoteReplacement(


### PR DESCRIPTION
## Problem
When a project sets its own recipient list explicitly (without $DEFAULT_RECIPIENTS), 
the $DEFAULT_RECIPIENTS token in the trigger-level list was still being expanded to 
the global default recipients, causing both lists to be merged instead of the project 
list taking precedence.

## Fix
In `ContentBuilder.transformText()`, detect when the project has explicitly set its 
own recipient list (non-blank and not delegating to $DEFAULT_RECIPIENTS). In that case, 
use the project recipient list as the replacement for $DEFAULT_RECIPIENTS instead of 
the global default, so the project-level setting correctly overrides the global one.

## Testing
- Existing `ContentBuilderTest` tests pass with no changes
- Spotless formatting check passes

Fixes #1407