### PR TITLE
Stream build log attachment instead of buffering entire content in memory

### DIFF
--- a/src/main/java/hudson/plugins/emailext/AttachmentUtils.java
+++ b/src/main/java/hudson/plugins/emailext/AttachmentUtils.java
@@ -111,7 +111,9 @@ public class AttachmentUtils implements Serializable {
                         try (out) {
                             long logFileLength = run.getLogText().length();
                             long pos = 0;
-                            pos = run.getLogText().writeLogTo(pos, out);
+                            while (pos < logFileLength) {
+                                pos = run.getLogText().writeLogTo(pos, out);
+                            }
                         } catch (IOException e) {
                             LOGGER.log(Level.FINE, "Error streaming build log", e);
                         }

--- a/src/main/java/hudson/plugins/emailext/AttachmentUtils.java
+++ b/src/main/java/hudson/plugins/emailext/AttachmentUtils.java
@@ -115,10 +115,10 @@ public class AttachmentUtils implements Serializable {
                                 pos = run.getLogText().writeLogTo(pos, out);
                             }
                         } catch (IOException e) {
-                            LOGGER.log(Level.FINE, "Error streaming build log", e);
+                            LOGGER.log(Level.WARNING, "Error streaming build log", e);
                         }
                     },
-                    "email-ext-log-writer-" + run.getFullDisplayName());
+                    "email-ext-log-writer-" + run.getNumber());
             writer.setDaemon(true);
             writer.start();
 

--- a/src/main/java/hudson/plugins/emailext/AttachmentUtils.java
+++ b/src/main/java/hudson/plugins/emailext/AttachmentUtils.java
@@ -18,15 +18,17 @@ import jakarta.mail.Multipart;
 import jakarta.mail.Part;
 import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeUtility;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.variant.OptionalExtension;
 
@@ -35,6 +37,8 @@ import org.jenkinsci.plugins.variant.OptionalExtension;
  *
  */
 public class AttachmentUtils implements Serializable {
+
+    private static final Logger LOGGER = Logger.getLogger(AttachmentUtils.class.getName());
 
     @Serial
     private static final long serialVersionUID = 1L;
@@ -99,17 +103,24 @@ public class AttachmentUtils implements Serializable {
 
         @Override
         public InputStream getInputStream() throws IOException {
-            InputStream res;
-            long logFileLength = run.getLogText().length();
-            long pos = 0;
-            ByteArrayOutputStream bao = new ByteArrayOutputStream();
+            PipedInputStream in = new PipedInputStream(65536);
+            PipedOutputStream out = new PipedOutputStream(in);
 
-            while (pos < logFileLength) {
-                pos = run.getLogText().writeLogTo(pos, bao);
-            }
+            Thread writer = new Thread(
+                    () -> {
+                        try (out) {
+                            long logFileLength = run.getLogText().length();
+                            long pos = 0;
+                                pos = run.getLogText().writeLogTo(pos, out);
+                        } catch (IOException e) {
+                            LOGGER.log(Level.FINE, "Error streaming build log", e);
+                        }
+                    },
+                    "email-ext-log-writer-" + run.getFullDisplayName());
+            writer.setDaemon(true);
+            writer.start();
 
-            res = new ByteArrayInputStream(bao.toByteArray());
-            return res;
+            return in;
         }
 
         @Override

--- a/src/main/java/hudson/plugins/emailext/AttachmentUtils.java
+++ b/src/main/java/hudson/plugins/emailext/AttachmentUtils.java
@@ -113,9 +113,11 @@ public class AttachmentUtils implements Serializable {
                             long pos = 0;
                             while (pos < logFileLength) {
                                 pos = run.getLogText().writeLogTo(pos, out);
-                            }
+                            }q
                         } catch (IOException e) {
-                            LOGGER.log(Level.WARNING, "Error streaming build log", e);
+                            // Any IOException here is pipe-related (reader closed or died)
+                            // a genuine read error surfaces to the caller via PipedInputStream
+                            LOGGER.log(Level.FINE, "Stopped streaming build log", e);
                         }
                     },
                     "email-ext-log-writer-" + run.getNumber());

