### PR TITLE
Fix JENKINS-68518: retry email send on transient SMTP 4xx errors

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisher.java
@@ -527,6 +527,23 @@ public class ExtendedEmailPublisher extends Notifier {
         return true;
     }
 
+    /**
+     * Returns true if the SMTP error is transient (4xx response code) and the
+     * send should be retried (fixes JENKINS-68518).
+     */
+    private static boolean isTransientSmtpError(Exception e) {
+        String msg = e.getMessage();
+        if (msg == null) {
+            return false;
+        }
+        // SMTP 4xx codes indicate transient server-side failures
+        return msg.matches("^4\\d\\d.*")
+                || msg.contains("421")
+                || msg.contains("450")
+                || msg.contains("451")
+                || msg.contains("452");
+    }
+
     @SuppressFBWarnings("REC_CATCH_EXCEPTION")
     boolean sendMail(ExtendedEmailPublisherContext context) {
         try {
@@ -620,6 +637,13 @@ public class ExtendedEmailPublisher extends Notifier {
                                         .println("Socket error sending email, retrying once more in 10 seconds...");
                                 transport.close();
                                 Thread.sleep(10000);
+                            } else if (isTransientSmtpError(e)) {
+                                context.getListener()
+                                        .getLogger()
+                                        .println(
+                                                "Transient SMTP error sending email, retrying once more in 10 seconds...");
+                                transport.close();
+                                Thread.sleep(10000);
                             } else {
                                 Address[] addresses = e.getValidSentAddresses();
                                 if (addresses != null && addresses.length > 0) {
@@ -669,6 +693,13 @@ public class ExtendedEmailPublisher extends Notifier {
                                         .getLogger()
                                         .println(
                                                 "SMTP connection error while sending email. Retrying once more in 10 seconds.");
+                                transport.close();
+                                Thread.sleep(10000);
+                            } else if (isTransientSmtpError(e)) {
+                                context.getListener()
+                                        .getLogger()
+                                        .println(
+                                                "Transient SMTP error while sending email. Retrying once more in 10 seconds.");
                                 transport.close();
                                 Thread.sleep(10000);
                             } else {


### PR DESCRIPTION
## Problem
Transient SMTP errors (4xx response codes like 421, 450, 451, 452) were 
treated as fatal, causing email sends to fail permanently when the SMTP 
server was temporarily unavailable or rate-limiting.

Only `SocketException` and `ConnectException` triggered a retry. All 
other `MessagingException` types broke immediately.

## Fix
Added `isTransientSmtpError()` helper that detects SMTP 4xx response 
codes in the exception message. Both the `SendFailedException` and 
`MessagingException` catch blocks now retry on transient errors, 
consistent with existing socket error retry behavior.

## Testing
- All existing `ExtendedEmailPublisherTest` tests pass
- Spotless formatting check passes

Fixes #1380