### PR TITLE
Add unit tests for authenticator and OAuth retry logic

### DIFF
--- a/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
+++ b/src/test/java/hudson/plugins/emailext/ExtendedEmailPublisherDescriptorTest.java
@@ -11,9 +11,14 @@ import static org.jvnet.hudson.test.JenkinsMatchers.hasKind;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.jenkins.plugins.credentials.oauth.GoogleRobotPrivateKeyCredentials;
 import hudson.FilePath;
 import hudson.Functions;
 import hudson.Launcher;
@@ -45,8 +50,13 @@ import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.util.FormValidation.Kind;
 import hudson.util.ListBoxModel;
+import hudson.util.Secret;
+import io.jenkins.plugins.entraoauth.EntraOAuthCredentials;
 import jakarta.mail.Authenticator;
+import jakarta.mail.PasswordAuthentication;
 import jakarta.mail.Session;
+import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -73,6 +83,7 @@ import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 @WithJenkins
@@ -89,6 +100,13 @@ class ExtendedEmailPublisherDescriptorTest {
         String actualTitle = page.getTitleText();
 
         assertTrue(actualTitle.startsWith("System"), "Should be at the Configure System page");
+    }
+
+    private static PasswordAuthentication invokeGetPasswordAuthentication(Authenticator authenticator)
+            throws Exception {
+        Method method = Authenticator.class.getDeclaredMethod("getPasswordAuthentication");
+        method.setAccessible(true);
+        return (PasswordAuthentication) method.invoke(authenticator);
     }
 
     @Test