--- a/src/main/java/hudson/plugins/emailext/AttachmentUtils.java
+++ b/src/main/java/hudson/plugins/emailext/AttachmentUtils.java
@@ -111,7 +111,7 @@ public class AttachmentUtils implements Serializable {
                         try (out) {
                             long logFileLength = run.getLogText().length();
                             long pos = 0;
-                                pos = run.getLogText().writeLogTo(pos, out);
+                            pos = run.getLogText().writeLogTo(pos, out);
                         } catch (IOException e) {
                             LOGGER.log(Level.FINE, "Error streaming build log", e);
                         }

--- a/src/main/java/hudson/plugins/emailext/AttachmentUtils.java
+++ b/src/main/java/hudson/plugins/emailext/AttachmentUtils.java
@@ -113,7 +113,7 @@ public class AttachmentUtils implements Serializable {
                             long pos = 0;
                             while (pos < logFileLength) {
                                 pos = run.getLogText().writeLogTo(pos, out);
-                            }q
+                            }
                         } catch (IOException e) {
                             // Any IOException here is pipe-related (reader closed or died)
                             // a genuine read error surfaces to the caller via PipedInputStream

--- a/src/test/java/hudson/plugins/emailext/AttachmentUtilsOomTest.java
+++ b/src/test/java/hudson/plugins/emailext/AttachmentUtilsOomTest.java
@@ -1,0 +1,55 @@
+package hudson.plugins.emailext;
+
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleProject;
+import hudson.plugins.emailext.plugins.recipients.ListRecipientProvider;
+import hudson.plugins.emailext.plugins.trigger.SuccessTrigger;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestBuilder;
+import org.jvnet.hudson.test.junit.jupiter.RealJenkinsExtension;
+
+class AttachmentUtilsOomTest {
+
+    @RegisterExtension
+    static final RealJenkinsExtension rj = new RealJenkinsExtension().javaOptions("-Xmx256m");
+
+    @Test
+    void largeBuildLogDoesNotExhaustMemory() throws Throwable {
+        rj.then(AttachmentUtilsOomTest::_largeBuildLogDoesNotExhaustMemory);
+    }
+
+    public static final class LargeLogBuilder extends TestBuilder {
+        @Override
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
+            String line = "The sky above the port was the color of television tuned to a dead channel.";
+            int iterations = (150 * 1024 * 1024) / line.length();
+            for (int i = 0; i < iterations; i++) {
+                listener.getLogger().println(line);
+            }
+            return true;
+        }
+    }
+
+    private static void _largeBuildLogDoesNotExhaustMemory(JenkinsRule r) throws Exception {
+        FreeStyleProject project = r.createFreeStyleProject("large-log");
+        ExtendedEmailPublisher publisher = new ExtendedEmailPublisher();
+        publisher.attachBuildLog = true;
+        publisher.compressBuildLog = true;
+        publisher.recipientList = "morgan@blackhand.com";
+        SuccessTrigger trigger = new SuccessTrigger(
+                Collections.singletonList(new ListRecipientProvider()), "", "", "", "", "", 0, "project");
+        publisher.getConfiguredTriggers().add(trigger);
+        project.getPublishersList().add(publisher);
+        project.getBuildersList().add(new LargeLogBuilder());
+
+        // Without the streaming fix, getInputStream() buffers the entire log in a ByteArrayOutputStream
+        // causing an OutOfMemoryError at -Xmx256m. The streaming fix reads through a 64KB pipe
+        // buffer so this completes without exhausting the heap.
+        r.buildAndAssertSuccess(project);
+    }
+}

--- a/src/test/java/hudson/plugins/emailext/AttachmentUtilsTest.java
+++ b/src/test/java/hudson/plugins/emailext/AttachmentUtilsTest.java
@@ -150,49 +150,6 @@ class AttachmentUtilsTest {
                 containsString("build.log")); // zips have plain text filename in them
     }
 
