### PR TITLE
restore ACL.SYSTEM for credential lookup in config page

### DIFF
--- a/src/main/java/hudson/plugins/emailext/MailAccount.java
+++ b/src/main/java/hudson/plugins/emailext/MailAccount.java
@@ -126,7 +126,7 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount> {
             }
             return result.includeEmptyValue()
                     .includeMatchingAs(
-                            item instanceof Queue.Task t ? Tasks.getAuthenticationOf(t) : Jenkins.getAuthentication(),
+                            item instanceof Queue.Task t ? Tasks.getAuthenticationOf2(t) : ACL.SYSTEM2,
                             item,
                             StandardUsernamePasswordCredentials.class,
                             Collections.emptyList(),
@@ -167,10 +167,10 @@ public class MailAccount extends AbstractDescribableImpl<MailAccount> {
                 }
             }
 
-            if (CredentialsProvider.listCredentials(
+            if (CredentialsProvider.listCredentialsInItem(
                             StandardUsernamePasswordCredentials.class,
                             item,
-                            item instanceof Queue.Task t ? Tasks.getAuthenticationOf(t) : Jenkins.getAuthentication(),
+                            item instanceof Queue.Task t ? Tasks.getAuthenticationOf2(t) : ACL.SYSTEM2,
                             null,
                             CredentialsMatchers.withId(value))
                     .isEmpty()) {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

PR #1494 replaced ACL.SYSTEM with Jenkins.getAuthentication() citing deprecation, but this broke credentials lookup on the config page where item is null as there is no job/pipeline context.

When item is null, Jenkins.getAuthentication() returns the current user's auth token which has no ItemGroup context, causing includeMatchingAs and listCredentials to return no credentials even for admin users, causing the credentials dropdown to appear empty.

Rather than reverting to the deprecated ACL.SYSTEM, this PR uses ACL.SYSTEM2, and has a few tweaks to support the same.

### Testing done
Tested on the system config page with credentials added under global scope. previously credentials weren't appearing and now the dropdown is populated properly. all tests are passing as well.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