@@ -498,6 +516,272 @@ class ExtendedEmailPublisherDescriptorTest {
         ArgumentCaptor<MailAccount> mailAccountCaptor = ArgumentCaptor.forClass(MailAccount.class);
         ArgumentCaptor<Run<?, ?>> runCaptor = ArgumentCaptor.forClass(Run.class);
         Mockito.verify(authenticatorProvider, Mockito.never()).apply(mailAccountCaptor.capture(), runCaptor.capture());
+    }
+
+    @Test
+    void noCredentialFoundReturnsNullPasswordAuthentication() throws Exception {
+        ExtendedEmailPublisherDescriptor descriptor =
+                j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
+
+        MailAccount ma = new MailAccount();
+        ma.setAddress("test@example.com");
+        ma.setCredentialsId("missing-creds");
+
+        Run<?, ?> run = Mockito.mock(Run.class);
+
+        try (MockedStatic<CredentialsProvider> mocked = Mockito.mockStatic(CredentialsProvider.class)) {
+            mocked.when(() -> CredentialsProvider.findCredentialById(
+                            Mockito.eq("missing-creds"),
+                            Mockito.eq(StandardUsernameCredentials.class),
+                            Mockito.eq(run),
+                            (DomainRequirement) Mockito.isNull()))
+                    .thenReturn(null);
+
+            Authenticator authenticator = descriptor.getAuthenticatorProvider().apply(ma, run);
+            PasswordAuthentication auth = invokeGetPasswordAuthentication(authenticator);
+
+            assertNull(auth, "No PasswordAuthentication should be created when no credential is found");
+        }
+    }
+
+    @Test
+    void usernamePasswordCredentialsAuthenticateWithCredentialUsername() throws Exception {
+        ExtendedEmailPublisherDescriptor descriptor =
+                j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
+
+        StandardUsernamePasswordCredentials credential = new UsernamePasswordCredentialsImpl(
+                CredentialsScope.GLOBAL, "plain-creds", "Plain username/password", "admin", "password");
+
+        MailAccount ma = new MailAccount();
+        ma.setAddress("test@example.com");
+        ma.setCredentialsId("plain-creds");
+
+        Run<?, ?> run = Mockito.mock(Run.class);
+
+        try (MockedStatic<CredentialsProvider> mocked = Mockito.mockStatic(CredentialsProvider.class)) {
+            mocked.when(() -> CredentialsProvider.findCredentialById(
+                            Mockito.eq("plain-creds"),
+                            Mockito.eq(StandardUsernameCredentials.class),
+                            Mockito.eq(run),
+                            (DomainRequirement) Mockito.isNull()))
+                    .thenReturn(credential);
+
+            Authenticator authenticator = descriptor.getAuthenticatorProvider().apply(ma, run);
+            PasswordAuthentication auth = invokeGetPasswordAuthentication(authenticator);
+
+            assertEquals("admin", auth.getUserName(), "Username should come from the credential, not the mail account");
+            assertEquals("password", auth.getPassword());
+        }
+    }
+
+    @Test
+    void entraOAuthAuthenticationSucceedsOnFirstAttempt() throws Exception {
+        ExtendedEmailPublisherDescriptor descriptor =
+                j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
+
+        EntraOAuthCredentials entraCred = Mockito.mock(EntraOAuthCredentials.class);
+        Mockito.when(entraCred.getAccessToken(null)).thenReturn(Secret.fromString("good-token"));
+
+        MailAccount ma = new MailAccount();
+        ma.setAddress("test@example.com");
+        ma.setCredentialsId("entra-creds");
+
+        Run<?, ?> run = Mockito.mock(Run.class);
+
+        try (MockedStatic<CredentialsProvider> mocked = Mockito.mockStatic(CredentialsProvider.class)) {
+            mocked.when(() -> CredentialsProvider.findCredentialById(
+                            Mockito.eq("entra-creds"),
+                            Mockito.eq(StandardUsernameCredentials.class),
+                            Mockito.eq(run),
+                            (DomainRequirement) Mockito.isNull()))
+                    .thenReturn(entraCred);
+
+            Authenticator authenticator = descriptor.getAuthenticatorProvider().apply(ma, run);
+            PasswordAuthentication auth = invokeGetPasswordAuthentication(authenticator);
+
+            assertEquals("test@example.com", auth.getUserName());
+            assertEquals("good-token", auth.getPassword());
+            Mockito.verify(entraCred, Mockito.times(1)).getAccessToken(null);
+        }
+    }
+
+    @Test
+    void entraOAuthAuthenticationRetriesOnceThenSucceeds() throws Exception {
+        // test performs a 2-second delay
+        ExtendedEmailPublisherDescriptor descriptor =
+                j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
+
+        EntraOAuthCredentials entraCred = Mockito.mock(EntraOAuthCredentials.class);
+        Mockito.when(entraCred.getAccessToken(null))
+                .thenReturn(null)
+                .thenReturn(Secret.fromString("token-after-retry"));
+
+        MailAccount ma = new MailAccount();
+        ma.setAddress("test@example.com");
+        ma.setCredentialsId("entra-creds");
+
+        Run<?, ?> run = Mockito.mock(Run.class);
+
+        try (MockedStatic<CredentialsProvider> mocked = Mockito.mockStatic(CredentialsProvider.class)) {
+            mocked.when(() -> CredentialsProvider.findCredentialById(
+                            Mockito.eq("entra-creds"),
+                            Mockito.eq(StandardUsernameCredentials.class),
+                            Mockito.eq(run),
+                            (DomainRequirement) Mockito.isNull()))
+                    .thenReturn(entraCred);
+
+            Authenticator authenticator = descriptor.getAuthenticatorProvider().apply(ma, run);
+            PasswordAuthentication auth = invokeGetPasswordAuthentication(authenticator);
+
+            assertEquals(
+                    "token-after-retry", auth.getPassword(), "Should succeed using the token from the retried attempt");
+            Mockito.verify(entraCred, Mockito.times(2)).getAccessToken(null);
+        }
+    }
+
+    @Test
+    void entraOAuthAuthenticationReturnsNullAfterExhaustingRetries() throws Exception {
+        ExtendedEmailPublisherDescriptor descriptor =
+                j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
+
+        EntraOAuthCredentials entraCred = Mockito.mock(EntraOAuthCredentials.class);
+        Mockito.when(entraCred.getAccessToken(null)).thenReturn(null);
+
+        MailAccount ma = new MailAccount();
+        ma.setAddress("test@example.com");
+        ma.setCredentialsId("entra-creds");
+
+        Run<?, ?> run = Mockito.mock(Run.class);
+
+        try (MockedStatic<CredentialsProvider> mocked = Mockito.mockStatic(CredentialsProvider.class)) {
+            mocked.when(() -> CredentialsProvider.findCredentialById(
+                            Mockito.eq("entra-creds"),
+                            Mockito.eq(StandardUsernameCredentials.class),
+                            Mockito.eq(run),
+                            (DomainRequirement) Mockito.isNull()))
+                    .thenReturn(entraCred);
+
+            Authenticator authenticator = descriptor.getAuthenticatorProvider().apply(ma, run);
+            PasswordAuthentication auth = invokeGetPasswordAuthentication(authenticator);
+
+            assertNull(auth, "Should give up and return null after exhausting both attempts");
+            Mockito.verify(entraCred, Mockito.times(2)).getAccessToken(null);
+        }
+    }
+
+    @Test
+    void googleOAuthAuthenticationSucceedsOnFirstAttempt() throws Exception {
+        ExtendedEmailPublisherDescriptor descriptor =
+                j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
+
+        GoogleRobotPrivateKeyCredentials googleCred = Mockito.mock(GoogleRobotPrivateKeyCredentials.class);
+        GoogleCredential baseCredential = Mockito.mock(GoogleCredential.class);
+        GoogleCredential delegatedCredential = Mockito.mock(GoogleCredential.class);
+
+        Mockito.when(googleCred.getGoogleCredential(Mockito.any(MailScopeRequirement.class)))
+                .thenReturn(baseCredential);
+        Mockito.when(baseCredential.createDelegated("test@example.com")).thenReturn(delegatedCredential);
+        Mockito.when(delegatedCredential.getAccessToken()).thenReturn("good-token");
+
+        MailAccount ma = new MailAccount();
+        ma.setAddress("test@example.com");
+        ma.setCredentialsId("google-creds");
+
+        Run<?, ?> run = Mockito.mock(Run.class);
+
+        try (MockedStatic<CredentialsProvider> mocked = Mockito.mockStatic(CredentialsProvider.class)) {
+            mocked.when(() -> CredentialsProvider.findCredentialById(
+                            Mockito.eq("google-creds"),
+                            Mockito.eq(StandardUsernameCredentials.class),
+                            Mockito.eq(run),
+                            (DomainRequirement) Mockito.isNull()))
+                    .thenReturn(googleCred);
+
+            Authenticator authenticator = descriptor.getAuthenticatorProvider().apply(ma, run);
+            PasswordAuthentication auth = invokeGetPasswordAuthentication(authenticator);
+
+            assertEquals("test@example.com", auth.getUserName());
+            assertEquals("good-token", auth.getPassword());
+            Mockito.verify(delegatedCredential, Mockito.times(1)).refreshToken();
+        }
+    }
+
+    @Test
+    void googleOAuthAuthenticationRetriesAfterIOExceptionThenSucceeds() throws Exception {
+        // test performs a 2-second delay
+        ExtendedEmailPublisherDescriptor descriptor =
+                j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
+
+        GoogleRobotPrivateKeyCredentials googleCred = Mockito.mock(GoogleRobotPrivateKeyCredentials.class);
+        GoogleCredential baseCredential = Mockito.mock(GoogleCredential.class);
+        GoogleCredential delegatedCredential = Mockito.mock(GoogleCredential.class);
+
+        Mockito.when(googleCred.getGoogleCredential(Mockito.any(MailScopeRequirement.class)))
+                .thenReturn(baseCredential);
+        Mockito.when(baseCredential.createDelegated("test@example.com")).thenReturn(delegatedCredential);
+        Mockito.when(delegatedCredential.refreshToken())
+                .thenThrow(new IOException("network blip"))
+                .thenReturn(true);
+        Mockito.when(delegatedCredential.getAccessToken()).thenReturn("token-after-retry");
+
+        MailAccount ma = new MailAccount();
+        ma.setAddress("test@example.com");
+        ma.setCredentialsId("google-creds");
+
+        Run<?, ?> run = Mockito.mock(Run.class);
+
+        try (MockedStatic<CredentialsProvider> mocked = Mockito.mockStatic(CredentialsProvider.class)) {
+            mocked.when(() -> CredentialsProvider.findCredentialById(
+                            Mockito.eq("google-creds"),
+                            Mockito.eq(StandardUsernameCredentials.class),
+                            Mockito.eq(run),
+                            (DomainRequirement) Mockito.isNull()))
+                    .thenReturn(googleCred);
+
+            Authenticator authenticator = descriptor.getAuthenticatorProvider().apply(ma, run);
+            PasswordAuthentication auth = invokeGetPasswordAuthentication(authenticator);
+
+            assertEquals("token-after-retry", auth.getPassword());
+            Mockito.verify(delegatedCredential, Mockito.times(2)).refreshToken();
+        }
+    }
+
+    @Test
+    void googleOAuthAuthenticationReturnsNullAfterExhaustingRetries() throws Exception {
+        ExtendedEmailPublisherDescriptor descriptor =
+                j.jenkins.getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
+
+        GoogleRobotPrivateKeyCredentials googleCred = Mockito.mock(GoogleRobotPrivateKeyCredentials.class);
+        GoogleCredential baseCredential = Mockito.mock(GoogleCredential.class);
+        GoogleCredential delegatedCredential = Mockito.mock(GoogleCredential.class);
+
+        Mockito.when(googleCred.getGoogleCredential(Mockito.any(MailScopeRequirement.class)))
+                .thenReturn(baseCredential);
+        Mockito.when(baseCredential.createDelegated("test@example.com")).thenReturn(delegatedCredential);
+        Mockito.when(delegatedCredential.refreshToken())
+                .thenThrow(new IOException("network blip"))
+                .thenThrow(new IOException("network blip"));
+
+        MailAccount ma = new MailAccount();
+        ma.setAddress("test@example.com");
+        ma.setCredentialsId("google-creds");
+
+        Run<?, ?> run = Mockito.mock(Run.class);
+
+        try (MockedStatic<CredentialsProvider> mocked = Mockito.mockStatic(CredentialsProvider.class)) {
+            mocked.when(() -> CredentialsProvider.findCredentialById(
+                            Mockito.eq("google-creds"),
+                            Mockito.eq(StandardUsernameCredentials.class),
+                            Mockito.eq(run),
+                            (DomainRequirement) Mockito.isNull()))
+                    .thenReturn(googleCred);
+
+            Authenticator authenticator = descriptor.getAuthenticatorProvider().apply(ma, run);
+            PasswordAuthentication auth = invokeGetPasswordAuthentication(authenticator);
+
+            assertNull(auth, "Should give up and return null after exhausting both attempts");
+            Mockito.verify(delegatedCredential, Mockito.times(2)).refreshToken();
+        }
     }
 
     @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR adds unit test coverage for `ExtendedEmailPublisherDescriptor` authenticator for all credential types and retry scenarios. The `getPasswordAuthentication` is protected, so tests invoke it via reflection.


### Testing done

Add unit tests for:

- Missing credentials
- Entra OAuth -> all retry scenarios
- Google OAuth -> all retry scenarios



<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
