### PR TITLE
Add single attempt retry logic to authenticator

### DIFF
--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -224,52 +224,65 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
                     }
 
                     String address = acc.isDefaultAccount() ? getAdminAddress() : acc.getAddress();
+                    final int TOKEN_ATTEMPTS = 2;
+                    final long RETRY_DELAY_MS = 2000;
 
                     if (c instanceof GoogleRobotPrivateKeyCredentials googleCred) {
                         GoogleCredential credential = googleCred
                                 .getGoogleCredential(new MailScopeRequirement())
                                 .createDelegated(address);
 
-                        try {
-                            credential.refreshToken();
-                        } catch (IOException e) {
-                            LOGGER.log(Level.WARNING, "Failed to obtain access token, retrying once.", e);
-
-                            try {
-                                Thread.sleep(2000);
-                            } catch (InterruptedException ie) {
-                                Thread.currentThread().interrupt();
-                                return null;
-                            }
-
+                        String token = null;
+                        for (int attempt = 1; attempt <= TOKEN_ATTEMPTS && token == null; attempt++) {
                             try {
                                 credential.refreshToken();
-                            } catch (IOException re) {
-                                LOGGER.log(Level.WARNING, "Failed to obtain access token after retry.", re);
-                                return null;
+                                token = credential.getAccessToken();
+                            } catch (IOException e) {
+                                LOGGER.log(
+                                        Level.WARNING,
+                                        "Failed to obtain Google OAuth access token"
+                                                + (attempt == 1 ? ", retrying once." : " after retry."),
+                                        e);
+
+                                if (attempt == TOKEN_ATTEMPTS) {
+                                    return null;
+                                }
+
+                                try {
+                                    Thread.sleep(RETRY_DELAY_MS);
+                                } catch (InterruptedException ie) {
+                                    Thread.currentThread().interrupt();
+                                    return null;
+                                }
                             }
                         }
-
-                        String token = credential.getAccessToken();
 
                         return new PasswordAuthentication(address, token);
                     }
 
                     if (c instanceof EntraOAuthCredentials entraCred) {
-                        Secret tokenSecret = entraCred.getAccessToken(null);
+                        Secret tokenSecret = null;
 
-                        if (tokenSecret == null) {
-                            LOGGER.log(Level.WARNING, "Failed to obtain access token, retrying once.");
-                            try {
-                                Thread.sleep(2000);
-                            } catch (InterruptedException e) {
-                                Thread.currentThread().interrupt();
-                                return null;
-                            }
+                        for (int attempt = 1; attempt <= TOKEN_ATTEMPTS && tokenSecret == null; attempt++) {
+
                             tokenSecret = entraCred.getAccessToken(null);
+
                             if (tokenSecret == null) {
-                                LOGGER.log(Level.WARNING, "Failed to obtain access token after retry.");
-                                return null;
+                                LOGGER.log(
+                                        Level.WARNING,
+                                        "Failed to obtain Entra OAuth access token"
+                                                + (attempt == 1 ? ", retrying once." : " after retry."));
+
+                                if (attempt == TOKEN_ATTEMPTS) {
+                                    return null;
+                                }
+
+                                try {
+                                    Thread.sleep(RETRY_DELAY_MS);
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                    return null;
+                                }
                             }
                         }
 

--- a/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
+++ b/src/main/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptor.java
@@ -223,25 +223,57 @@ public final class ExtendedEmailPublisherDescriptor extends BuildStepDescriptor<
                         return null;
                     }
 
+                    String address = acc.isDefaultAccount() ? getAdminAddress() : acc.getAddress();
+
                     if (c instanceof GoogleRobotPrivateKeyCredentials googleCred) {
                         GoogleCredential credential = googleCred
                                 .getGoogleCredential(new MailScopeRequirement())
-                                .createDelegated(acc.isDefaultAccount() ? getAdminAddress() : acc.getAddress());
+                                .createDelegated(address);
+
                         try {
                             credential.refreshToken();
                         } catch (IOException e) {
-                            LOGGER.log(Level.WARNING, "Failed to obtain access token.", e);
-                            return null;
+                            LOGGER.log(Level.WARNING, "Failed to obtain access token, retrying once.", e);
+
+                            try {
+                                Thread.sleep(2000);
+                            } catch (InterruptedException ie) {
+                                Thread.currentThread().interrupt();
+                                return null;
+                            }
+
+                            try {
+                                credential.refreshToken();
+                            } catch (IOException re) {
+                                LOGGER.log(Level.WARNING, "Failed to obtain access token after retry.", re);
+                                return null;
+                            }
                         }
+
                         String token = credential.getAccessToken();
-                        return new PasswordAuthentication(
-                                acc.isDefaultAccount() ? getAdminAddress() : acc.getAddress(), token);
+
+                        return new PasswordAuthentication(address, token);
                     }
 
                     if (c instanceof EntraOAuthCredentials entraCred) {
-                        return new PasswordAuthentication(
-                                acc.isDefaultAccount() ? getAdminAddress() : acc.getAddress(),
-                                Secret.toString(entraCred.getAccessToken(null)));
+                        Secret tokenSecret = entraCred.getAccessToken(null);
+
+                        if (tokenSecret == null) {
+                            LOGGER.log(Level.WARNING, "Failed to obtain access token, retrying once.");
+                            try {
+                                Thread.sleep(2000);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                return null;
+                            }
+                            tokenSecret = entraCred.getAccessToken(null);
+                            if (tokenSecret == null) {
+                                LOGGER.log(Level.WARNING, "Failed to obtain access token after retry.");
+                                return null;
+                            }
+                        }
+
+                        return new PasswordAuthentication(address, Secret.toString(tokenSecret));
                     }
 
                     // maintain using username from credential for backwards compatibility


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Modified the authenticatorProvider to retry once when there is failure during OAuth token fetching. This should handle transient errors such as if the OAuth provider was down or other network errors that may be encountered.

### Testing done
Manually tested both the OAuth and normal SMTP authentication code paths. Both still work as expected.
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
