### PR TITLE
add Test Oauth2 Credentials class for unit/integration tests

### DIFF
--- a/src/test/java/hudson/plugins/emailext/MailAccountTest.java
+++ b/src/test/java/hudson/plugins/emailext/MailAccountTest.java
@@ -12,8 +12,10 @@ import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.plugins.emailext.MailAccount.MailAccountDescriptor;
+import hudson.security.ACL;
 import hudson.util.FormValidation.Kind;
 import hudson.util.Secret;
+import java.util.Collections;
 import java.util.List;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
@@ -25,6 +27,37 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
 class MailAccountTest {
+
+    @Test
+    void testCanStoreAndResolveTestOAuthCredential(JenkinsRule j) {
+        final String credentialId = "test-oauth-id";
+        final String tokenValue = "test-access-token";
+
+        TestOAuth2CredentialsImpl credential = new TestOAuth2CredentialsImpl(
+                CredentialsScope.GLOBAL, credentialId, "test oauth credential", "oauth-user", tokenValue);
+        SystemCredentialsProvider.getInstance().getCredentials().add(credential);
+
+        List<TestOAuth2CredentialsImpl> credentials = CredentialsProvider.lookupCredentialsInItemGroup(
+                TestOAuth2CredentialsImpl.class, j.jenkins, ACL.SYSTEM2, Collections.emptyList());
+        assertEquals(1, credentials.size());
+        TestOAuth2CredentialsImpl resolved = credentials.get(0);
+        assertEquals(credentialId, resolved.getId());
+        assertEquals("oauth-user", resolved.getUsername());
+        assertEquals(
+                tokenValue,
+                resolved.getAccessToken(new TestOAuth2CredentialsImpl.TestOAuth2Requirement())
+                        .getPlainText());
+
+        TestOAuth2CredentialsImpl byId = CredentialsProvider.findCredentialByIdInItemGroup(
+                credentialId, TestOAuth2CredentialsImpl.class, j.jenkins, ACL.SYSTEM2, Collections.emptyList());
+        assertNotNull(byId);
+        assertEquals(
+                tokenValue,
+                byId.getAccessToken(new TestOAuth2CredentialsImpl.TestOAuth2Requirement())
+                        .getPlainText());
+
+        assertEquals("Test OAuth2 Credentials", byId.getDescriptor().getDisplayName());
+    }
 
     @Test
     @WithoutJenkins

--- a/src/test/java/hudson/plugins/emailext/TestOAuth2CredentialsImpl.java
+++ b/src/test/java/hudson/plugins/emailext/TestOAuth2CredentialsImpl.java
@@ -1,0 +1,62 @@
+package hudson.plugins.emailext;
+
+import com.cloudbees.plugins.credentials.CredentialsDescriptor;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import com.google.jenkins.plugins.credentials.oauth.OAuth2ScopeRequirement;
+import com.google.jenkins.plugins.credentials.oauth.StandardUsernameOAuth2Credentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.util.Secret;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Test implementation of OAuth2 credentials for testing OAuth SMTP authentication.
+ * This is a test-only utility class.
+ */
+public final class TestOAuth2CredentialsImpl extends BaseStandardCredentials
+        implements StandardUsernameOAuth2Credentials<TestOAuth2CredentialsImpl.TestOAuth2Requirement> {
+
+    private final String username;
+    private final Secret accessToken;
+
+    public TestOAuth2CredentialsImpl(
+            CredentialsScope scope, String id, String description, String username, String token) {
+        super(scope, id, description);
+        this.username = username;
+        this.accessToken = Secret.fromString(token);
+    }
+
+    @Override
+    @NonNull
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public Secret getAccessToken(TestOAuth2Requirement requirement) {
+        return accessToken;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends CredentialsDescriptor {
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return "Test OAuth2 Credentials";
+        }
+    }
+
+    /**
+     * OAuth2 scope requirement for SMTP token requests.
+     */
+    public static final class TestOAuth2Requirement extends OAuth2ScopeRequirement {
+        private static final Collection<String> SCOPES = Collections.singleton("smtp.send");
+
+        @Override
+        public Collection<String> getScopes() {
+            return SCOPES;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Adds a test only implementation of an Oauth2 credential that Jenkins tests can use to verify behavior.  The class mirrors the structure of existing provider implementations, and has a test OAuth2ScopeRequirement in case scope behavior might need to be tested.
This class can be used for credential discovery and lookup, exercising code paths that request an access token, and validating OAuth UI, etc

Added a small integration test to verify the test credential can be properly registered through the credential API since I'm planning on reusing it for subsequent OAuth related tests
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