-    // To verify this test actually catches the regression, run with -Xmx128m
-    // Without a heap limit the default JVM heap is large enough that the OOM may not trigger
-    @Test
-    void testLargeBuildLogDoesNotExhaustMemory() throws Exception {
-        FreeStyleProject project = j.createFreeStyleProject("large-log");
-        ExtendedEmailPublisher publisher = new ExtendedEmailPublisher();
-        publisher.attachBuildLog = true;
-        publisher.compressBuildLog = true;
-        publisher.recipientList = "morgan@blackhand.com";
-        SuccessTrigger trigger = new SuccessTrigger(
-                Collections.singletonList(new ListRecipientProvider()), "", "", "", "", "", 0, "project");
-        publisher.getConfiguredTriggers().add(trigger);
-        project.getPublishersList().add(publisher);
-        project.getBuildersList().add(new TestBuilder() {
-            @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
-                // Generate ~50MB of console output which is enough to OOM a ByteArrayOutputStream
-                // on a test JVM but fine when streamed
-                String line = "The sky above the port was the color of television tuned to a dead channel.";
-                int iterations = (50 * 1024 * 1024) / line.length();
-                for (int i = 0; i < iterations; i++) {
-                    listener.getLogger().println(line);
-                }
-                return true;
-            }
-        });
-
-        FreeStyleBuild b = j.buildAndAssertSuccess(project);
-
-        Mailbox mbox = Mailbox.get("morgan@blackhand.com");
-        assertEquals(1, mbox.size(), "Should have an email from success");
-
-        Message msg = mbox.get(0);
-        assertThat(msg.getContent(), instanceOf(MimeMultipart.class));
-
-        MimeMultipart part = (MimeMultipart) msg.getContent();
-        assertEquals(2, part.getCount(), "Should have two body items (message + attachment)");
-
-        BodyPart attach = part.getBodyPart(1);
-        assertEquals("build.zip", attach.getFileName());
-        assertThat(attach.getSize(), greaterThan(0));
-    }
-
     @Test
     void testAttachmentFromWorkspace() throws Exception {
         URL url = this.getClass().getResource("/test.pdf");

--- a/src/test/java/hudson/plugins/emailext/AttachmentUtilsTest.java
+++ b/src/test/java/hudson/plugins/emailext/AttachmentUtilsTest.java
@@ -150,6 +150,8 @@ class AttachmentUtilsTest {
                 containsString("build.log")); // zips have plain text filename in them
     }
 
+    // To verify this test actually catches the regression, run with -Xmx128m
+    // Without a heap limit the default JVM heap is large enough that the OOM may not trigger
     @Test
     void testLargeBuildLogDoesNotExhaustMemory() throws Exception {
         FreeStyleProject project = j.createFreeStyleProject("large-log");

--- a/src/test/java/hudson/plugins/emailext/AttachmentUtilsTest.java
+++ b/src/test/java/hudson/plugins/emailext/AttachmentUtilsTest.java
@@ -151,6 +151,47 @@ class AttachmentUtilsTest {
     }
 
     @Test
+    void testLargeBuildLogDoesNotExhaustMemory() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject("large-log");
+        ExtendedEmailPublisher publisher = new ExtendedEmailPublisher();
+        publisher.attachBuildLog = true;
+        publisher.compressBuildLog = true;
+        publisher.recipientList = "morgan@blackhand.com";
+        SuccessTrigger trigger = new SuccessTrigger(
+                Collections.singletonList(new ListRecipientProvider()), "", "", "", "", "", 0, "project");
+        publisher.getConfiguredTriggers().add(trigger);
+        project.getPublishersList().add(publisher);
+        project.getBuildersList().add(new TestBuilder() {
+            @Override
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
+                // Generate ~50MB of console output which is enough to OOM a ByteArrayOutputStream
+                // on a test JVM but fine when streamed
+                String line = "The sky above the port was the color of television tuned to a dead channel.";
+                int iterations = (50 * 1024 * 1024) / line.length();
+                for (int i = 0; i < iterations; i++) {
+                    listener.getLogger().println(line);
+                }
+                return true;
+            }
+        });
+
+        FreeStyleBuild b = j.buildAndAssertSuccess(project);
+
+        Mailbox mbox = Mailbox.get("morgan@blackhand.com");
+        assertEquals(1, mbox.size(), "Should have an email from success");
+
+        Message msg = mbox.get(0);
+        assertThat(msg.getContent(), instanceOf(MimeMultipart.class));
+
+        MimeMultipart part = (MimeMultipart) msg.getContent();
+        assertEquals(2, part.getCount(), "Should have two body items (message + attachment)");
+
+        BodyPart attach = part.getBodyPart(1);
+        assertEquals("build.zip", attach.getFileName());
+        assertThat(attach.getSize(), greaterThan(0));
+    }
+
+    @Test
     void testAttachmentFromWorkspace() throws Exception {
         URL url = this.getClass().getResource("/test.pdf");
         final File attachment = new File(url.getFile());


### PR DESCRIPTION
`LogFileDataSource.getInputStream()` buffers the entire console log into a `ByteArrayOutputStream` before returning it, causing `OutOfMemoryError` on large logs regardless of `maxAttachmentSize` configuration. 

<!-- Please describe your pull request here. -->

### Testing done
Added unit tests which OOM without the fix.
Tested in a jenkins instance which shows no OOM after the fix

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
